### PR TITLE
Fix frame buffer reporting

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -336,8 +336,19 @@ def main():
     redis_listener = RedisListener(redis_controller, ssd_monitor)
     battery_monitor = BatteryMonitor()
 
-    simple_gui = SimpleGUI(redis_controller, cinepi_controller, ssd_monitor, dmesg_monitor,
-                       battery_monitor, sensor_detect, redis_listener, None, usb_monitor=usb_monitor, serial_handler=serial_handler)
+    simple_gui = SimpleGUI(
+        redis_controller,
+        cinepi_controller,
+        ssd_monitor,
+        dmesg_monitor,
+        battery_monitor,
+        sensor_detect,
+        redis_listener,
+        None,
+        usb_monitor=usb_monitor,
+        serial_handler=serial_handler,
+        settings=settings,
+    )
 
     if settings.get("i2c_oled", {}).get("enabled", False):
         i2c_oled = I2cOled(settings, redis_controller)

--- a/src/module/app/templates/template.html
+++ b/src/module/app/templates/template.html
@@ -107,8 +107,8 @@
         <button id="unmount-btn">Unmount</button>
         <div><span id="disk-space"></span></div>
         <div>WRITE: <span id="write-speed"></span></div>
-        <div>FRAMES: <span id="buffer-used"></span></div>
-        <div>BUFFER: <span id="buffer-size"></span></div>
+        <div>FRAMES BUFFERED: <span id="buffer-used"></span></div>
+        <div>BUFFER SIZE: <span id="buffer-size"></span></div>
         <div>CPU: <span id="cpu-load"></span></div>
         <div>RAM: <span id="ram-load"></span></div>
         <div>TEMP: <span id="cpu-temp"></span></div>

--- a/src/module/config_loader.py
+++ b/src/module/config_loader.py
@@ -100,4 +100,7 @@ def load_settings(filename: str | Path) -> dict:
         res_cfg.setdefault(k, v)
     settings["resolutions"] = res_cfg
 
+    # Default for buffer VU meter visibility
+    settings.setdefault("buffer_vu_meter", True)
+
     return settings

--- a/src/module/redis_listener.py
+++ b/src/module/redis_listener.py
@@ -185,12 +185,12 @@ class RedisListener:
 
                         # Update Redis key for current buffer size if changed
                         if buffer_size is not None:
-                            current_buffer = self.redis_controller.get_value('BUFFER')
+                            current_buffer = self.redis_controller.get_value(ParameterKey.BUFFER.value)
                             # Redis returns bytes or None → normalise to int or None
                             current_buffer = int(current_buffer) if current_buffer is not None else None
 
                             if current_buffer != buffer_size:
-                                self.redis_controller.set_value('BUFFER', buffer_size)
+                                self.redis_controller.set_value(ParameterKey.BUFFER.value, buffer_size)
                                 #logging.info(f"Buffer size changed to {buffer_size}")
 
                         # Update sensor timestamps

--- a/src/module/simple_gui.py
+++ b/src/module/simple_gui.py
@@ -26,7 +26,8 @@ class SimpleGUI(threading.Thread):
                 #timekeeper, 
                 socketio: SocketIO = None,
                 usb_monitor=None,
-                serial_handler=None):
+                serial_handler=None,
+                settings=None):
         threading.Thread.__init__(self)
         
         self.daemon = True          # die if the parent dies
@@ -60,6 +61,11 @@ class SimpleGUI(threading.Thread):
         
         self.serial_handler = serial_handler
 
+        # Buffer VU meter toggle from settings
+        if settings is not None:
+            self.show_buffer_vu = bool(settings.get("buffer_vu_meter", True))
+        else:
+            self.show_buffer_vu = True
 
         self.background_color_changed = False
         
@@ -1038,7 +1044,8 @@ class SimpleGUI(threading.Thread):
                 
         self.update_smoothed_vu_levels()
         self.draw_right_vu_meter(draw)
-        #self.draw_framebuffer_vu_meter(draw)
+        if self.show_buffer_vu:
+            self.draw_framebuffer_vu_meter(draw)
 
         vu = self.vu_smoothed  # Or .usb_monitor.audio_monitor.vu_levels if you want raw
         # if vu:

--- a/src/settings.json
+++ b/src/settings.json
@@ -212,5 +212,6 @@
     ]
   },
   "welcome_message": "THIS IS A COOL MACHINE",
-  "welcome_image": null
+  "welcome_image": null,
+  "buffer_vu_meter": true
 }


### PR DESCRIPTION
## Summary
- fix writing buffer value to Redis
- update GUI labels for buffered frames
- show framebuffer VU meter controlled via settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883fe185a4c8332bfa6cc186e5d175d