### PR TITLE
fix(clearhdr): stop seeding the degenerate 0/0 data-selection threshold pair

### DIFF
--- a/_test/test_clearhdr_threshold_defaults.py
+++ b/_test/test_clearhdr_threshold_defaults.py
@@ -1,0 +1,96 @@
+"""ClearHDR data-selection thresholds must not be seeded to a degenerate pair.
+
+The imx585 driver boots the pair at EXP_TH_H 0x0FFF / EXP_TH_L 0x0000 and
+carries a comment explaining why: with the two thresholds equal, the sensor
+falls back to the AppNote's weighted blend and the ClearHDR combiner output
+stays clamped near the black level, so every HDR frame comes out flat.
+
+CineMate used to seed 0/0 into Redis on every boot, writing exactly that
+rejected configuration over the driver's default. These tests pin the two
+halves of the fix: the shipped settings no longer configure a degenerate
+pair, and an unconfigured threshold seeds "" (write nothing) rather than 0.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from module.config_loader import clearhdr_startup_values  # noqa: E402
+from module.config_loader import _strip_jsonc_comments, _strip_trailing_commas  # noqa: E402
+
+
+def _shipped_hdr_settings():
+    text = (REPO_ROOT / "settings.jsonc").read_text(encoding="utf-8")
+    settings = json.loads(_strip_trailing_commas(_strip_jsonc_comments(text)))
+    return settings["image_capture"]["hdr"]
+
+
+def test_shipped_settings_do_not_configure_a_degenerate_threshold_pair():
+    hdr = _shipped_hdr_settings()
+    low, high = hdr.get("threshold_low"), hdr.get("threshold_high")
+
+    if low is None or high is None:
+        # "leave the driver's pair alone" -- only valid if neither is set,
+        # because cinepi-raw writes 0 for whichever side is empty.
+        assert low is None and high is None
+    else:
+        assert low != high
+
+
+def test_unconfigured_thresholds_seed_empty_not_zero():
+    values = clearhdr_startup_values({"image_capture": {"hdr": {}}})
+
+    assert values["hdr_threshold_low"] == ""
+    assert values["hdr_threshold_high"] == ""
+
+
+def test_explicit_null_seeds_empty_not_zero():
+    settings = {
+        "image_capture": {"hdr": {"threshold_low": None, "threshold_high": None}}
+    }
+
+    values = clearhdr_startup_values(settings)
+
+    assert values["hdr_threshold_low"] == ""
+    assert values["hdr_threshold_high"] == ""
+
+
+def test_configured_thresholds_are_passed_through():
+    settings = {
+        "image_capture": {"hdr": {"threshold_low": 0, "threshold_high": 4095}}
+    }
+
+    values = clearhdr_startup_values(settings)
+
+    assert values["hdr_threshold_low"] == 0
+    assert values["hdr_threshold_high"] == 4095
+
+
+def test_blend_and_gain_adder_keep_their_defaults():
+    values = clearhdr_startup_values({})
+
+    assert values["hdr_blend"] == 0
+    assert values["hdr_gain_adder"] == 1
+
+
+@pytest.mark.parametrize("hdr_cfg", [None, [], "nonsense", 7])
+def test_malformed_hdr_block_does_not_raise(hdr_cfg):
+    values = clearhdr_startup_values({"image_capture": {"hdr": hdr_cfg}})
+
+    assert values["hdr_threshold_low"] == ""
+    assert values["hdr_gain_adder"] == 1
+
+
+def test_shipped_settings_validate_against_the_schema():
+    jsonschema = pytest.importorskip("jsonschema")
+
+    text = (REPO_ROOT / "settings.jsonc").read_text(encoding="utf-8")
+    settings = json.loads(_strip_trailing_commas(_strip_jsonc_comments(text)))
+    schema = json.loads((REPO_ROOT / "settings.schema.json").read_text(encoding="utf-8"))
+
+    jsonschema.validate(settings, schema)

--- a/settings.jsonc
+++ b/settings.jsonc
@@ -190,11 +190,18 @@
       // Startup values for the ClearHDR live knobs (0-4095 / 0-8 / 0-5).
       // Applied when a ClearHDR mode is selected; adjust live afterwards
       // with `set hdr threshold low/high`, `set hdr blend`, `set hdr gain
-      // adder`, or a pot/quad-rotary channel. 16-bit linear, HG 1/2 + LG
-      // 1/2 blend, +6 dB gain adder (menu 1) -- a lower noise floor than
-      // the driver's +12 dB default.
-      "threshold_low": 0,
-      "threshold_high": 0,
+      // adder`, or a pot/quad-rotary channel. HG 1/2 + LG 1/2 blend, +6 dB
+      // gain adder (menu 1) -- a lower noise floor than the driver's +12 dB
+      // default.
+      //
+      // null on the two thresholds means "leave the sensor driver's own
+      // pair alone" (EXP_TH_H 0x0FFF, EXP_TH_L 0x0000). Do not set both to
+      // the same value: equal thresholds select the AppNote's weighted-blend
+      // fallback, where the ClearHDR combiner output stays clamped near the
+      // black level and every HDR frame comes out flat. Set both, or
+      // neither.
+      "threshold_low": null,
+      "threshold_high": null,
       "blend": 0,
       "gain_adder": 1
     },

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -293,16 +293,16 @@
               "default": true
             },
             "threshold_low": {
-              "type": "integer",
+              "type": ["integer", "null"],
               "minimum": 0,
               "maximum": 4095,
-              "default": 0
+              "default": null
             },
             "threshold_high": {
-              "type": "integer",
+              "type": ["integer", "null"],
               "minimum": 0,
               "maximum": 4095,
-              "default": 0
+              "default": null
             },
             "blend": {
               "type": "integer",

--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,7 @@ import glob
 from module.config_loader import (
     SettingsLoadError,
     auto_storage_preroll_enabled,
+    clearhdr_startup_values,
     load_settings,
     DEFAULT_SETTINGS_PATH,
 )
@@ -734,11 +735,10 @@ def run_application(args, log_queue):
     # re-applies these from Redis once a ClearHDR mode is actually selected;
     # seeding them here just means the first `set hdr threshold/blend/gain
     # adder` read (pot, quad, CLI) already sees the configured default.
-    _hdr_cfg = settings.get("image_capture", {}).get("hdr", {})
-    redis_controller.set_value(ParameterKey.HDR_THRESHOLD_LOW.value, _hdr_cfg.get("threshold_low", 0))
-    redis_controller.set_value(ParameterKey.HDR_THRESHOLD_HIGH.value, _hdr_cfg.get("threshold_high", 0))
-    redis_controller.set_value(ParameterKey.HDR_BLEND.value, _hdr_cfg.get("blend", 0))
-    redis_controller.set_value(ParameterKey.HDR_GAIN_ADDER.value, _hdr_cfg.get("gain_adder", 1))
+    # An unconfigured threshold seeds "" -- write nothing, keep the driver's
+    # own pair. See clearhdr_startup_values() for why 0/0 was not harmless.
+    for _hdr_key, _hdr_value in clearhdr_startup_values(settings).items():
+        redis_controller.set_value(_hdr_key, _hdr_value)
 
     # Reset recording time
     redis_controller.set_value(ParameterKey.RECORDING_TIME.value, 0)

--- a/src/module/config_loader.py
+++ b/src/module/config_loader.py
@@ -233,6 +233,47 @@ def storage_preroll_enabled(settings: dict) -> bool:
     return auto_storage_preroll_enabled(settings)
 
 
+def clearhdr_startup_values(settings: dict) -> dict:
+    """Startup values for the ClearHDR live knobs, keyed by Redis key.
+
+    The two data-selection thresholds only come back as numbers when
+    ``image_capture.hdr`` actually configures them. Left unset they come back
+    as ``""``, which means "write nothing" rather than "write zero":
+    cinepi-raw skips the sensor write entirely while both are empty, so the
+    imx585 driver keeps the pair it boots with (EXP_TH_H 0x0FFF,
+    EXP_TH_L 0x0000).
+
+    That distinction is the point of this helper. EXP_TH_H == EXP_TH_L selects
+    the AppNote's weighted-blend fallback, which leaves the ClearHDR combiner
+    clamped near the black level on ordinary scenes; the driver carries a
+    comment saying exactly that, and defaults to the rule-based range instead.
+    Seeding 0/0 wrote that rejected configuration over the driver's own
+    default on every boot.
+
+    The empty string is written rather than skipped so a 0 persisted into
+    Redis by an earlier build is cleared on upgrade instead of surviving it.
+
+    ``blend`` and ``gain_adder`` keep their previous defaults: 0 is the
+    driver's own blend value, and 1 (+6 dB) is a deliberate choice over the
+    driver's +12 dB.
+    """
+
+    hdr_cfg = settings.get("image_capture", {}).get("hdr", {})
+    if not isinstance(hdr_cfg, dict):
+        hdr_cfg = {}
+
+    def threshold(name):
+        value = hdr_cfg.get(name)
+        return "" if value is None else value
+
+    return {
+        "hdr_threshold_low": threshold("threshold_low"),
+        "hdr_threshold_high": threshold("threshold_high"),
+        "hdr_blend": hdr_cfg.get("blend", 0),
+        "hdr_gain_adder": hdr_cfg.get("gain_adder", 1),
+    }
+
+
 def _apply_settings_defaults(settings: dict) -> dict:
     # ── system: splash, network, storage behavior ──────────────────────────
     system_cfg = settings.setdefault("system", {})


### PR DESCRIPTION
ClearHDR shipped with `hdr_threshold_low: 0` and `hdr_threshold_high: 0` in
`settings.jsonc`, and `main.py` seeded both into Redis on every boot.
cinepi-raw applies that pair to the sensor as `IMX585_CID_HDR_DATASEL_TH`
whenever a ClearHDR mode is selected.

Equal thresholds are the one configuration the imx585 driver deliberately
avoids.

## Evidence

The driver's default is `hdr_thresh_def[2] = { 0x0FFF, 0x0000 }` and the
comment above it says why (`imx585.c`, `innomaker-v1.0`):

> The AppNote's "initial value" of `EXP_TH_H = EXP_TH_L = 0x1000` documents a
> fallback to the `EXP_BK` weighted blend, but empirically that path leaves
> the combiner output clamped near BLC for typical scenes (verified at LED
> 5500K @ 80% on this rig: HDR-16 DNG max stays at ~4200 with
> `TH_H=TH_L=0x1000`, vs ~36000 with `TH_H=0xFFF / TH_L=0`). Use the
> rule-based selection range instead so HG drives the bulk of the output and
> LG only takes over once HG saturates.

So the shipped defaults overwrote a deliberately chosen, rig-validated value
with the configuration the driver author had rejected — on every startup,
with nothing logged.

This is consistent with two prior observations:

- **Round 4 (2026-08-27, hardware-confirmed):** ClearHDR modes silently
  produced a constant BLC-pedestal fill with no warning anywhere;
  re-issuing `set hdr threshold low/high` restored real data instantly with
  no reboot.
- **2026-08-29, live read of the dev rig:** `hdr_threshold_low = 0`,
  `hdr_threshold_high = 0` in Redis while the 12-bit ClearHDR preview was
  visibly wrong — flat and washed out (mean 196/255, range 178–226) with the
  sensor's exposure register at 10 lines, an exposure at which the frame
  should be nearly black.

## What changed

- Both thresholds now default to `null` — "leave the driver's pair alone".
- Seeding moved into `config_loader.clearhdr_startup_values()`, which returns
  `""` for an unset threshold. cinepi-raw skips the sensor write entirely
  while both keys are empty, so the driver's own pair survives.
- `""` is written rather than skipped so a `0` persisted into Redis by an
  earlier build is cleared on upgrade instead of surviving it.
- `blend` and `gain_adder` are untouched: `0` is the driver's own blend
  value, and `1` (+6 dB) is a deliberate choice over the driver's +12 dB.
- Schema accepts `integer | null` for both thresholds.

## Verification

Desk only — `python -m pytest _test/ -q -p no:randomly` → **613 passed**,
`ruff check src/` → clean. New `_test/test_clearhdr_threshold_defaults.py`
pins both halves: the shipped settings never configure a degenerate pair, and
an unconfigured threshold seeds `""` rather than `0`.

**Not verified on hardware.** The Pi checks that should gate the merge:

1. Boot with this change; confirm `redis-cli GET hdr_threshold_low` and
   `hdr_threshold_high` are both empty, and that the journal shows no
   "ClearHDR data-selection threshold restored to …" line.
2. Read the sensor back: `v4l2-ctl -d /dev/v4l-subdev2
   --get-ctrl=hdr_data_selection_threshold` (control name "HDR Data Selection
   Threshold") should report the driver default, 4095/0.
3. In 12-bit CCMP ClearHDR, with a fixed shutter, record a take and confirm
   the frames are no longer a constant pedestal fill and respond to a ~3-stop
   shutter change (settled frames only — frame ≥ 20, per the known
   post-mode-switch exposure latency).
4. Upgrade path: on a rig whose Redis already holds `0`, confirm the keys
   come back empty after one boot rather than staying `0`.

## Two things this PR deliberately does not claim

- **It is not proven to be the whole cause of the washed-out 12-bit ClearHDR
  preview.** With the decompand table applied to code 491, the preview math
  yields Y ≈ 35; the rig was showing ≈ 196 at a shorter exposure. Something
  in the preview render path may be wrong as well. That is a separate
  investigation and a separate fix.
- **The key-to-register mapping is left alone.** cinepi-raw builds the pair
  as `{ hdr_threshold_low, hdr_threshold_high }` while the driver reads
  `th[0] → EXP_TH_H` and `th[1] → EXP_TH_L`, so CineMate's "low" drives the
  *high* register. Under that wiring the driver's constraint
  (`EXP_TH_H ≥ EXP_TH_L`) reads as `low ≥ high`, and round 4's successful
  recovery values (`low 2048`, `high 3584`) would have been the
  spec-prohibited ordering — which contradicts the recovery having worked.
  Something there does not add up, and swapping the pair on a hunch would
  risk breaking a path that currently works. Resolving it needs a read-back
  on hardware; it is the first item in the round-6 handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
