### PR TITLE
fix(settings-editor): grey out disabled dropdowns

### DIFF
--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -388,6 +388,7 @@
     padding: 7px 9px; min-width: 84px;
   }
   .field-input:focus-visible, select.field-input:focus-visible{ outline:none; box-shadow: var(--focus); }
+  .field-input:disabled, select.field-input:disabled{ opacity:.5; cursor:default; }
   select.field-input{ min-width: 140px; }
   input[type="text"].wide, input[type="password"].wide{ min-width: 220px; }
   .num-input{ width: 84px; text-align: right; font-family: ui-monospace, monospace; font-variant-numeric: tabular-nums; }
@@ -760,7 +761,7 @@
   .capacity-track{ height:8px; border-radius:999px; background: var(--panel-2); border:1px solid var(--line); overflow:hidden; }
   .capacity-fill{ height:100%; background: var(--accent); border-radius:999px 0 0 999px; }
   .storage-format{ display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
-  .storage-format .btn:disabled, .storage-format select:disabled{ opacity:.5; cursor:default; }
+  .storage-format .btn:disabled{ opacity:.5; cursor:default; }
 
   .clip-toolbar{
     display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap;


### PR DESCRIPTION
## Summary
- The link-frequency dropdowns (Camera 0/1) on the config.txt boot-config page never visually greyed out while the RP1 Overclock toggle was off, even though `sel.disabled` was already being set correctly by `cfgSyncLinkFreqCards()`.
- Root cause: `.card.is-disabled .card-main{opacity:.45}` only dims the label/help text; the `<select>` lives in the sibling `.card-control` and had no `:disabled` style anywhere in the template, so it rendered at full white/black contrast regardless of state.
- Added a general `.field-input:disabled, select.field-input:disabled{opacity:.5;cursor:default}` rule (matches the existing convention already used for the storage-format buttons), and removed the now-redundant `.storage-format select:disabled` special case it subsumes.

## Test plan
- [x] Verified with a static desk harness (`settings_editor_harness.py`-style stub, mocked `link_frequency_menus` for imx585, `rp1_overclock: false`) that the Camera 0/1 link-frequency selects render greyed (opacity 0.5) while RP1 Overclock is off.
- [x] Verified toggling `#cfg-rp1` live re-enables (full contrast) and re-disables (greyed) both selects immediately, in both directions.
- [ ] Pi-unverified (desk/browser only — no runtime behavior changed, CSS-only diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)