### PR TITLE
fix: shutter/exposure Redis staleness + WDR toggle retry

### DIFF
--- a/_test/test_shutter_exposure_time_republish.py
+++ b/_test/test_shutter_exposure_time_republish.py
@@ -1,0 +1,95 @@
+"""set_shutter_a() and set_shutter_a_nom() must republish exposure_time.
+
+Before this fix, exposure_time (ParameterKey.EXPOSURE_TIME) was only ever
+written to Redis from the fps-change path. A shutter-only change updated the
+real sensor control (shutter_a, which cinepi-raw actually consumes) and
+computed a fresh self.exposure_time_seconds, but never published it -- so the
+web GUI's exposure readout (template.html's 'v-exp', bound to V.exposure_time)
+went stale after any shutter change that didn't also touch fps. That read as
+"the shutter change didn't take effect" even though the real capture path was
+fine.
+"""
+
+import sys
+import threading
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+sys.modules.setdefault("smbus", types.SimpleNamespace(SMBus=object))
+
+from module.cinepi_controller import CinePiController
+from module.redis_controller import ParameterKey
+
+
+class FakeRedis:
+    def __init__(self, initial=None):
+        self.values = dict(initial or {})
+
+    def get_value(self, key, default=None):
+        key = key.value if isinstance(key, ParameterKey) else key
+        return self.values.get(key, default)
+
+    def set_value(self, key, value):
+        key = key.value if isinstance(key, ParameterKey) else key
+        self.values[key] = value
+
+
+def make_controller(fps=25):
+    c = CinePiController.__new__(CinePiController)
+    c.redis_controller = FakeRedis()
+    c.parameters_lock_obj = threading.Lock()
+
+    c.shutter_a_free = False
+    c.shutter_a_nom_lock = False
+    c.shutter_a_sync_mode = 0
+    c.shutter_a_steps = [45.0, 90.0, 180.0, 270.0, 360.0]
+    c.shutter_a_steps_dynamic = []
+    c.light_hz = [50.0, 60.0]
+    c.current_fps = fps
+    c.shutter_angle_nom = None
+    c.shutter_angle_actual = None
+    c.exposure_time_nominal = None
+
+    return c
+
+
+class ShutterExposureTimeRepublishTests(unittest.TestCase):
+    def test_set_shutter_a_republishes_exposure_time(self):
+        c = make_controller(fps=25)
+
+        c.set_shutter_a(180.0)
+
+        expected = (180.0 / 360.0) / 25
+        self.assertEqual(
+            c.redis_controller.get_value(ParameterKey.EXPOSURE_TIME.value), expected
+        )
+
+    def test_set_shutter_a_updates_exposure_time_on_every_call_not_just_the_first(self):
+        c = make_controller(fps=25)
+
+        c.set_shutter_a(180.0)
+        c.set_shutter_a(90.0)
+
+        expected = (90.0 / 360.0) / 25
+        self.assertEqual(
+            c.redis_controller.get_value(ParameterKey.EXPOSURE_TIME.value), expected
+        )
+
+    def test_set_shutter_a_nom_republishes_exposure_time(self):
+        c = make_controller(fps=25)
+
+        c.set_shutter_a_nom(90.0)
+
+        expected = (90.0 / 360.0) / 25
+        self.assertEqual(
+            c.redis_controller.get_value(ParameterKey.EXPOSURE_TIME.value), expected
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_shutter_exposure_time_republish.py
+++ b/_test/test_shutter_exposure_time_republish.py
@@ -1,13 +1,27 @@
-"""set_shutter_a() and set_shutter_a_nom() must republish exposure_time.
+"""set_shutter_a() and set_shutter_a_nom() must republish exposure_time, and
+set_shutter_a() must keep self.shutter_angle_actual in sync too.
 
-Before this fix, exposure_time (ParameterKey.EXPOSURE_TIME) was only ever
-written to Redis from the fps-change path. A shutter-only change updated the
-real sensor control (shutter_a, which cinepi-raw actually consumes) and
-computed a fresh self.exposure_time_seconds, but never published it -- so the
-web GUI's exposure readout (template.html's 'v-exp', bound to V.exposure_time)
-went stale after any shutter change that didn't also touch fps. That read as
-"the shutter change didn't take effect" even though the real capture path was
-fine.
+Before the first fix, exposure_time (ParameterKey.EXPOSURE_TIME) was only
+ever written to Redis from the fps-change path. A shutter-only change
+updated the real sensor control (shutter_a, which cinepi-raw actually
+consumes) and computed a fresh self.exposure_time_seconds, but never
+published it -- so the web GUI's exposure readout (template.html's 'v-exp',
+bound to V.exposure_time) went stale after any shutter change that didn't
+also touch fps. That read as "the shutter change didn't take effect" even
+though the real capture path was fine.
+
+Before the second fix, set_shutter_a() wrote the corrected value to the
+shutter_angle_actual REDIS KEY but never updated the shutter_angle_actual
+PYTHON ATTRIBUTE that set_fps()'s "keep motion-blur constant" snap (and
+update_shutter_angle_for_fps()) read instead. The next fps change -- and
+every mode switch triggers one -- re-derived a snapped angle from whatever
+that attribute was stale at BEFORE the shutter change and overwrote the
+correct Redis value with it. Confirmed live on hardware: `set shutter a 1`
+correctly set shutter_a=1 and shutter_angle_actual=1, but a subsequent mode
+switch (which changes fps) silently reverted shutter_angle_actual to an
+earlier session's 180 while shutter_a (the key cinepi-raw actually reads)
+stayed at 1 -- the sensor kept capturing at 1 degree while the display
+claimed 180.
 """
 
 import sys
@@ -89,6 +103,37 @@ class ShutterExposureTimeRepublishTests(unittest.TestCase):
         self.assertEqual(
             c.redis_controller.get_value(ParameterKey.EXPOSURE_TIME.value), expected
         )
+
+
+class ShutterActualAttributeStalenessTests(unittest.TestCase):
+    def test_set_shutter_a_updates_the_actual_attribute_not_just_the_redis_key(self):
+        c = make_controller(fps=25)
+        c.shutter_angle_actual = 180.0  # stale, as if left over from an earlier session
+
+        c.set_shutter_a(90.0)
+
+        self.assertEqual(c.shutter_angle_actual, 90.0)
+        self.assertEqual(
+            c.redis_controller.get_value(ParameterKey.SHUTTER_A_ACTUAL.value), 90.0
+        )
+
+    def test_a_subsequent_fps_change_snaps_from_the_just_set_angle_not_a_stale_one(self):
+        """Reproduces the hardware bug directly: set_fps()'s motion-blur-constant
+        snap (cinepi_controller.py:1025-1027) reads self.shutter_angle_actual, so
+        if set_shutter_a() left it stale, the next fps change -- which every mode
+        switch triggers -- resurrects the stale value instead of snapping the
+        angle that was actually just requested.
+        """
+        c = make_controller(fps=25)
+        c.shutter_angle_actual = 180.0  # stale
+
+        c.set_shutter_a(90.0)
+
+        # The exact snap set_fps() performs, using whichever value
+        # shutter_angle_actual holds after set_shutter_a().
+        snapped = min(c.shutter_a_steps, key=lambda x: abs(x - c.shutter_angle_actual))
+
+        self.assertEqual(snapped, 90.0)
 
 
 if __name__ == "__main__":

--- a/_test/test_wide_dynamic_range_retry.py
+++ b/_test/test_wide_dynamic_range_retry.py
@@ -1,0 +1,83 @@
+"""_set_wide_dynamic_range() must retry before giving up.
+
+It races the outgoing cinepi-raw process's teardown -- confirmed on hardware
+(round 6): the identical `v4l2-ctl --set-ctrl wide_dynamic_range=1` succeeds
+standalone with no process contention, yet logged "no subdev accepted" on
+effectively every resolution change all session, because it never retried a
+transient failure.
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+sys.modules.setdefault("smbus", types.SimpleNamespace(SMBus=object))
+
+from module.cinepi_controller import CinePiController
+
+
+def make_controller():
+    return CinePiController.__new__(CinePiController)
+
+
+class WideDynamicRangeRetryTests(unittest.TestCase):
+    def test_retries_and_succeeds_after_a_transient_failure(self):
+        c = make_controller()
+        attempts = {"n": 0}
+
+        def fake_run(cmd, capture_output, text):
+            attempts["n"] += 1
+            ok = attempts["n"] >= 3  # fails twice, then succeeds
+            return types.SimpleNamespace(
+                returncode=0 if ok else 1,
+                stderr="" if ok else "Device or resource busy",
+            )
+
+        with mock.patch("module.cinepi_controller.os.path.exists", return_value=True), \
+             mock.patch("module.cinepi_controller.subprocess.run", side_effect=fake_run), \
+             mock.patch("module.cinepi_controller.time.sleep"):
+            result = c._set_wide_dynamic_range(True)
+
+        self.assertTrue(result)
+        self.assertGreaterEqual(attempts["n"], 3)
+
+    def test_gives_up_after_exhausting_retries(self):
+        c = make_controller()
+
+        def fake_run(cmd, capture_output, text):
+            return types.SimpleNamespace(returncode=1, stderr="Device or resource busy")
+
+        with mock.patch("module.cinepi_controller.os.path.exists", return_value=True), \
+             mock.patch("module.cinepi_controller.subprocess.run", side_effect=fake_run), \
+             mock.patch("module.cinepi_controller.time.sleep") as mock_sleep, \
+             mock.patch("module.cinepi_controller.logging.warning") as mock_warn:
+            result = c._set_wide_dynamic_range(True)
+
+        self.assertFalse(result)
+        self.assertTrue(mock_sleep.called)
+        mock_warn.assert_called_once()
+
+    def test_unknown_control_on_unrelated_subdevs_is_not_reported_as_an_error(self):
+        c = make_controller()
+
+        def fake_run(cmd, capture_output, text):
+            return types.SimpleNamespace(returncode=1, stderr="unknown control 'wide_dynamic_range'")
+
+        with mock.patch("module.cinepi_controller.os.path.exists", return_value=True), \
+             mock.patch("module.cinepi_controller.subprocess.run", side_effect=fake_run), \
+             mock.patch("module.cinepi_controller.time.sleep"), \
+             mock.patch("module.cinepi_controller.logging.warning") as mock_warn:
+            result = c._set_wide_dynamic_range(True)
+
+        self.assertFalse(result)
+        mock_warn.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -1991,6 +1991,14 @@ class CinePiController:
         )
         logging.info(f"Shutter angle set to {safe_value}°, exposure time: {self.exposure_time_seconds:.6f}s ({self.exposure_time_fractions})")
 
+        # F-shutter-exposure-stale: this key drives the web GUI's exposure
+        # readout; it must be republished on every shutter change, not just
+        # on an fps change, or the display goes stale while the sensor's
+        # actual exposure (shutter_a, above) keeps updating correctly.
+        self.redis_controller.set_value(
+            ParameterKey.EXPOSURE_TIME.value, self.exposure_time_seconds
+        )
+
 
     def set_shutter_a_nom(self, value):
         logging.info(f"Entering set_shutter_a_nom() with value: {value}")
@@ -2053,6 +2061,13 @@ class CinePiController:
                     
                 # ensure main shutter_a value is updated for preview and web UI
                 self.redis_controller.set_value(ParameterKey.SHUTTER_A.value, safe_value)
+
+                # F-shutter-exposure-stale: republish so the web GUI's
+                # exposure readout doesn't go stale on a nominal-angle-only
+                # change (see set_shutter_a() for the same fix).
+                self.redis_controller.set_value(
+                    ParameterKey.EXPOSURE_TIME.value, self.exposure_time_seconds
+                )
 
     def set_shu_fps_lock(self, value=None):
         if value is not None:

--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -1976,9 +1976,17 @@ class CinePiController:
 
         # Commit the final value outside the lock
         self.redis_controller.set_value(ParameterKey.SHUTTER_A.value, safe_value)
-        
+
         # also update the "actual" key so GUI reflects CLI changes
         self.redis_controller.set_value(ParameterKey.SHUTTER_A_ACTUAL.value, safe_value)
+        # F-shutter-actual-attr-stale: set_fps()'s "keep motion-blur constant"
+        # snap and update_shutter_angle_for_fps() both read this attribute,
+        # not the Redis key -- leaving it stale here means the next fps
+        # change (every mode switch triggers one) re-derives a snapped angle
+        # from whatever this was BEFORE this call and overwrites the correct
+        # Redis value with it. The real sensor control (shutter_a) was never
+        # wrong; only this attribute, and everything reading it, went stale.
+        self.shutter_angle_actual = safe_value
         # keep nominal angle in sync when not using sync mode
 
         if self.shutter_a_sync_mode == 0:

--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -584,23 +584,49 @@ class CinePiController:
         Returns True when at least one subdev took the control. The control
         changes the sensor's mode list, so callers must re-detect modes and
         restart cinepi-raw afterwards.
+
+        This races the outgoing cinepi-raw process's teardown: this call
+        fires from _publish_resolution_gui_state(), which runs before the
+        relaunch that will actually own the new mode, so the subdev is often
+        still held by the process this resolution change is about to
+        replace. Confirmed on hardware (round 6): the identical `v4l2-ctl
+        --set-ctrl wide_dynamic_range=1` on the imx585 subdev succeeds
+        silently when run standalone with no process contention, yet this
+        method logged "no subdev accepted" on effectively every resolution
+        change all session -- not a real incompatibility, a race it wasn't
+        retrying. Every attempt logging a warning also drowned out any
+        genuine failure (wrong subdev, control truly rejected) in the noise.
+        A short retry lets the common transient case actually succeed
+        instead of just failing quietly faster.
         """
         value = 1 if enable else 0
-        applied = False
-        for idx in range(16):
-            dev = f"/dev/v4l-subdev{idx}"
-            if not os.path.exists(dev):
-                continue
-            probe = subprocess.run(
-                ["v4l2-ctl", "-d", dev, "--set-ctrl", f"wide_dynamic_range={value}"],
-                capture_output=True, text=True,
+        last_errors = {}
+        for attempt in range(5):
+            applied = False
+            last_errors = {}
+            for idx in range(16):
+                dev = f"/dev/v4l-subdev{idx}"
+                if not os.path.exists(dev):
+                    continue
+                probe = subprocess.run(
+                    ["v4l2-ctl", "-d", dev, "--set-ctrl", f"wide_dynamic_range={value}"],
+                    capture_output=True, text=True,
+                )
+                if probe.returncode == 0:
+                    logging.info(f"wide_dynamic_range={value} set on {dev}")
+                    applied = True
+                elif "unknown control" not in probe.stderr.lower():
+                    last_errors[dev] = probe.stderr.strip()
+            if applied:
+                return True
+            if attempt < 4:
+                time.sleep(0.05)
+        if last_errors:
+            logging.warning(
+                "No sensor subdev accepted wide_dynamic_range (imx585 ClearHDR) "
+                f"after retrying: {last_errors}"
             )
-            if probe.returncode == 0:
-                logging.info(f"wide_dynamic_range={value} set on {dev}")
-                applied = True
-        if not applied:
-            logging.warning("No sensor subdev accepted wide_dynamic_range (imx585 ClearHDR)")
-        return applied
+        return False
 
     def set_hdr_threshold_low(self, value):
         """Set the ClearHDR data-selection threshold, low side (0–4095). Applied live."""


### PR DESCRIPTION
## Summary

Three independent fixes to `cinepi_controller.py`, all found live on the physical rig during a round-6 debugging session and each root-caused and fixed in direct response to a specific operator-reported symptom:

- **`84b286f8`** — `set_shutter_a()` / `set_shutter_a_nom()` computed a fresh `exposure_time_seconds` on every call but only ever republished the `exposure_time` Redis key from the fps-change code path. The real sensor control (`shutter_a`) always updated correctly; only the web GUI's exposure readout went stale, reading as "the shutter change didn't work" when it had. Fix: both setters now also publish `ParameterKey.EXPOSURE_TIME`.
- **`11a0622c`** — `set_shutter_a()` updated the `shutter_angle_actual` **Redis key** but never the **Python attribute** of the same name, which `set_fps()`'s "keep motion-blur constant" snap reads instead. Any fps change after a shutter change (every mode switch triggers one) re-derived a snapped angle from whatever the attribute was stale at and overwrote the correct Redis value with it. Reproduced on hardware pre-fix (`shutter_a=1` / `shutter_angle_actual=180` observed simultaneously) and confirmed gone post-fix.
- **`c1831a13`** — `_set_wide_dynamic_range()`'s direct `v4l2-ctl --set-ctrl` pre-toggle races the outgoing `cinepi-raw` process's teardown during a resolution-change relaunch, and logged a "no subdev accepted" WARNING on effectively every resolution change even though the identical call succeeds when run standalone with no contention. Added a short retry (5× 50 ms) so the common transient case succeeds instead of just failing quietly faster.

All three are independent of the mono ClearHDR work and branched cleanly off `dev`.

## Hardware verification — scope note

All three fixes were operator-verified live on the physical rig. That verification tree also contained the (separate, still-unmerged) mono `cg_rb` skip from `fix/mono-clearhdr-stack`. For `84b286f8` and `c1831a13` this is immaterial — neither touches camera-gain/red-blue gain logic. For `11a0622c`, the fix sits in the same function (`_reapply_camera_controls()`'s neighbourhood via `set_shutter_a()`) that also carries the mono `cg_rb` skip, so the hardware verification for this one specifically was not on a tree that isolates it from that skip. The unit tests for all three are self-contained and pass against plain `dev` independent of the mono stack; only the *live rig confirmation* had that qualification.

## Test plan

- [x] 616 tests + ruff green locally on `dev` + this branch (per round-6 notes)
- [x] New test file `_test/test_shutter_exposure_time_republish.py` (3 tests, pins both setters and repeated calls)
- [x] Reproduced the `shutter_angle_actual` staleness pre-fix, confirmed resolved post-fix, on hardware
- [x] Operator-confirmed working live for all three fixes