### PR TITLE
Fix Pi 5 camera port detection

### DIFF
--- a/docs/dual-sensors.md
+++ b/docs/dual-sensors.md
@@ -8,4 +8,6 @@ CineMate automatically detects each camera connected to the Raspberry Pi and spa
 
 Cameras are synchronized with cam0 being the server and cam1 being the client.
 
+On Raspberry Pi 5 carrier boards, the second CSI connector may appear as `i2c@70000` in `--list-cameras`. Cinemate maps this path to **cam1** so each sensor gets the correct port assignment.
+
 You can override default HDMI mappings in `settings.json` under the `output` section.

--- a/src/module/cinepi_multi.py
+++ b/src/module/cinepi_multi.py
@@ -60,11 +60,13 @@ class CameraInfo:
         # Pi 4 / Zero 2 W
         if 'i2c@1a0000' in self.path or 'i2c@10' in self.path:
             return 'cam0'
+
         # Pi 5 / CM4 / CM3
-        elif 'i2c@88000' in self.path:
+        if 'i2c@88000' in self.path:
             return 'cam0'
-        elif 'i2c@80000' in self.path:
+        if 'i2c@80000' in self.path or 'i2c@70000' in self.path:
             return 'cam1'
+
         # Fallback: assume cam0
         return 'cam0'
 


### PR DESCRIPTION
## Summary
- detect `/i2c@70000` as cam1
- document the new path in the dual sensor guide

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a73c68ccc8332ac4bb4be24f6caab