### PR TITLE
Add hdmi_gui settings group with VU options

### DIFF
--- a/src/module/config_loader.py
+++ b/src/module/config_loader.py
@@ -100,7 +100,14 @@ def load_settings(filename: str | Path) -> dict:
         res_cfg.setdefault(k, v)
     settings["resolutions"] = res_cfg
 
-    # Default for buffer VU meter visibility
-    settings.setdefault("buffer_vu_meter", True)
+    # Defaults for HDMI GUI settings
+    hdmi_gui_defaults = {
+        "buffer_vu_meter": True,
+        "vu_meter_hatch_lines": True,
+    }
+    hdmi_gui_cfg = settings.setdefault("hdmi_gui", {})
+    for k, v in hdmi_gui_defaults.items():
+        hdmi_gui_cfg.setdefault(k, v)
+    settings["hdmi_gui"] = hdmi_gui_cfg
 
     return settings

--- a/src/module/simple_gui.py
+++ b/src/module/simple_gui.py
@@ -61,11 +61,14 @@ class SimpleGUI(threading.Thread):
         
         self.serial_handler = serial_handler
 
-        # Buffer VU meter toggle from settings
+        # Buffer VU meter and hatch line toggles from settings
         if settings is not None:
-            self.show_buffer_vu = bool(settings.get("buffer_vu_meter", True))
+            hdmi_cfg = settings.get("hdmi_gui", {})
+            self.show_buffer_vu = bool(hdmi_cfg.get("buffer_vu_meter", True))
+            self.vu_meter_hatch_lines = bool(hdmi_cfg.get("vu_meter_hatch_lines", True))
         else:
             self.show_buffer_vu = True
+            self.vu_meter_hatch_lines = True
 
         self.background_color_changed = False
         
@@ -880,10 +883,11 @@ class SimpleGUI(threading.Thread):
                             base_x + BAR_W,
                             base_y + BAR_H],
                         fill=fill_colour)
-        # ── optional hatch lines (unchanged) ────────────────────────
-        for dy in range(0, filled_h, 2):
-            y = base_y + BAR_H - 1 - dy
-            draw.line([(base_x, y), (base_x + BAR_W, y)], fill=border_col)
+        # ── optional hatch lines ───────────────────────────────────
+        if self.vu_meter_hatch_lines:
+            for dy in range(0, filled_h, 2):
+                y = base_y + BAR_H - 1 - dy
+                draw.line([(base_x, y), (base_x + BAR_W, y)], fill=border_col)
 
         # ── tick marks at 25/50/75/100 % (unchanged) ────────────────
         for frac in (0.25, 0.50, 0.75, 1.00):

--- a/src/settings.json
+++ b/src/settings.json
@@ -31,6 +31,11 @@
     }
   },
 
+  "hdmi_gui": {
+    "buffer_vu_meter": true,
+    "vu_meter_hatch_lines": true
+  },
+
   "preview": {
     "default_zoom": 1.0,
     "zoom_steps":   [1.0, 1.5, 2.0]
@@ -213,5 +218,5 @@
   },
   "welcome_message": "THIS IS A COOL MACHINE",
   "welcome_image": null,
-  "buffer_vu_meter": true
+  
 }


### PR DESCRIPTION
## Summary
- add `hdmi_gui` group in settings
- support VU meter hatch toggle via settings
- load new HDMI GUI settings in config loader

## Testing
- `python -m py_compile src/module/config_loader.py src/module/simple_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_68840b1786548332b97199a6abc5d44a