### PR TITLE
feat: Create and use enum for redis keys

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ import json
 
 from module.config_loader import load_settings
 from module.logger import configure_logging
-from module.redis_controller import RedisController
+from module.redis_controller import RedisController, ParameterKey
 from module.cinepi_app import CinePi
 from module.ssd_monitor import SSDMonitor
 from module.usb_monitor import USBMonitor
@@ -163,10 +163,10 @@ def main():
     redis_controller, sensor_detect, pwm_controller, ssd_monitor, usb_monitor, gpio_output, dmesg_monitor = initialize_system(settings)
     
     # Store Pi model in Redis
-    redis_controller.set_value('pi_model', pi_model)
-    
+    redis_controller.set_value(ParameterKey.PI_MODEL.value, pi_model)
+
     # Set redis anamorphic factor to default value
-    redis_controller.set_value('anamorphic_factor', settings["anamorphic_preview"]["default_anamorphic_factor"])
+    redis_controller.set_value(ParameterKey.ANAMORPHIC_FACTOR.value, settings["anamorphic_preview"]["default_anamorphic_factor"])
 
     # Initialize CinePi application
     cinepi = CinePi(redis_controller, sensor_detect)
@@ -248,8 +248,8 @@ def main():
     # Ensure system cleanup on exit
     def cleanup():
         logging.info("Shutting down components...")
-        redis_controller.set_value('is_recording', 0)
-        redis_controller.set_value('is_writing', 0)
+        redis_controller.set_value(ParameterKey.IS_RECORDING.value, 0)
+        redis_controller.set_value(ParameterKey.IS_WRITING.value, 0)
         pwm_controller.stop_pwm()
         dmesg_monitor.join()
         command_executor.join()

--- a/src/module/analog_controls.py
+++ b/src/module/analog_controls.py
@@ -6,6 +6,8 @@ import logging
 import traceback
 from collections import deque
 
+from module.redis_controller import ParameterKey
+
 class AnalogControls(threading.Thread):
     def __init__(self, cinepi_controller, redis_controller, iso_pot=None, shutter_a_pot=None, fps_pot=None, wb_pot=None, iso_steps=None, shutter_a_steps=None, fps_steps=None, wb_steps=None):
         threading.Thread.__init__(self)
@@ -137,7 +139,7 @@ class AnalogControls(threading.Thread):
 
                 if new_wb is not None and new_wb != self.last_wb:
                     logging.info(f"Setting White Balance to {new_wb}K")
-                    self.redis_controller.set_value('wb_user', new_wb)
+                    self.redis_controller.set_value(ParameterKey.WB_USER.value, new_wb)
                     self.cinepi_controller.set_wb(new_wb)
                     self.last_wb = new_wb
 

--- a/src/module/app/main/events.py
+++ b/src/module/app/main/events.py
@@ -1,44 +1,45 @@
 from flask_socketio import emit
 import time
+from module.redis_controller import ParameterKey
 
 def register_events(socketio, redis_controller, cinepi_controller, simple_gui, sensor_detect):
     
     @socketio.on('connect')
     def handle_connect():
         initial_values = {
-            'iso': redis_controller.get_value('iso'),
-            'shutter_a': redis_controller.get_value('shutter_a'),
-            'fps': redis_controller.get_value('fps_actual'),
+            'iso': redis_controller.get_value(ParameterKey.ISO.value),
+            'shutter_a': redis_controller.get_value(ParameterKey.SHUTTER_A.value),
+            'fps': redis_controller.get_value(ParameterKey.FPS_ACTUAL.value),
             'background_color': simple_gui.get_background_color(),
             'shutter_a_steps': cinepi_controller.shutter_a_steps_dynamic,
             'fps_steps': cinepi_controller.fps_steps_dynamic,
             'wb_steps': cinepi_controller.wb_steps,
-            'wb': redis_controller.get_value('wb') or (cinepi_controller.wb_steps[0] if cinepi_controller.wb_steps else None)
+            'wb': redis_controller.get_value(ParameterKey.WB.value) or (cinepi_controller.wb_steps[0] if cinepi_controller.wb_steps else None)
         }
 
         initial_values.update(simple_gui.populate_values())
 
         initial_values['sensor_resolutions'] = sensor_detect.get_available_resolutions()
         initial_values['current_sensor'] = sensor_detect.camera_model
-        initial_values['selected_resolution_mode'] = redis_controller.get_value('sensor_mode')
+        initial_values['selected_resolution_mode'] = redis_controller.get_value(ParameterKey.SENSOR_MODE.value)
 
         emit('initial_values', initial_values)
 
     def redis_change_handler(data):
         key = data['key']
         value = data['value']
-        if key in ['iso', 'shutter_a', 'fps_actual', 'wb', 'framecount', 'buffer']:
+        if key in [ParameterKey.ISO.value, ParameterKey.SHUTTER_A.value, ParameterKey.FPS_ACTUAL.value, ParameterKey.WB.value, ParameterKey.FRAMECOUNT.value, ParameterKey.BUFFER.value]:
             socketio.emit('parameter_change', {key: value})
-            
-        if key == 'fps_actual':
+
+        if key == ParameterKey.FPS_ACTUAL.value:
             # Emit the updated shutter_a_steps array and the current shutter speed
             shutter_a_steps = cinepi_controller.calculate_dynamic_shutter_angles(
-                int(float(redis_controller.get_value('fps_actual')))
+                int(float(redis_controller.get_value(ParameterKey.FPS_ACTUAL.value)))
             )
-            current_shutter_a = redis_controller.get_value('shutter_a')
+            current_shutter_a = redis_controller.get_value(ParameterKey.SHUTTER_A.value)
             socketio.emit('shutter_a_update', {'shutter_a_steps': shutter_a_steps, 'current_shutter_a': current_shutter_a})
-            
-        if key in ['sensor_mode', 'wb']:
+
+        if key in [ParameterKey.SENSOR_MODE.value, ParameterKey.WB.value]:
             time.sleep(2)  # Add a 2-second pause
             socketio.emit('reload_browser')  # Emit event to reload the browser
 
@@ -71,7 +72,7 @@ def register_events(socketio, redis_controller, cinepi_controller, simple_gui, s
             socketio.emit('parameter_change', {'shutter_a': shutter_a})
             # Emit the updated shutter_a_steps array and the current shutter speed
             shutter_a_steps = cinepi_controller.calculate_dynamic_shutter_angles(
-                int(float(redis_controller.get_value('fps_actual')))
+                int(float(redis_controller.get_value(ParameterKey.FPS_ACTUAL.value)))
             )
             socketio.emit('shutter_a_update', {'shutter_a_steps': shutter_a_steps, 'current_shutter_a': shutter_a})
 
@@ -83,7 +84,7 @@ def register_events(socketio, redis_controller, cinepi_controller, simple_gui, s
             socketio.emit('parameter_change', {'fps': fps})
             # Emit the updated shutter_a_steps array and the current shutter speed
             shutter_a_steps = cinepi_controller.calculate_dynamic_shutter_angles(int(fps))
-            current_shutter_a = redis_controller.get_value('shutter_a')
+            current_shutter_a = redis_controller.get_value(ParameterKey.SHUTTER_A.value)
             socketio.emit('shutter_a_update', {'shutter_a_steps': shutter_a_steps, 'current_shutter_a': current_shutter_a})
 
     @socketio.on('change_wb')
@@ -101,10 +102,10 @@ def register_events(socketio, redis_controller, cinepi_controller, simple_gui, s
             socketio.emit('resolution_change', {'sensor_mode': sensor_mode})
             # Emit the current values and steps immediately before reloading
             shutter_a_steps = cinepi_controller.calculate_dynamic_shutter_angles(
-                int(float(redis_controller.get_value('fps_actual')))
+                int(float(redis_controller.get_value(ParameterKey.FPS_ACTUAL.value)))
             )
-            current_shutter_a = redis_controller.get_value('shutter_a')
-            current_fps = redis_controller.get_value('fps_actual')
+            current_shutter_a = redis_controller.get_value(ParameterKey.SHUTTER_A.value)
+            current_fps = redis_controller.get_value(ParameterKey.FPS_ACTUAL.value)
             socketio.emit('shutter_a_update', {
                 'shutter_a_steps': shutter_a_steps,
                 'current_shutter_a': current_shutter_a

--- a/src/module/app/main/routes.py
+++ b/src/module/app/main/routes.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, current_app, jsonify, request, render_template
+from module.redis_controller import ParameterKey
 
 main_routes = Blueprint('main', __name__)
 
@@ -9,9 +10,9 @@ def index():
     simple_gui = current_app.config['SIMPLE_GUI']
     sensor_detect = current_app.config['SENSOR_DETECT']
 
-    iso_value = redis_controller.get_value("iso")
-    shutter_a_value = redis_controller.get_value("shutter_a")
-    fps_value = redis_controller.get_value("fps_actual")
+    iso_value = redis_controller.get_value(ParameterKey.ISO.value)
+    shutter_a_value = redis_controller.get_value(ParameterKey.SHUTTER_A.value)
+    fps_value = redis_controller.get_value(ParameterKey.FPS_ACTUAL.value)
     background_color_value = simple_gui.get_background_color()
     
     dynamic_data = simple_gui.populate_values()

--- a/src/module/i2c_oled.py
+++ b/src/module/i2c_oled.py
@@ -8,6 +8,7 @@ import busio
 import adafruit_ssd1306
 from PIL import Image, ImageDraw, ImageFont
 from module.utils import Utils
+from module.redis_controller import ParameterKey
 
 class i2cOledSettings(TypedDict):
     width: int
@@ -26,7 +27,7 @@ class I2cOled(threading.Thread):
         self.width = self.settings.get("width", 128)
         self.height = self.settings.get("height", 64)
         self.font_size = self.settings.get("font_size", 10)
-        self.values = self.settings.get("values", ["iso", "fps", "shutter_a", "resolution", "is_recording"])
+        self.values = self.settings.get("values", [ParameterKey.ISO.value, ParameterKey.FPS.value, ParameterKey.SHUTTER_A.value, 'resolution', ParameterKey.IS_RECORDING.value])
 
         self.i2c = busio.I2C(board.SCL, board.SDA)
         self.oled = adafruit_ssd1306.SSD1306_I2C(self.width, self.height, self.i2c)
@@ -44,15 +45,15 @@ class I2cOled(threading.Thread):
 
     def update(self):
         texts = {
-            "shutter_a": {
+            ParameterKey.SHUTTER_A.value: {
                 "label": "SHUTTER",
                 "suffix": "°",
             },
-            "wb_user": {
+            ParameterKey.WB_USER.value: {
                 "label": "WB",
                 "suffix": "K",
             },
-            "space_left": {
+            ParameterKey.SPACE_LEFT.value: {
                 "label": "SPACE",
                 "suffix": "GB",
             },
@@ -62,10 +63,10 @@ class I2cOled(threading.Thread):
         firstLine = []
         for key in self.values:
             match key:
-                case "is_recording":
+                case ParameterKey.IS_RECORDING.value:
                     firstLine.append("●" if bool(int(self.redis_controller.get_value(key, 0))) else " ")
                 case "resolution":
-                    firstLine.append(f"{self.redis_controller.get_value('width', '')}x{self.redis_controller.get_value('height', '')}@{self.redis_controller.get_value('bit_depth', '')}Bit")
+                    firstLine.append(f"{self.redis_controller.get_value(ParameterKey.WIDTH.value, '')}x{self.redis_controller.get_value(ParameterKey.HEIGHT.value, '')}@{self.redis_controller.get_value(ParameterKey.BIT_DEPTH.value, '')}Bit")
                 case "cpu_load":
                     lines.append(f"CPU: {Utils.cpu_load()}")
                 case "cpu_temp":

--- a/src/module/redis_controller.py
+++ b/src/module/redis_controller.py
@@ -1,7 +1,47 @@
+from enum import Enum
 import redis
 import logging
 import threading
 import RPi.GPIO as GPIO
+
+class ParameterKey(Enum):
+    ANAMORPHIC_FACTOR = "anamorphic_factor"
+    BIT_DEPTH = "bit_depth"
+    BUFFER = "buffer"
+    CAM_INIT = "cam_init"
+    CAMERAS = "cameras"
+    CG_RB = "cg_rb"
+    FILE_SIZE = "file_size"
+    FPS = "fps"
+    FPS_ACTUAL = "fps_actual"
+    FPS_LAST = "fps_last"
+    FPS_MAX = "fps_max"
+    FPS_USER = "fps_user"
+    FRAMECOUNT = "framecount"
+    GUI_LAYOUT = "gui_layout"
+    HEIGHT = "height"
+    IR_FILTER = "ir_filter"
+    IS_BUFFERING = "is_buffering"
+    IS_MOUNTED = "is_mounted"
+    IS_RECORDING = "is_recording"
+    IS_WRITING = "is_writing"
+    IS_WRITING_BUF = "is_writing_buf"
+    ISO = "iso"
+    LORES_HEIGHT = "lores_height"
+    LORES_WIDTH = "lores_width"
+    PI_MODEL = "pi_model"
+    REC = "rec"
+    SENSOR = "sensor"
+    SENSOR_MODE = "sensor_mode"
+    SHUTTER_A = "shutter_a"
+    SHUTTER_A_NOM = "shutter_a_nom"
+    SPACE_LEFT = "space_left"
+    STORAGE_TYPE = "storage_type"
+    TRIGGER_MODE = "trigger_mode"
+    WB = "wb"
+    WB_USER = "wb_user"
+    WIDTH = "width"
+    # Add more as needed
 
 class Event:
     def __init__(self):
@@ -68,7 +108,7 @@ class RedisController:
                         self.local_updates.remove(changed_key)
                         continue
 
-                if changed_key != "fps_actual":
+                if changed_key != ParameterKey.FPS_ACTUAL.value:
                     logging.info(f"Changed value: {changed_key} = {value_str}")
                     self.redis_parameter_changed.emit({'key': changed_key, 'value': value_str})
 
@@ -93,7 +133,7 @@ class RedisController:
 
             self.local_updates.add(key)  # Track locally updated key
 
-            if key != 'fps_actual':
+            if key != ParameterKey.FPS_ACTUAL.value:
                 logging.info(f"Changed value: {key} = {value}")
 
 

--- a/src/module/ssd_monitor.py
+++ b/src/module/ssd_monitor.py
@@ -5,6 +5,8 @@ import time
 import subprocess
 import smbus
 
+from module.redis_controller import ParameterKey
+
 class Event:
     def __init__(self):
         self._listeners = []
@@ -75,8 +77,8 @@ class SSDMonitor:
             self.device_name = self._get_device_name()
             self.device_type = self._detect_device_type()
             if self.redis_controller:
-                self.redis_controller.set_value('storage_type', self.device_type.lower())
-                self.redis_controller.set_value('is_mounted', '1')
+                self.redis_controller.set_value(ParameterKey.STORAGE_TYPE.value, self.device_type.lower())
+                self.redis_controller.set_value(ParameterKey.IS_MOUNTED.value, '1')
             logging.info(f"RAW drive mounted at {self.mount_path} ({self.device_type})")
             self._update_space_left()
             self.mount_event.emit(self.mount_path, self.device_type)
@@ -87,9 +89,9 @@ class SSDMonitor:
             self.device_name = None
             self.device_type = None
             if self.redis_controller:
-                self.redis_controller.set_value('storage_type', 'none')
-                self.redis_controller.set_value('is_mounted', '0')
-                self.redis_controller.set_value('space_left', '0')
+                self.redis_controller.set_value(ParameterKey.STORAGE_TYPE.value, 'none')
+                self.redis_controller.set_value(ParameterKey.IS_MOUNTED.value, '0')
+                self.redis_controller.set_value(ParameterKey.SPACE_LEFT.value, '0')
             self.unmount_event.emit(self.mount_path)
         elif self.is_mounted:
             self._update_space_left()
@@ -131,13 +133,13 @@ class SSDMonitor:
                     self.space_left = new_space_left
                     logging.info(f"Updated space left on SSD: {self.space_left:.2f} GB")
                     if self.redis_controller:
-                        self.redis_controller.set_value('space_left', f"{self.space_left:.2f}")
+                        self.redis_controller.set_value(ParameterKey.SPACE_LEFT.value, f"{self.space_left:.2f}")
                     self.space_update_event.emit(self.space_left)
             except OSError as e:
                 logging.error(f"Error updating space left: {e}")
                 self.space_left = None
                 if self.redis_controller:
-                    self.redis_controller.set_value('space_left', '0')
+                    self.redis_controller.set_value(ParameterKey.SPACE_LEFT.value, '0')
 
     def get_mount_status(self):
         return self.is_mounted
@@ -161,9 +163,9 @@ class SSDMonitor:
                 self.device_name = None
                 self.device_type = None
                 if self.redis_controller:
-                    self.redis_controller.set_value('storage_type', 'none')
-                    self.redis_controller.set_value('is_mounted', '0')
-                    self.redis_controller.set_value('space_left', '0')
+                    self.redis_controller.set_value(ParameterKey.STORAGE_TYPE.value, 'none')
+                    self.redis_controller.set_value(ParameterKey.IS_MOUNTED.value, '0')
+                    self.redis_controller.set_value(ParameterKey.SPACE_LEFT.value, '0')
                 self.unmount_event.emit(self.mount_path)
             except subprocess.CalledProcessError as e:
                 logging.error(f"Failed to unmount SSD: {e}")


### PR DESCRIPTION
This adds an enum to use instead of lose strings when setting/getting values from redis.
old way:
`redis_controller.get_value("fps")`
new way:
`redis_controller.get_value(ParameterKey.FPS.value)`

This has no functional change it only makes the code more readable and easier to work with.

The benefits are:
- easy to get an overview of available parameters
- code completion
- minimize risk for typos
- if a parameter change name it's easy to change it

Currently only implemented for redis get/set but can be expanded to be used for every parameter (ui, cine-pi-controller etc.)