### PR TITLE
fix(web-gui): reload the page automatically when a resolution change completes

### DIFF
--- a/_test/test_cinepi_controller_resolution_gui.py
+++ b/_test/test_cinepi_controller_resolution_gui.py
@@ -267,9 +267,13 @@ class ResolutionGuiStateTests(unittest.TestCase):
 
     def test_switch_complete_timer_fallback_fires_the_callback(self):
         # The evidence path (handle_cinepi_raw_message) is the fast path;
-        # this is the fallback if that log line is never seen.
+        # this is the fallback if that log line is never seen. RESOLUTION_SWITCHING
+        # has to be published True first -- as _apply_resolution_mode always does
+        # before calling this -- or the already-complete guard treats the switch
+        # as finished and returns without scheduling.
         controller = self.controller()
         resolution_info = controller.sensor_detect.res_modes[1]
+        controller._publish_resolution_target_state(1, resolution_info, switching=True)
         complete_calls = []
         controller.add_resolution_switch_complete_callback(lambda: complete_calls.append(1))
 

--- a/_test/test_web_gui_resolution_auto_refresh.py
+++ b/_test/test_web_gui_resolution_auto_refresh.py
@@ -1,0 +1,185 @@
+"""The web GUI didn't refresh automatically on a resolution change, and the
+switch-complete path could double-fire. Three defects, one fix:
+
+D1 (client) -- a frozen MJPEG <img> after a cinepi-raw restart fires neither
+`error` nor a naturalWidth drop, so the single `reload_stream` emit was the
+only recovery path; miss it (backgrounded tab, socket hiccup during the
+restart) and the preview stays frozen until a manual refresh.
+
+D2 (server) -- `restart()` runs synchronously inside `_apply_resolution_mode`,
+so cinepi-raw's "Raw stream: WxH" evidence usually clears RESOLUTION_SWITCHING
+and fires switch-complete *before* `_schedule_resolution_switch_complete` is
+even called. The fallback timer got scheduled anyway and fired a second,
+redundant switch-complete `GUI_RESOLUTION_SWITCHING_HOLD_SECONDS` later.
+
+D3 (requirement) -- resolution changes only reloaded the stream `<img>`; the
+operator wants the white-balance behaviour, a full automatic browser refresh
+once the switch completes.
+
+Fix: (A) module/app/__init__.py's switch-complete callback now also schedules
+a deferred `reload_browser` emit -- same threading.Timer shape as the WB path
+in main/events.py -- gated off while recording and debounced to one pending
+timer per switch. (B) cinepi_controller.py's _schedule_resolution_switch_complete
+returns before scheduling if RESOLUTION_SWITCHING is already 0 -- the evidence
+path already completed this switch during the synchronous restart. (C)
+template.html gives stream recovery a second, independent path: it tracks the
+resolution_switching truthy->falsy edge (fed by the Redis fan-out, not by the
+reload_stream emit) and calls reloadStreams() on that edge.
+
+This checks the wiring end to end against the real sources -- no Flask app is
+constructed and no browser runs.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_INIT = ROOT / "src/module/app/__init__.py"
+CINEPI_CONTROLLER = ROOT / "src/module/cinepi_controller.py"
+TEMPLATE = ROOT / "src/module/app/templates/template.html"
+
+
+class WebGuiResolutionAutoRefreshTests(unittest.TestCase):
+    def setUp(self):
+        self.app_init_src = APP_INIT.read_text(encoding="utf-8")
+        self.cinepi_controller_src = CINEPI_CONTROLLER.read_text(encoding="utf-8")
+        self.template_src = TEMPLATE.read_text(encoding="utf-8")
+
+    # -- A: server schedules a deferred, gated reload_browser -------------
+
+    def test_switch_complete_callback_schedules_reload_browser_via_timer(self):
+        m = re.search(
+            r"def emit_reload_stream\(\):(.*?)\n        cinepi_controller\."
+            r"add_resolution_switch_complete_callback",
+            self.app_init_src,
+            re.S,
+        )
+        self.assertIsNotNone(m, "emit_reload_stream callback not found")
+        body = m.group(1)
+        self.assertIn(
+            "socketio.emit('reload_stream')",
+            body,
+            "switch-complete callback no longer emits reload_stream",
+        )
+        self.assertIn(
+            "threading.Timer(2.0,",
+            body,
+            "reload_browser is no longer scheduled on a deferred 2.0s threading.Timer",
+        )
+        self.assertIn(
+            "socketio.emit('reload_browser')",
+            body,
+            "the deferred timer no longer emits reload_browser",
+        )
+
+    def test_reload_browser_is_gated_on_is_recording(self):
+        self.assertRegex(
+            self.app_init_src,
+            r"ParameterKey\.IS_RECORDING\.value\)\s*==\s*\"1\"",
+            "reload_browser scheduling lost its IS_RECORDING gate",
+        )
+
+    def test_reload_browser_is_debounced_to_one_pending_timer(self):
+        # A closure variable must hold the live Timer and be checked before
+        # scheduling another one -- otherwise every switch-complete during a
+        # single switch would queue its own page reload.
+        self.assertIn("reload_browser_timer", self.app_init_src)
+        self.assertRegex(
+            self.app_init_src,
+            r"if reload_browser_timer is not None:\s*\n(?:\s*#.*\n)*\s*return",
+            "no debounce guard against a second pending reload_browser timer",
+        )
+
+    # -- B: single-fire switch-complete -----------------------------------
+
+    def test_schedule_resolution_switch_complete_has_already_complete_guard(self):
+        m = re.search(
+            r"def _schedule_resolution_switch_complete\(self, value, resolution_info\):"
+            r"(.*?)\n    def ",
+            self.cinepi_controller_src,
+            re.S,
+        )
+        self.assertIsNotNone(m, "_schedule_resolution_switch_complete not found")
+        body = m.group(1)
+        cancel_idx = body.find("self._cancel_resolution_switching_timer()")
+        guard_idx = body.find(
+            "as_bool(self.redis_controller.get_value(ParameterKey.RESOLUTION_SWITCHING.value))"
+        )
+        self.assertNotEqual(cancel_idx, -1, "timer cancel call missing")
+        self.assertNotEqual(guard_idx, -1, "already-complete guard missing")
+        self.assertLess(
+            cancel_idx,
+            guard_idx,
+            "already-complete guard must run after cancelling the fallback timer",
+        )
+        guard_to_timer = body[guard_idx:body.find("threading.Timer", guard_idx)]
+        self.assertIn(
+            "return",
+            guard_to_timer,
+            "an already-0 RESOLUTION_SWITCHING must return without scheduling",
+        )
+
+    # -- C: client-side falling-edge redundancy ----------------------------
+
+    def test_template_handles_reload_browser(self):
+        self.assertIn(
+            "socket.on('reload_browser'",
+            self.template_src,
+            "template.html no longer handles reload_browser",
+        )
+
+    def test_template_seeds_the_edge_tracker_from_initial_values(self):
+        m = re.search(
+            r"socket\.on\('initial_values', \(data\) => \{(.*?)\n    \}\);",
+            self.template_src,
+            re.S,
+        )
+        self.assertIsNotNone(m, "initial_values handler not found")
+        self.assertIn(
+            "resolution_switching",
+            m.group(1),
+            "initial_values handler no longer seeds the resolution_switching tracker "
+            "-- page load would be misread as a falling edge",
+        )
+
+    def test_resolution_switching_assignment_reacts_to_the_edge(self):
+        for event in ("parameter_change", "resolution_change"):
+            with self.subTest(event=event):
+                m = re.search(
+                    rf"socket\.on\('{event}', \(data\) => \{{(.*?)\n    \}}\);",
+                    self.template_src,
+                    re.S,
+                )
+                self.assertIsNotNone(m, f"{event} handler not found")
+                body = m.group(1)
+                switching_idx = body.find(
+                    "V.resolution_switching = data.resolution_switching;"
+                )
+                self.assertNotEqual(
+                    switching_idx, -1, f"{event} no longer assigns V.resolution_switching"
+                )
+                after = body[switching_idx:]
+                self.assertRegex(
+                    after,
+                    r"reloadStreams\(\)|noteResolutionSwitching\(\)",
+                    f"{event} no longer reacts to the resolution_switching edge",
+                )
+
+    def test_falling_edge_helper_uses_truthy_and_reloads_streams(self):
+        m = re.search(
+            r"function noteResolutionSwitching\(\) \{(.*?)\n    \}",
+            self.template_src,
+            re.S,
+        )
+        self.assertIsNotNone(m, "noteResolutionSwitching() not found")
+        body = m.group(1)
+        self.assertIn("truthy(", body, "falling-edge check no longer uses truthy()")
+        self.assertIn(
+            "reloadStreams()", body, "falling edge no longer calls reloadStreams()"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/web-gui.md
+++ b/docs/web-gui.md
@@ -21,6 +21,8 @@ Socket.IO only pushes live values back to the page; it carries no control events
 The browser UI exposes:
 
 - ISO, shutter angle, FPS, white balance, and resolution selectors
+- the page reloads automatically once a resolution change completes, unless a recording is in
+  progress
 - live preview from the MJPEG stream
 - tap/click on the preview area to toggle REC
 - CineMate Log toggle (`set log`) and storage unmount button (`unmount`)

--- a/src/module/app/__init__.py
+++ b/src/module/app/__init__.py
@@ -2,6 +2,7 @@ from flask import Flask
 from module.redis_controller import ParameterKey
 from flask_socketio import SocketIO
 import logging
+import threading
 
 def create_app(redis_controller, cinepi_controller, simple_gui, sensor_detect,
                 command_executor, settings):
@@ -34,12 +35,34 @@ def create_app(redis_controller, cinepi_controller, simple_gui, sensor_detect,
         cinepi_controller.add_resolution_change_callback(emit_resolution_change)
 
     if hasattr(cinepi_controller, 'add_resolution_switch_complete_callback'):
+        reload_browser_timer = None
+
         def emit_reload_stream():
             # Fires when the switch actually *completes* -- either evidence
             # from cinepi-raw's own "Raw stream: WxH" log line, or (if that
             # never arrives) the switching-hold fallback timer. Either way
             # the new stream exists by the time this runs (F-290).
             socketio.emit('reload_stream')
+
+            nonlocal reload_browser_timer
+            if redis_controller.get_value(ParameterKey.IS_RECORDING.value) == "1":
+                # Dynamic-resolution substitution mid-take is same-aspect, no
+                # restart -- reload_stream alone covers it, and a full page
+                # reload would kick the operator out of fullscreen mid-take.
+                return
+            if reload_browser_timer is not None:
+                # A reload is already pending for this switch -- one page
+                # reload per switch, same as reload_stream isn't re-emitted.
+                return
+
+            def fire_reload_browser():
+                nonlocal reload_browser_timer
+                reload_browser_timer = None
+                socketio.emit('reload_browser')
+
+            reload_browser_timer = threading.Timer(2.0, fire_reload_browser)
+            reload_browser_timer.daemon = True
+            reload_browser_timer.start()
 
         cinepi_controller.add_resolution_switch_complete_callback(emit_reload_stream)
 

--- a/src/module/app/templates/template.html
+++ b/src/module/app/templates/template.html
@@ -891,6 +891,20 @@
     // ── push: server → browser only (module/app/main/events.py) ────────
     const socket = io();
 
+    // Second, independent path to stream recovery, alongside `reload_stream`
+    // (D1): a frozen MJPEG <img> fires neither `error` nor a naturalWidth
+    // drop, so if the single reload_stream emit is missed (backgrounded tab,
+    // socket hiccup during the restart), catching resolution_switching's
+    // truthy->falsy edge here -- fed by the Redis fan-out, not the emit --
+    // gives recovery a second chance. Seeded from initial_values so page
+    // load itself is never mistaken for a falling edge.
+    let prevResolutionSwitching = false;
+    function noteResolutionSwitching() {
+        const now = truthy(V.resolution_switching);
+        if (prevResolutionSwitching && !now) { reloadStreams(); }
+        prevResolutionSwitching = now;
+    }
+
     socket.on('initial_values', (data) => {
         V = Object.assign({}, data);
         steps.iso = data.iso_steps || [];
@@ -898,6 +912,7 @@
         steps.fps = data.fps_steps || [];
         steps.wb = data.wb_steps || [];
         steps.resolutions = data.sensor_resolutions || [];
+        prevResolutionSwitching = truthy(V.resolution_switching);
         render();
     });
 
@@ -919,6 +934,7 @@
         }
         if (data.resolution_switching !== undefined) {
             V.resolution_switching = data.resolution_switching;
+            noteResolutionSwitching();
         }
         render();
     });
@@ -937,6 +953,7 @@
         if (data.sensor_mode !== undefined) { V.selected_resolution_mode = data.sensor_mode; }
         if (data.resolution_switching !== undefined) {
             V.resolution_switching = data.resolution_switching;
+            noteResolutionSwitching();
         }
         render();
     });

--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -1675,6 +1675,14 @@ class CinePiController:
     def _schedule_resolution_switch_complete(self, value, resolution_info):
         self._cancel_resolution_switching_timer()
 
+        if not as_bool(self.redis_controller.get_value(ParameterKey.RESOLUTION_SWITCHING.value)):
+            # restart_process=True runs self.cinepi.restart() synchronously
+            # before this is called, so handle_cinepi_raw_message can already
+            # have seen "Raw stream: WxH" and cleared switching. Scheduling
+            # here anyway would fire a second, redundant switch-complete
+            # GUI_RESOLUTION_SWITCHING_HOLD_SECONDS later.
+            return
+
         def complete():
             try:
                 self._publish_resolution_target_state(


### PR DESCRIPTION
## Symptom

After a resolution change (from the web GUI dropdown or any other input path), the browser had to be refreshed manually before the preview and page state were correct again. Requirement: the web GUI refreshes automatically on resolution change, the way white-balance changes already do.

## The three defects

**D1 — frozen-MJPEG blind spot (client).** When cinepi-raw restarts (aspect-ratio / bit-depth / HDR change), the MJPEG connection dies; browsers keep the last decoded frame, fire no `error`, and `naturalWidth` stays > 0 — so neither the error handler nor the 4 s watchdog can see the freeze. Recovery depended entirely on the single `reload_stream` emit and its single 350 ms reload attempt.

**D2 — double-fire on the restart path (server).** `restart()` is synchronous inside `_apply_resolution_mode`, so the `Raw stream: WxH` evidence usually arrives *during* the restart and fires switch-complete before `_schedule_resolution_switch_complete` has been called; the fallback timer was then scheduled anyway and inevitably fired a second switch-complete 2.5 s later.

**D3 — no automatic page refresh.** Resolution changes only reloaded the stream `<img>`; the WB path already does a deferred `reload_browser`.

## Changes

- `src/module/app/__init__.py` — the switch-complete callback keeps the immediate `reload_stream` and now also schedules a deferred 2.0 s `reload_browser` emit (same `threading.Timer` shape as the WB path), debounced to one pending timer per switch and skipped while recording, so a mid-take dynamic-resolution substitution (same-aspect, no restart) can't kick the operator out of fullscreen.
- `src/module/cinepi_controller.py` — `_schedule_resolution_switch_complete` returns without scheduling when `RESOLUTION_SWITCHING` is already cleared (the evidence path completed the switch during the synchronous restart). No-restart path unchanged.
- `src/module/app/templates/template.html` — stream recovery gets a second, independent path: the client tracks the `resolution_switching` truthy→falsy edge (fed by the Redis fan-out, not the `reload_stream` emit) and calls `reloadStreams()` on it. Seeded from `initial_values` so page load is never misread as an edge.
- `docs/web-gui.md` — one behaviour line.
- `_test/test_web_gui_resolution_auto_refresh.py` — new stdlib-only wiring test (b97 shape) covering all three fixes; verified to fail against the unfixed sources. One existing fallback-timer test now publishes `RESOLUTION_SWITCHING=1` first, as `_apply_resolution_mode` always does, matching its sibling tests.

## Testing

`_test/` full suite with Python 3.12: **555 passed, 313 subtests passed**. Not yet verified on the Pi — the browser-facing behaviour (auto page reload after a `set resolution` from any input path, stream recovery after an aspect-ratio restart) needs a hardware pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)