### PR TITLE
Update timecode handling in RedisListener

### DIFF
--- a/docs/redis-guide.md
+++ b/docs/redis-guide.md
@@ -67,7 +67,8 @@ Every frame, cinepi-raw sends a small JSON object containing live statistics.
 
 CineMate’s `RedisListener` parses these messages and updates Redis keys like `framecount`, `BUFFER` and `fps_actual`.
 The timestamp fields are converted to SMPTE timecode based on `fps_user` and
-written to `tc_cam0` and `tc_cam1`.
+written to `tc_cam0` and `tc_cam1`.  Values are only updated when the underlying
+timestamp changes so Redis clients receive a new timecode once per frame.
 
 ## Controlling the camera from your own script
 

--- a/src/module/redis_listener.py
+++ b/src/module/redis_listener.py
@@ -81,7 +81,11 @@ class RedisListener:
 
 
         self.current_framerate = None
-        
+
+        self.last_timestamp_single = None
+        self.last_timestamp_cam0 = None
+        self.last_timestamp_cam1 = None
+
         self.start_listeners()
 
     def start_listeners(self):
@@ -166,15 +170,18 @@ class RedisListener:
                             self.redis_controller.get_value(ParameterKey.FPS_USER.value) or 24
                         )
 
-                        if timestamp is not None:
+                        if timestamp is not None and timestamp != self.last_timestamp_cam0:
                             tc = self.redis_controller.nanoseconds_to_timecode(int(timestamp), fps_user)
                             self.redis_controller.set_value(ParameterKey.TC_CAM0.value, tc)
-                        if timestamp_cam0 is not None:
+                            self.last_timestamp_cam0 = timestamp
+                        if timestamp_cam0 is not None and timestamp_cam0 != self.last_timestamp_cam0:
                             tc0 = self.redis_controller.nanoseconds_to_timecode(int(timestamp_cam0), fps_user)
                             self.redis_controller.set_value(ParameterKey.TC_CAM0.value, tc0)
-                        if timestamp_cam1 is not None:
+                            self.last_timestamp_cam0 = timestamp_cam0
+                        if timestamp_cam1 is not None and timestamp_cam1 != self.last_timestamp_cam1:
                             tc1 = self.redis_controller.nanoseconds_to_timecode(int(timestamp_cam1), fps_user)
                             self.redis_controller.set_value(ParameterKey.TC_CAM1.value, tc1)
+                            self.last_timestamp_cam1 = timestamp_cam1
 
                         # Update Redis key for current buffer size if changed
                         if buffer_size is not None:


### PR DESCRIPTION
## Summary
- only publish camera timecode when the timestamp changes
- document new behaviour in redis-guide

## Testing
- `python -m py_compile src/module/redis_listener.py`

------
https://chatgpt.com/codex/tasks/task_e_687cb9066c488332809d5bf81e826ddd