### PR TITLE
Fix default GPIO output config

### DIFF
--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -13,6 +13,9 @@ import sys
 
 from module.redis_controller import ParameterKey
 from module.ir_filter import IRFilter
+from module.config_loader import load_settings as _load_settings
+
+SETTINGS_FILE = "/home/pi/cinemate/src/settings.json"
 
 class CinePiController:
     def __init__(self,
@@ -297,10 +300,9 @@ class CinePiController:
 
     def load_settings(self):
         try:
-            with open('/home/pi/cinemate/src/settings.json', 'r') as file:
-                settings = json.load(file)
-                logging.info("Settings loaded successfully.")
-                return settings
+            settings = _load_settings(SETTINGS_FILE)
+            logging.info("Settings loaded successfully.")
+            return settings
         except Exception as e:
             logging.error(f"Error loading settings: {e}")
             return {}

--- a/src/module/config_loader.py
+++ b/src/module/config_loader.py
@@ -21,7 +21,14 @@ def load_settings(filename: str | Path) -> dict:
         settings = {}
 
     # ── top-level placeholders ───────────────────────────────────────────
-    settings.setdefault("gpio_output",     {})
+    gpio_defaults = {
+        "pwm_pin": 19,
+        "rec_out_pin": [6, 21],
+    }
+    gpio_cfg = settings.setdefault("gpio_output", {})
+    for k, v in gpio_defaults.items():
+        gpio_cfg.setdefault(k, v)
+    settings["gpio_output"] = gpio_cfg
     settings.setdefault("arrays",          {})
     settings.setdefault("settings",        {"light_hz": [50, 60], "conform_frame_rate": 24})
     system_cfg = settings.setdefault("system", {})


### PR DESCRIPTION
## Summary
- default `gpio_output` section now includes `pwm_pin` and `rec_out_pin`
- load CinePiController settings using new default loader

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6884e56145e88332aa7a87c3979e014a