### PR TITLE
fix(settings-editor): re-sync config.txt toggles when returning to the config tab

### DIFF
--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -4574,6 +4574,16 @@
   var pageTabButtons = document.querySelectorAll('[data-page-tab]');
   var pageLedes = document.querySelectorAll('[data-page-lede]');
   function setActivePage(page){
+    /* loadConfigTxt() only ever ran once, at page load (see the bottom of
+       this script). config.txt can change underneath an open tab without
+       any of this page's own doing -- an SSH edit, a save from a different
+       browser tab, cinemate-recovery's confirm-or-revert timeout -- and the
+       form kept showing whatever it fetched at load, including a toggle
+       (e.g. RP1 overclock) that no longer matches the file on disk. Refetch
+       on every arrival at the config page instead, skipped only when there
+       are unsaved edits already in progress (configDirty) so this can't
+       silently discard those. */
+    if (page === 'config' && activePage !== 'config' && !configDirty) loadConfigTxt();
     activePage = page;
     pageTabButtons.forEach(function(b){
       var isActive = b.getAttribute('data-page-tab') === page;


### PR DESCRIPTION
## What was broken

The settings editor's config.txt form fetched `/api/config-txt` exactly
once, at page load (`loadConfigTxt()` called once at the bottom of the
script). Any later change to the actual file — an SSH edit, a save from a
different browser tab, `cinemate-recovery`'s confirm-or-revert timeout —
left every toggle on the page showing whatever was true at load time, with
no indication it had gone stale. Surfaced while chasing an RP1-overclock
confusion: the settings pane showed the toggle "active" while the file on
disk had it commented out (the file had changed since the tab was opened).

## The fix

`setActivePage()` now re-fetches `/api/config-txt` whenever the user
navigates into the config tab from a different one, so switching back to
it always reflects what's actually on disk. Skipped when there are unsaved
edits in progress (`configDirty`) so an in-flight edit can't be silently
discarded by a background refresh.

## No behaviour change

- First arrival at the config tab still calls `loadConfigTxt()` exactly
  once (the pre-existing page-load call), so nothing changes for the
  common case of loading the page and editing without switching away.
- Re-fetching only ever *reads*; it never writes or reboots anything.

## Verification

Not unit-testable in this repo's Python suite (pure browser JS, no test
harness for it here). Verified manually with a standalone Flask harness
(`settings_editor_bp` mounted alone, `config.txt` pointed at a scratch
file): loaded the page with RP1 overclock uncommented (toggle on), edited
the file on disk to comment it out without reloading the page, switched to
the settings tab and back — toggle correctly flipped to off. Confirmed the
same steps reproduce the stale "on" state against the unfixed template.

Full `_test` suite (582 tests) unaffected, no regressions.

**Pi-unverified in the real app** (verified against a standalone harness
only, not the live cinemate stack) — operator should confirm the same
behaviour in the real settings pane: open Settings → config.txt, SSH in and
toggle a line by hand, switch tabs away and back in the browser without
reloading, confirm the toggle updates.