### PR TITLE
Fix frame buffer reporting

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -336,8 +336,19 @@ def main():
     redis_listener = RedisListener(redis_controller, ssd_monitor)
     battery_monitor = BatteryMonitor()
 
-    simple_gui = SimpleGUI(redis_controller, cinepi_controller, ssd_monitor, dmesg_monitor,
-                       battery_monitor, sensor_detect, redis_listener, None, usb_monitor=usb_monitor, serial_handler=serial_handler)
+    simple_gui = SimpleGUI(
+        redis_controller,
+        cinepi_controller,
+        ssd_monitor,
+        dmesg_monitor,
+        battery_monitor,
+        sensor_detect,
+        redis_listener,
+        None,
+        usb_monitor=usb_monitor,
+        serial_handler=serial_handler,
+        settings=settings,
+    )
 
     if settings.get("i2c_oled", {}).get("enabled", False):
         i2c_oled = I2cOled(settings, redis_controller)

--- a/src/module/app/templates/template.html
+++ b/src/module/app/templates/template.html
@@ -107,8 +107,8 @@
         <button id="unmount-btn">Unmount</button>
         <div><span id="disk-space"></span></div>
         <div>WRITE: <span id="write-speed"></span></div>
-        <div>FRAMES: <span id="buffer-used"></span></div>
-        <div>BUFFER: <span id="buffer-size"></span></div>
+        <div>FRAMES BUFFERED: <span id="buffer-used"></span></div>
+        <div>BUFFER SIZE: <span id="buffer-size"></span></div>
         <div>CPU: <span id="cpu-load"></span></div>
         <div>RAM: <span id="ram-load"></span></div>
         <div>TEMP: <span id="cpu-temp"></span></div>

--- a/src/module/config_loader.py
+++ b/src/module/config_loader.py
@@ -52,6 +52,16 @@ def load_settings(filename: str | Path) -> dict:
     settings.setdefault("welcome_message", "THIS IS A COOL MACHINE")
     settings.setdefault("welcome_image", None)
 
+    # ── HDMI GUI defaults ───────────────────────────────────────────────
+    hdmi_gui_defaults = {
+        "buffer_vu_meter": True,
+        "vu_meter_hatch": True,
+    }
+    hdmi_gui_cfg = settings.setdefault("hdmi_gui", {})
+    for k, v in hdmi_gui_defaults.items():
+        hdmi_gui_cfg.setdefault(k, v)
+    settings["hdmi_gui"] = hdmi_gui_cfg
+
     # ── preview / zoom defaults ──────────────────────────────────────────
     preview_defaults = {
         "default_zoom": 1.0,

--- a/src/module/redis_listener.py
+++ b/src/module/redis_listener.py
@@ -185,12 +185,12 @@ class RedisListener:
 
                         # Update Redis key for current buffer size if changed
                         if buffer_size is not None:
-                            current_buffer = self.redis_controller.get_value('BUFFER')
+                            current_buffer = self.redis_controller.get_value(ParameterKey.BUFFER.value)
                             # Redis returns bytes or None → normalise to int or None
                             current_buffer = int(current_buffer) if current_buffer is not None else None
 
                             if current_buffer != buffer_size:
-                                self.redis_controller.set_value('BUFFER', buffer_size)
+                                self.redis_controller.set_value(ParameterKey.BUFFER.value, buffer_size)
                                 #logging.info(f"Buffer size changed to {buffer_size}")
 
                         # Update sensor timestamps

--- a/src/settings.json
+++ b/src/settings.json
@@ -31,6 +31,11 @@
     }
   },
 
+  "hdmi_gui": {
+    "buffer_vu_meter": true,
+    "vu_meter_hatch": true
+  },
+
   "preview": {
     "default_zoom": 1.0,
     "zoom_steps":   [1.0, 1.5, 2.0]


### PR DESCRIPTION
## Summary
- fix writing buffer value to Redis
- update GUI labels for buffered frames
- show framebuffer VU meter controlled via settings
- allow turning hatch lines on/off via new hdmi_gui settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883fe185a4c8332bfa6cc186e5d175d