### PR TITLE
test add generated docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,24 @@
+# Getting Started
+
+This quick guide walks through building a minimal CineMate setup using only a Raspberry Pi and a camera sensor. The preview is viewed from a phone connected over Wi‑Fi.
+
+## Requirements
+
+- Raspberry Pi 4/5 (or CM4)
+- Camera sensor such as the HQ or Global Shutter camera
+- microSD card (16 GB or larger) with the CineMate image
+- Phone or tablet for preview
+
+## Assemble the hardware
+
+1. **Connect the camera** while the Pi is powered off.
+2. Insert the microSD card and boot the Pi. CineMate starts automatically.
+3. The Pi creates a Wi‑Fi hotspot named `CinePi` with password `11111111`.
+4. Join the hotspot on your phone and open `http://cinepi.local:5000` in a browser. A clean feed is available at `http://cinepi.local:8000/stream`.
+
+## Recording basics
+
+- Tap the preview screen in the browser or run `rec` over SSH to start/stop recording.
+- Footage is written to a drive labeled `RAW`.
+
+For more details see the [overview](overview.md) and the rest of this documentation.

--- a/docs/mkdocs-install.md
+++ b/docs/mkdocs-install.md
@@ -1,0 +1,20 @@
+# Installing MkDocs
+
+This project uses [MkDocs](https://www.mkdocs.org/) with the Material theme to build the documentation.
+
+## Quick start
+
+1. Install the Python dependencies:
+   ```bash
+   pip install mkdocs mkdocs-material
+   ```
+2. Start a local preview server from the repository root:
+   ```bash
+   mkdocs serve
+   ```
+   The site will be available at `http://127.0.0.1:8000` and reload on file changes.
+3. To build the static site:
+   ```bash
+   mkdocs build
+   ```
+   The generated files will appear in the `site/` directory.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,15 @@
+# Module Overview
+
+CineMate is organised into a collection of small modules that communicate through Redis. At the core is the `cinepi-raw` capture binary which handles all camera I/O. The Python modules orchestrate `cinepi-raw`, manage hardware controls and expose a simple GUI.
+
+## Main pieces
+
+- **`main.py`** – launches all services and loads `settings.json`.
+- **`cinepi_controller.py`** – talks to `cinepi-raw` and forwards camera state changes to Redis.
+- **`simple_gui.py`** – lightweight GUI served over Flask and displayed on HDMI or in a browser.
+- **`redis_controller.py`** – central interface for publishing and reading parameters.
+- **`mediator.py`** – coordinates events across modules so that button presses, CLI commands and network messages all interact consistently.
+
+Other helpers monitor the SSD, Wi‑Fi hotspot and GPIO pins. Each component is optional and can be modified to suit a custom build.
+
+CineMate relies on [`cinepi-raw`](https://github.com/cinepi/cinepi-raw) for image capture. The Python code starts one `cinepi-raw` process per sensor and feeds it parameters such as resolution, ISO and shutter angle.

--- a/docs/settings-json.md
+++ b/docs/settings-json.md
@@ -1,125 +1,52 @@
-# `settings.json` Cheat Sheet
+# `settings.json` Reference
 
-A quick-reference table of every setting in `settings.json`, what it does, and its allowed values.
+The configuration file lives at `/home/pi/cinemate/src/settings.json`. It controls GPIO assignments, recording arrays and other options. Below is a summary of the main keys and the default values shipped with the project.
+
+## Geometry and Output
+
 ```json
-    {
-      "pin": 27,
-      "state_on_action": {"method": "set_all_lock", "args": [1]},
-      "state_off_action": {"method": "set_all_lock", "args": [0]}
-    },
+"geometry": {
+  "cam0": {"rotate_180": false, "horizontal_flip": false, "vertical_flip": false},
+  "cam1": {"rotate_180": false, "horizontal_flip": false, "vertical_flip": false}
+},
+"output": {
+  "cam0": {"hdmi_port": 0},
+  "cam1": {"hdmi_port": 1}
+}
 ```
-
-```python
-if self.button.is_pressed:      # high at rest → treat as “inverse”
-    self.inverse = True
-```
-
-## Geometry
-
-| JSON Path                             | Description                                         | Values           |
-|---------------------------------------|-----------------------------------------------------|------------------|
-| `geometry.camX.rotate_180`            | Rotate image 180° on startup                        | `true` / `false` |
-| `geometry.camX.horizontal_flip`       | Flip image horizontally on startup                  | `true` / `false` |
-| `geometry.camX.vertical_flip`         | Flip image vertically on startup                    | `true` / `false` |
-
----
-
-## Output
-
-| JSON Path                    | Description                                                          | Values                      |
-|------------------------------|----------------------------------------------------------------------|-----------------------------|
-| `output.camX.hdmi_port`      | Select DRM connector for HDMI output (`cinepi-raw --hdmi-port`)      | `0`, `1`, or `-1` (auto)    |
-
----
 
 ## GPIO Outputs
 
-| JSON Path               | Description                                   | Values                   |
-|-------------------------|-----------------------------------------------|--------------------------|
-| `gpio_output.pwm_pin`   | PWM pin for strobe / shutter sync             | BCM pin number (e.g. 19) |
-| `gpio_output.rec_out_pin` | Pin(s) pulled high while recording            | List of BCM pins         |
-
----
-
-## Fixed-Palette Arrays
-
-| JSON Path               | Description                                  | Values                              |
-|-------------------------|----------------------------------------------|-------------------------------------|
-| `arrays.iso_steps`      | ISO step presets (if `iso_free = false`)     | `[100,…,sensor_native]`             |
-| `arrays.shutter_a_steps`| Shutter angles (if `shutter_a_free = false`) | `[1.0,…,360.0]` (degrees)           |
-| `arrays.fps_steps`      | Frame-rate presets (if `fps_free = false`)   | integers ≤ sensor-mode `fps_max`    |
-| `arrays.wb_steps`       | White-balance Kelvin presets                 | `[2000,…,9000]` (Kelvin)            |
-
----
-
-## Flicker Suppression
-
-| JSON Path             | Description                                                      | Values               |
-|-----------------------|------------------------------------------------------------------|----------------------|
-| `settings.light_hz`   | Frequencies used to calculate flicker-free shutter angles        | `[50]`, `[60]`, or `[50,60]` |
-
----
-
-## Analog Controls
-
-| JSON Path                   | Description                                               | Values      |
-|-----------------------------|-----------------------------------------------------------|-------------|
-| `analog_controls.*_pot`     | ADC channel for ISO, shutter, FPS, or WB (Grove HAT)      | `0–7` or `null` |
-
----
-
-## Free-Mode Overrides
-
-When `true`, ignores the fixed arrays and exposes full legal ranges.
-
-| JSON Path                    | Description                      | Values           |
-|------------------------------|----------------------------------|------------------|
-| `free_mode.iso_free`         | Full ISO range                   | `true` / `false` |
-| `free_mode.shutter_a_free`   | Full shutter-angle range         | `true` / `false` |
-| `free_mode.fps_free`         | Full frame-rate range            | `true` / `false` |
-| `free_mode.wb_free`          | Full white-balance range         | `true` / `false` |
-
-> **Free ranges:** ISO 100–3200, Shutter 1.0°–360.0°, FPS 1–fps_max, WB 1000–10000 K
-
----
-
-## Anamorphic Preview
-
-| JSON Path                                     | Description                                | Values               |
-|-----------------------------------------------|--------------------------------------------|----------------------|
-| `anamorphic_preview.anamorphic_steps`         | Anamorphic squeeze factors                 | list of floats ≥ 1.0 |
-| `anamorphic_preview.default_anamorphic_factor`| Initial factor stored in Redis on power-up | one of the above     |
-
----
-
-## Buttons & Switches
-
-| JSON Path                 | Description                                                   | Values                            |
-|---------------------------|---------------------------------------------------------------|-----------------------------------|
-| `buttons[]`               | SmartButton entries: `press_action`, `click_action`, `hold_action`, etc. | List of BCM pins + args          |
-| `two_way_switches[]`      | Latching switches: `state_on_action` / `state_off_action`      | `pin` + optional `pull_up`       |
-| `three_way_switches[]`    | 3-position switches: `state_0/1/2_action`                     | `pins`: [low, mid, high]         |
-
----
-
-## Encoders
-
-| JSON Path                  | Description                                               | Values                        |
-|----------------------------|-----------------------------------------------------------|-------------------------------|
-| `rotary_encoders[]`        | GPIO rotary (CLK/DT) + optional button                    | `clk_pin`, `dt_pin` BCM pins  |
-| `quad_rotary_encoders`     | I²C RGB Encoder breakout (0x49) with four dials/buttons  | Indices `"0"`–`"3"`           |
-
----
-
-## OLED Status Screen
-
-| JSON Path           | Description                                              | Values                              |
-|---------------------|----------------------------------------------------------|-------------------------------------|
-| `i2c_oled.width`    | OLED panel width in pixels                               | integer                             |
-| `i2c_oled.height`   | OLED panel height in pixels                              | integer                             |
-| `i2c_oled.values`   | Redis keys or pseudo-keys to display (e.g. `cpu_temp`)   | ordered list                        |
-
-```python
-if self.button.is_pressed:      # high at rest → treat as “inverse”
-    self.inverse = True
+```json
+"gpio_output": {"pwm_pin": 19, "rec_out_pin": [6, 21]}
 ```
+
+## Arrays
+
+```json
+"arrays": {
+  "iso_steps": [100, 200, 400, 640, 800, 1200, 1600, 2500, 3200],
+  "shutter_a_steps": [1, 45, 90, 135, 172.8, 180, 225, 270, 315, 346.6, 360],
+  "fps_steps": [1, 2, 4, 8, 12, 16, 18, 24, 25, 33, 40, 50],
+  "wb_steps": [3200, 4400, 5600]
+}
+```
+
+## Misc settings
+
+- **`settings.light_hz`** – `[50, 60]` values used to compute flicker‑free shutter angles.
+- **`free_mode.*`** – when `true`, bypasses the fixed arrays and allows full ranges.
+- **`anamorphic_preview`** – defines selectable anamorphic factors.
+
+For a complete table of every key see `settings.schema.json` in the source tree.
+
+## Default controls
+
+- **Record button:** GPIO 5
+- **Increase ISO:** GPIO 13 (momentary)
+- **Decrease ISO:** GPIO 10
+- **Double FPS:** GPIO 16
+- **Resolution / system actions:** GPIO 26 with multiple click interactions
+- **Rec LED output:** GPIO 6 and 21
+
+These defaults can be edited directly in `settings.json` to match your hardware wiring.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,11 +13,14 @@ dev_addr: 0.0.0.0:8000            # live-preview reachable from your laptop
 # ───────────────────────────
 nav:
   - Home: index.md
-  - Getting started:
-    - Overview: overview.md
-    - Cli commands: cli_commands.md
-    - Buttons: inverse_buttons.md
-    - Settings.json cheat sheet: settings-json.md
+  - Getting started: getting-started.md
+  - Overview: overview.md
+  - CLI reference:
+      - Commands: cli_commands.md
+      - Settings.json: settings-json.md
+  - Modules: modules.md
+  - MkDocs installation: mkdocs-install.md
+  - Buttons: inverse_buttons.md
 
 # ───────────────────────────
 # Theme


### PR DESCRIPTION
## Summary
- document how to install mkdocs and preview docs locally
- link the new page in `mkdocs.yml`
- add quick-start documentation using a phone as preview
- write a new modules overview
- overhaul settings.json reference with defaults

## Testing
- `mkdocs build --strict` *(fails: 1 conversion errors)*

------
https://chatgpt.com/codex/tasks/task_e_686da7458a8883328207890a4acf3ef7