### PR TITLE
Fix CLI thread shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ When a compatible USB microphone is connected, VU meters appear on the right sid
 
 ## Audio recording (experimental) <img src="https://img.shields.io/badge/cinepi--raw%20fork-ff69b4?style=flat" height="14">
 
-CineMate can capture audio alongside the image sequence. Support is currently limited to a few USB microphones with hard coded configurations:
+Audio support is currently limited to a few USB microphones with hard coded configurations:
  - **RØDE VideoMic NTG** – recorded in stereo at 24‑bit/48 kHz.
  - **USB PnP microphones** – recorded in mono at 16‑bit/48 kHz.
 
@@ -157,7 +157,7 @@ Audio is written as `.wav` files into the same folder as the `.dng` frames. The 
 ## storage-automount service
 `storage-automount` is a systemd service that watches for removable drives and mounts them automatically. The accompanying Python script reacts to udev events and the CFE-HAT eject button so drives can be attached or detached safely.
 
-It understands `ext4`, `ntfs` and `exfat` filesystems. Partitions labelled `RAW` are mounted at `/media/RAW`; any other label is mounted under `/media/<LABEL>` after sanitising the name. This applies to USB SSDs, NVMe drives and the CFE-HAT slot.
+Currently works with `ext4` filesystems. This applies to USB SSDs, NVMe drives and the CFE-HAT slot.
 
 The service is already installed on the cinemate image file. To manually install and enable the service with:
 
@@ -365,9 +365,7 @@ _To be added._
 
 CineMate automatically detects each camera connected to the Raspberry Pi and spawns a separate `cinepi-raw` process per sensor. By default:
 
-- **Primary camera** (first detected) displays its preview on HDMI port 0.
-- **Secondary cameras** run with `--nopreview` and map to subsequent HDMI outputs (cam1→HDMI 1, cam2→HDMI 2, etc.).
-- Preview windows are centered and sized according to your `geometry` settings.
+Camera connected to physical port cam0 displays its preview on HDMI port 0. Camera on cam1 → HDMI 1
 
 You can override default HDMI mappings in `settings.json` under the `output` section:
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Status LEDs are configured under `gpio_output`. Two flavours are available:
 `sys_LED` for single‑colour outputs and `sys_LED_RGB` for RGB indicators.  Each
 entry holds an ordered list of rules which map Redis keys to LED behaviour.
 The first rule that matches determines the LED state.
+RGB LEDs can be wired as `common_cathode` (default) or `common_anode` and are set per entry using the `type` field.
 
 ```json
 "gpio_output": {
@@ -227,6 +228,7 @@ The first rule that matches determines the LED state.
   "sys_LED_RGB": [
     {
       "pins": [23,24,10],
+      "type": "common_cathode",
       "rules": [
         {"key": "is_mounted", "value": 1, "mode": "steady", "color": "blue"},
         {"key": "is_mounted", "value": 0, "mode": "blink_long", "color": "blue"},

--- a/README.md
+++ b/README.md
@@ -208,14 +208,35 @@ CineMate supports multiple cameras with per‑port customization in your `settin
 - **output.cam0/cam1**: Maps each camera to an HDMI output port. By default, `cam0`→HDMI 0 and `cam1`→HDMI 1, but you can remap as needed.
 
 #### GPIO output
-Default rec LED pins are 6 and 21. Make sure to use a 220 Ohm resistor on this pin!
+Status LEDs are configured under `gpio_output`. Two flavours are available:
+`sys_LED` for single‑colour outputs and `sys_LED_RGB` for RGB indicators.  Each
+entry holds an ordered list of rules which map Redis keys to LED behaviour.
+The first rule that matches determines the LED state.
 
 ```json
-  "gpio_output": {
-    "pwm_pin": 19,
-    "rec_out_pin": [6, 21]
-  },
+"gpio_output": {
+  "sys_LED": [
+    {
+      "pin": 19,
+      "rules": [
+        {"key": "drop_frame_detected", "mode": "blink"},
+        {"key": "rec", "value": 1, "mode": "steady"}
+      ]
+    }
+  ],
+  "sys_LED_RGB": [
+    {
+      "pins": [23,24,10],
+      "rules": [
+        {"key": "is_mounted", "value": 1, "mode": "steady", "color": "blue"},
+        {"key": "is_mounted", "value": 0, "mode": "blink_long", "color": "blue"},
+        {"key": "is_writing", "mode": "pulse", "color": "green"}
+      ]
+    }
+  ]
+}
 ```
+Note the reversed hierarchical order: the lowest defined indicator takes precedence. For example, if the system is writing (`is_writing`= 1) to the mounted storage (`is_mounted` = 1), the LED wil pulsate in green
 
 #### Arrays
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -214,13 +214,33 @@ CineMate supports multiple cameras with per‑port customization in your `settin
 - **output.cam0/cam1**: Maps each camera to an HDMI output port. By default, `cam0`→HDMI 0 and `cam1`→HDMI 1, but you can remap as needed.
 
 #### GPIO output
-Default rec LED pins are 6 and 21. Make sure to use a 220 Ohm resistor on this pin!
+Status LEDs are configured under `gpio_output`. Two flavours are available:
+`sys_LED` for single‑colour outputs and `sys_LED_RGB` for RGB indicators.  Each
+entry holds an ordered list of rules which map Redis keys to LED behaviour.
+The first rule that matches determines the LED state.
 
 ```json
-  "gpio_output": {
-    "pwm_pin": 19,
-    "rec_out_pin": [6, 21]
-  },
+"gpio_output": {
+  "sys_LED": [
+    {
+      "pin": 19,
+      "rules": [
+        {"key": "drop_frame_detected", "mode": "blink"},
+        {"key": "rec", "value": 1, "mode": "steady"}
+      ]
+    }
+  ],
+  "sys_LED_RGB": [
+    {
+      "pins": [23,24,10],
+      "rules": [
+        {"key": "is_mounted", "value": 1, "mode": "steady", "color": "blue"},
+        {"key": "is_mounted", "value": 0, "mode": "blink_long", "color": "blue"},
+        {"key": "is_writing", "mode": "pulse", "color": "green"}
+      ]
+    }
+  ]
+}
 ```
 
 #### Arrays

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -147,6 +147,7 @@ Simple GUI is available via browser and/or attached HDMI monitor.
 - Red color means camera is recording.
 - Purple color means camera detected a drop frame 
 - Green color means camera is writing buffered frames to disk. You can still start recording at this stage, but any buffered frames from the last recording will be lost.
+- Alternatively a small dot with "REC"/"STBY" can be used. Choose between frame or dot in `gui.recording_indicator` inside `settings.json`.
 
 Buffer meter in the lower left indicates number of frames in buffer. Useful when testing storage media.
 
@@ -218,6 +219,7 @@ Status LEDs are configured under `gpio_output`. Two flavours are available:
 `sys_LED` for single‑colour outputs and `sys_LED_RGB` for RGB indicators.  Each
 entry holds an ordered list of rules which map Redis keys to LED behaviour.
 The first rule that matches determines the LED state.
+RGB LEDs may be wired as `common_cathode` or `common_anode`; specify this with the optional `type` field.
 
 ```json
 "gpio_output": {

--- a/docs/settings-json.md
+++ b/docs/settings-json.md
@@ -40,9 +40,11 @@ if self.button.is_pressed:      # high at rest → treat as “inverse”
 | `gpio_output.sys_LED_RGB[]` | RGB status LEDs                        | `pins` + ordered `rules`    |
 | `gpio_output.pwm_pin`       | PWM pin for strobe / shutter sync      | BCM pin number              |
 
-Each rule maps a Redis key (and optional value) to a behaviour
-(`steady`, `blink`, `blink_long`, or `pulse`). RGB LEDs also take a
-`color` using one of: red, green, blue, yellow, cyan, magenta, white.
+Each rule maps a Redis key (and optional value) to a behaviour (`steady`, `blink`, `blink_long`, or `pulse`). 
+
+RGB LEDs also take a `color` using one of: red, green, blue, yellow, cyan, magenta, white.
+
+`type` can be `common_cathode` (default) or `common_anode` to match your LED wiring.
 
 ---
 
@@ -128,3 +130,11 @@ When `true`, ignores the fixed arrays and exposes full legal ranges.
 if self.button.is_pressed:      # high at rest → treat as “inverse”
     self.inverse = True
 ```
+
+---
+
+## GUI
+
+| JSON Path                 | Description                                     | Values                 |
+|---------------------------|-------------------------------------------------|------------------------|
+| `gui.recording_indicator` | Recording indicator style (`frame` or `dot`)    | `"frame"` / `"dot"`

--- a/docs/settings-json.md
+++ b/docs/settings-json.md
@@ -34,10 +34,15 @@ if self.button.is_pressed:      # high at rest → treat as “inverse”
 
 ## GPIO Outputs
 
-| JSON Path               | Description                                   | Values                   |
-|-------------------------|-----------------------------------------------|--------------------------|
-| `gpio_output.pwm_pin`   | PWM pin for strobe / shutter sync             | BCM pin number (e.g. 19) |
-| `gpio_output.rec_out_pin` | Pin(s) pulled high while recording            | List of BCM pins         |
+| JSON Path                   | Description                            | Values                      |
+|-----------------------------|----------------------------------------|-----------------------------|
+| `gpio_output.sys_LED[]`     | Single-colour status LEDs              | `pin` + ordered `rules`     |
+| `gpio_output.sys_LED_RGB[]` | RGB status LEDs                        | `pins` + ordered `rules`    |
+| `gpio_output.pwm_pin`       | PWM pin for strobe / shutter sync      | BCM pin number              |
+
+Each rule maps a Redis key (and optional value) to a behaviour
+(`steady`, `blink`, `blink_long`, or `pulse`). RGB LEDs also take a
+`color` using one of: red, green, blue, yellow, cyan, magenta, white.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ termcolor
 board
 adafruit-blinka
 adafruit-circuitpython-seesaw
-adafruit-circuitpython-ssd1306
+luma.oled

--- a/src/main.py
+++ b/src/main.py
@@ -169,7 +169,15 @@ def initialize_system(settings):
     sensor_detect = SensorDetect()
     ssd_monitor = SSDMonitor(redis_controller=redis_controller)
     usb_monitor = USBMonitor(ssd_monitor)
-    gpio_output = GPIOOutput(rec_out_pins=settings["gpio_output"]["rec_out_pin"])
+    gpio_cfg = settings.get("gpio_output", {})
+    sys_led_configs = gpio_cfg.get("sys_LED", [])
+    sys_led_rgb_configs = gpio_cfg.get("sys_LED_RGB", [])
+    from module.gpio_output import RedisGPIOOutput
+    gpio_output = RedisGPIOOutput(
+        redis_controller,
+        sys_led_configs=sys_led_configs,
+        sys_led_rgb_configs=sys_led_rgb_configs
+    )
     dmesg_monitor = DmesgMonitor()
     dmesg_monitor.start()
 
@@ -338,6 +346,9 @@ def main():
             simple_gui.stop()              # <— new: quit the thread
             simple_gui.clear_framebuffer() # <— new: blank fb0
 
+        # Release GPIO resources
+        gpio_output.cleanup()
+ 
         clear_screen()                     # wipe tty1
         show_cursor()
         

--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -576,7 +576,6 @@ class CinePiController:
                 
                 self.fps_correction_factor = self.sensor_detect.get_fps_correction_factor(
                     self.current_sensor,
-                    int(self.redis_controller.get_value(ParameterKey.SENSOR_MODE.value))
                     )
 
                 self.redis_controller.set_value(ParameterKey.SENSOR.value, self.sensor_detect.camera_model)

--- a/src/module/config_loader.py
+++ b/src/module/config_loader.py
@@ -94,6 +94,7 @@ def load_settings(filename: str | Path) -> dict:
 
     # sys_LED_RGB
     for led in gpio_cfg.get("sys_LED_RGB", []):
+        led.setdefault("type", "common_cathode")
         for pin in led.get("pins", []):
             add_pin(pin, "gpio_output.sys_LED_RGB")
 

--- a/src/module/dmesg_monitor.py
+++ b/src/module/dmesg_monitor.py
@@ -5,7 +5,7 @@ import time
 
 class DmesgMonitor(threading.Thread):
     def __init__(self):
-        super().__init__()
+        super().__init__(daemon=True)
         self.keywords = {
             "Undervoltage": "Under-voltage detected!",
             "Voltage_normalised": "Voltage normalised",
@@ -16,6 +16,7 @@ class DmesgMonitor(threading.Thread):
         self.undervoltage_timer = None
         self.disk_attached = False
         self.disk_detached_event = threading.Event()
+        self.running = True
 
     def run(self):
         self._start_monitoring()
@@ -54,7 +55,7 @@ class DmesgMonitor(threading.Thread):
 
     def _start_monitoring(self):
         # Main event loop
-        while True:
+        while self.running:
             dmesg_lines = self.read_dmesg_log()
             new_messages = self.parse_dmesg_messages(dmesg_lines)
             new_messages = self.track_last_occurrence(new_messages)
@@ -79,5 +80,9 @@ class DmesgMonitor(threading.Thread):
                                 logging.info("Disk detached.")
                                 self.disk_detached_event.set()
             time.sleep(5)
+
+    def stop(self):
+        """Stop the monitoring loop."""
+        self.running = False
 
 

--- a/src/module/gpio_output.py
+++ b/src/module/gpio_output.py
@@ -1,9 +1,102 @@
-from module.rpi_gpio_wrapper import RPi
 import logging
+import threading
+import time
+import math
+from module.rpi_gpio_wrapper import RPi
+from module.redis_controller import ParameterKey
+
+# simple RGB colour lookup (1=on, 0=off)
+COLOR_DICT = {
+    "red":    (1, 0, 0),
+    "green":  (0, 1, 0),
+    "blue":   (0, 0, 1),
+    "yellow": (1, 1, 0),
+    "cyan":   (0, 1, 1),
+    "magenta":(1, 0, 1),
+    "white":  (1, 1, 1),
+    "off":    (0, 0, 0),
+}
+
+class _LED(threading.Thread):
+    def __init__(self):
+        super().__init__(daemon=True)
+        self.mode = "off"
+        self.color = (1, 1, 1)
+        self._event = threading.Event()
+        self.running = True
+
+    def set_mode(self, mode, color=None):
+        self.mode = mode
+        if color is not None:
+            self.color = color
+        self._event.set()
+
+    def stop(self):
+        self.running = False
+        self._event.set()
+
+    # subclasses must implement _write(r,g,b) with 0/1 or duty 0..100
+
+    def run(self):
+        phase = 0.0
+        while self.running:
+            m = self.mode
+            if m == "steady":
+                self._write(*self.color)
+                self._event.wait(0.1)
+            elif m == "blink":
+                state = int((time.time()*5) % 2 < 1)
+                self._write(*(c*state for c in self.color))
+                self._event.wait(0.1)
+            elif m == "blink_long":
+                state = int((time.time()) % 1 < 0.5)
+                self._write(*(c*state for c in self.color))
+                self._event.wait(0.1)
+            elif m == "pulse":
+                phase = (phase + 0.05) % 1.0
+                duty = (1-math.cos(2*math.pi*phase))/2
+                self._write_pwm(duty)
+                self._event.wait(0.05)
+            else:
+                self._write(0,0,0)
+                self._event.wait(0.1)
+            self._event.clear()
+
+    # default PWM writer falls back to on/off
+    def _write_pwm(self, duty):
+        state = 1 if duty > 0.5 else 0
+        self._write(*(c*state for c in self.color))
+
+class SystemLED(_LED):
+    def __init__(self, pin):
+        super().__init__()
+        self.pin = pin
+        RPi.GPIO.setup(pin, RPi.GPIO.OUT)
+
+    def _write(self, r, g, b=None):
+        RPi.GPIO.output(self.pin, RPi.GPIO.HIGH if r else RPi.GPIO.LOW)
+
+class SystemLED_RGB(_LED):
+    def __init__(self, pins):
+        super().__init__()
+        self.pins = pins
+        for p in pins:
+            RPi.GPIO.setup(p, RPi.GPIO.OUT)
+
+    def _write(self, r, g, b):
+        for val, pin in zip((r,g,b), self.pins):
+            RPi.GPIO.output(pin, RPi.GPIO.HIGH if val else RPi.GPIO.LOW)
 
 class GPIOOutput:
+    """Handle recording indicator GPIO pins and LED threads."""
+
     def __init__(self, rec_out_pins=None):
-        self.rec_out_pins = rec_out_pins if rec_out_pins is not None else []  # This is the list of pins for recording
+        # list of pins driving LEDs indicating recording/writing status
+        self.rec_out_pins = rec_out_pins if rec_out_pins is not None else []
+
+        # container for optional LED threads started by other modules
+        self._led_threads = []
+        self._stop_event = threading.Event()
 
         # Set up each pin in rec_out_pins as an output if the list is provided
         for pin in self.rec_out_pins:
@@ -11,7 +104,81 @@ class GPIOOutput:
             logging.info(f"REC light instantiated on pin {pin}")
 
     def set_recording(self, status):
-        """Set the status of the recording pins based on the given status."""
+        """Set the status of the recording pins."""
         for pin in self.rec_out_pins:
             RPi.GPIO.output(pin, RPi.GPIO.HIGH if status else RPi.GPIO.LOW)
             logging.info(f"GPIO {pin} set to {'HIGH' if status else 'LOW'}")
+
+    def cleanup(self):
+        """Stop LED threads and release GPIO pins."""
+        self._stop_event.set()
+        for thread in list(self._led_threads):
+            if thread.is_alive():
+                thread.join()
+        self._led_threads.clear()
+
+        try:
+            RPi.GPIO.cleanup()
+            logging.info("GPIO pins cleaned up")
+        except Exception as exc:
+            logging.warning(f"GPIO cleanup failed: {exc}")
+
+class RedisGPIOOutput:
+    def __init__(self, redis_controller, sys_led_configs=None, sys_led_rgb_configs=None):
+        self.redis = redis_controller
+        self.leds = []  # list of (led, rules)
+
+        for cfg in sys_led_configs or []:
+            led = SystemLED(cfg.get("pin"))
+            self.leds.append((led, cfg.get("rules", [])))
+            led.start()
+
+        for cfg in sys_led_rgb_configs or []:
+            led = SystemLED_RGB(cfg.get("pins", []))
+            self.leds.append((led, cfg.get("rules", [])))
+            led.start()
+
+        if self.leds:
+            self.redis.redis_parameter_changed.subscribe(self._redis_update)
+            # initial state
+            for led, rules in self.leds:
+                self._update_led(led, rules)
+
+    def _redis_update(self, data):
+        key = data["key"]
+        for led, rules in self.leds:
+            if any(rule.get("key") == key for rule in rules):
+                self._update_led(led, rules)
+
+    def _get_value(self, key):
+        return self.redis.get_value(key)
+
+    def _match(self, val, rule_val):
+        if rule_val is None:
+            return str(val) not in ("0", "False", "false", "None", "")
+        return str(val) == str(int(rule_val)) or str(val).lower() == str(rule_val).lower()
+
+    def _update_led(self, led, rules):
+        for rule in rules:
+            val = self._get_value(rule.get("key"))
+            if self._match(val, rule.get("value")):
+                color = COLOR_DICT.get(rule.get("color", "white"), (1,1,1))
+                led.set_mode(rule.get("mode", "off"), color)
+                return
+        led.set_mode("off")
+
+    def set_recording(self, status):
+        # compatibility shim – set first LED if defined
+        for led, rules in self.leds:
+            for r in rules:
+                if r.get("key") == ParameterKey.REC.value:
+                    val = 1 if status else 0
+                    if self._match(val, r.get("value")):
+                        color = COLOR_DICT.get(r.get("color", "white"), (1,1,1))
+                        led.set_mode(r.get("mode", "off"), color)
+                    else:
+                        led.set_mode("off")
+
+    def cleanup(self):
+        for led, _ in self.leds:
+            led.stop()

--- a/src/module/i2c_oled.py
+++ b/src/module/i2c_oled.py
@@ -3,9 +3,8 @@ import os
 import threading
 import time
 from typing import TypedDict
-import board
-import busio
-import adafruit_ssd1306
+from luma.core.interface.serial import i2c
+from luma.oled.device import ssd1306
 from PIL import Image, ImageDraw, ImageFont
 from module.utils import Utils
 from module.redis_controller import ParameterKey
@@ -29,8 +28,8 @@ class I2cOled(threading.Thread):
         self.font_size = self.settings.get("font_size", 10)
         self.values = self.settings.get("values", [ParameterKey.ISO.value, ParameterKey.FPS.value, ParameterKey.SHUTTER_A.value, 'resolution', ParameterKey.IS_RECORDING.value])
 
-        self.i2c = busio.I2C(board.SCL, board.SDA)
-        self.oled = adafruit_ssd1306.SSD1306_I2C(self.width, self.height, self.i2c)
+        self.serial = i2c(port=1, address=0x3C)
+        self.oled = ssd1306(self.serial, width=self.width, height=self.height)
         self.update()
 
     def display_text(self, text, x=0, y=0):
@@ -40,8 +39,7 @@ class I2cOled(threading.Thread):
         font_path = os.path.join(current_directory, '../../resources/fonts/Arial.ttf')
         font = ImageFont.truetype(font_path, self.font_size)
         draw.text((x, y), text, font=font, fill=255)
-        self.oled.image(image)
-        self.oled.show()
+        self.oled.display(image)
 
     def update(self):
         texts = {

--- a/src/module/ir_filter.py
+++ b/src/module/ir_filter.py
@@ -1,3 +1,5 @@
+# Based on the original code by Will Whang: https://github.com/will127534/StarlightEye/blob/main/software/README.md
+
 import json
 import logging
 import smbus

--- a/src/module/mediator.py
+++ b/src/module/mediator.py
@@ -86,11 +86,21 @@ class Mediator:
         
         # Handle "is_writing" key changes        
         elif data['key'] == ParameterKey.IS_WRITING.value:
-            is_writing = bool(data['value'])
-            if is_writing == 1:
+            is_writing = bool(int(data['value']))
+            if is_writing:
                 self.stream.toggle_background_color()
+                self.gpio_output.set_drive_color("blue")
             else:
-                self.gpio_output.set_recording(0)    
+                self.gpio_output.set_drive_color(
+                    "green" if self.redis_controller.get_value(ParameterKey.IS_MOUNTED.value) == "1" else "off")
+                self.gpio_output.set_recording(0)
+
+        elif data['key'] == ParameterKey.IS_MOUNTED.value:
+            mounted = bool(int(data['value']))
+            if not mounted:
+                self.gpio_output.set_drive_color("off")
+            else:
+                self.gpio_output.set_drive_color("green")
 
     def handle_stop_recording_timeout(self):
         """Handle the timeout event when recording should be stopped."""

--- a/src/module/redis_controller.py
+++ b/src/module/redis_controller.py
@@ -29,6 +29,7 @@ class ParameterKey(Enum):
     FPS_MAX           = "fps_max"
     FPS_USER          = "fps_user"
     FRAMECOUNT        = "framecount"
+    RECORDING_TIME_ELAPSED = "recording_time_elapsed"
     GUI_LAYOUT        = "gui_layout"
     HEIGHT            = "height"
     IR_FILTER         = "ir_filter"
@@ -37,6 +38,7 @@ class ParameterKey(Enum):
     IS_RECORDING      = "is_recording"
     IS_WRITING        = "is_writing"
     IS_WRITING_BUF    = "is_writing_buf"
+    DROP_FRAME_DETECTED = "drop_frame_detected"
     
     ISO               = "iso"
     LORES_HEIGHT      = "lores_height"

--- a/src/module/sensor_detect.py
+++ b/src/module/sensor_detect.py
@@ -32,18 +32,18 @@ class SensorDetect:
                 3: {'aspect': 1.77, 'width': 3840, 'height': 2160, 'bit_depth': 10, 'packing': 'P', 'fps_max': 18, 'gui_layout': 0, 'file_size': 31}, # driver fps max 18                   
             },
             'imx585': {             
-                0: {'aspect': 1.77, 'width': 1928, 'height': 1090, 'bit_depth': 12, 'packing': 'U', 'fps_max': 87, 'gui_layout': 0, 'file_size': 4.1}, # driver fps max 87
-                1: {'aspect': 1.77, 'width': 3856, 'height': 2180, 'bit_depth': 12, 'packing': 'U', 'fps_max': 34, 'gui_layout': 0, 'file_size': 13.5}, # driver fps max 34
-               # 2: {'aspect': 1.77, 'width': 1928, 'height': 1090, 'bit_depth': 16, 'packing': 'U', 'fps_max': 30, 'gui_layout': 0, 'file_size': 13.5}, # driver fps max 30
+                0: {'aspect': 1.77, 'width': 1928, 'height': 1090, 'bit_depth': 12, 'packing': 'U', 'fps_max': 100, 'gui_layout': 0, 'file_size': 4.1}, # driver fps max 87
+                1: {'aspect': 1.77, 'width': 3856, 'height': 2180, 'bit_depth': 12, 'packing': 'U', 'fps_max': 50, 'gui_layout': 0, 'file_size': 13.5}, # driver fps max 34
+               # 2: {'aspect': 1.77, 'width': 1928, 'height': 1090, 'bit_depth': 16, 'packing': 'U', 'fps_max': 50, 'gui_layout': 0, 'file_size': 13.5}, # driver fps max 30
 
-                #3: {'aspect': 1.77, 'width': 3856, 'height': 2180, 'bit_depth': 16, 'packing': 'U', 'fps_max': 21, 'gui_layout': 0, 'file_size': 8},                                      
+                #3: {'aspect': 1.77, 'width': 3856, 'height': 2180, 'bit_depth': 16, 'packing': 'U', 'fps_max': 25, 'gui_layout': 0, 'file_size': 8},                                      
             },
             'imx585_mono': {             
-                0: {'aspect': 1.77, 'width': 1928, 'height': 1090, 'bit_depth': 12, 'packing': 'U', 'fps_max': 87, 'gui_layout': 0, 'file_size': 4.1, 'fps_correction_factor': 0.9980},  # driver fps max 87
-                1: {'aspect': 1.77, 'width': 3856, 'height': 2180, 'bit_depth': 12, 'packing': 'U', 'fps_max': 34, 'gui_layout': 0, 'file_size': 13.5, 'fps_correction_factor': 0.9980}, # driver fps max 34
-                #2: {'aspect': 1.77, 'width': 1928, 'height': 1090, 'bit_depth': 16, 'packing': 'U', 'fps_max': 30, 'gui_layout': 0, 'file_size': 13.5, 'fps_correction_factor': 0.9980}, # driver fps max 30
+                0: {'aspect': 1.77, 'width': 1928, 'height': 1090, 'bit_depth': 12, 'packing': 'U', 'fps_max': 100, 'gui_layout': 0, 'file_size': 4.1, 'fps_correction_factor': 0.9980},  # driver fps max 87
+                1: {'aspect': 1.77, 'width': 3856, 'height': 2180, 'bit_depth': 12, 'packing': 'U', 'fps_max': 50, 'gui_layout': 0, 'file_size': 13.5, 'fps_correction_factor': 0.9980}, # driver fps max 34
+                #2: {'aspect': 1.77, 'width': 1928, 'height': 1090, 'bit_depth': 16, 'packing': 'U', 'fps_max': 50, 'gui_layout': 0, 'file_size': 13.5, 'fps_correction_factor': 0.9980}, # driver fps max 30
 
-                #3: {'aspect': 1.77, 'width': 3856, 'height': 2180, 'bit_depth': 16, 'packing': 'U', 'fps_max': 21, 'gui_layout': 0, 'file_size': 8},                                      
+                #3: {'aspect': 1.77, 'width': 3856, 'height': 2180, 'bit_depth': 16, 'packing': 'U', 'fps_max': 25, 'gui_layout': 0, 'file_size': 8},                                      
             },
         }
         

--- a/src/settings.json
+++ b/src/settings.json
@@ -30,6 +30,10 @@
     }
   },
 
+  "gui": {
+    "recording_indicator": "dot"
+  },
+
   "preview": {
     "default_zoom": 1.0,
     "zoom_steps":   [1.0, 1.5, 2.0]
@@ -51,12 +55,12 @@
       }
     ],
     "sys_LED_RGB": [
-      {
-        "pins": [14,15,18],
-        "rules": [
+    {
+      "pins": [14,18,15],
+      "type": "common_cathode",
+      "rules": [
           {"key": "is_mounted", "value": 1, "mode": "steady", "color": "blue"},
-          {"key": "is_mounted", "value": 0, "mode": "blink_long", "color": "blue"},
-          {"key": "is_writing", "mode": "pulse", "color": "green"}
+          {"key": "is_mounted", "value": 0, "mode": "blink_long", "color": "blue"}
         ]
       }
     ]
@@ -202,4 +206,5 @@
 
     ]
   }
+
 }

--- a/src/settings.json
+++ b/src/settings.json
@@ -37,12 +37,29 @@
 
   "anamorphic_preview": {
       "default_anamorphic_factor": 1,
-    "anamorphic_steps": [1, 1.33, 2.0]
+      "anamorphic_steps": [1, 1.33, 2.0]
   },
 
   "gpio_output": {
-    "pwm_pin": 19,
-    "rec_out_pin": [6, 21]
+    "sys_LED": [
+      {
+        "pin": 4,
+        "rules": [
+          {"key": "drop_frame_detected", "mode": "blink"},
+          {"key": "rec", "value": 1, "mode": "steady"}
+        ]
+      }
+    ],
+    "sys_LED_RGB": [
+      {
+        "pins": [14,15,18],
+        "rules": [
+          {"key": "is_mounted", "value": 1, "mode": "steady", "color": "blue"},
+          {"key": "is_mounted", "value": 0, "mode": "blink_long", "color": "blue"},
+          {"key": "is_writing", "mode": "pulse", "color": "green"}
+        ]
+      }
+    ]
   },
   
   "arrays": {
@@ -70,8 +87,6 @@
     "wb_free": false
   },
 
-
-  
 "buttons": [
     {
       "pin": 5,
@@ -129,7 +144,7 @@
       "state_off_action": {"method": "set_shutter_a_sync_mode", "args": [0]}
     },
     {
-      "pin": 18,
+      "pin": 19,
       "state_on_action": {"method": "set_filter", "args": [1]},
       "state_off_action": {"method": "set_filter", "args": [0]}
     }


### PR DESCRIPTION
## Summary
- ensure cleanup only runs once and call it from the signal handler
- make CommandExecutor and DmesgMonitor daemon threads
- guard stop calls when cleaning up threads

## Testing
- `pytest -q`
- `python -m compileall -q src/module/ src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68757c69825083328eee0e18bb163e71