### PR TITLE
fix(shutter,hdr): close sync-mode nominal staleness, restore silent-failure log

### DIFF
--- a/_test/test_shutter_exposure_time_republish.py
+++ b/_test/test_shutter_exposure_time_republish.py
@@ -118,22 +118,66 @@ class ShutterActualAttributeStalenessTests(unittest.TestCase):
         )
 
     def test_a_subsequent_fps_change_snaps_from_the_just_set_angle_not_a_stale_one(self):
-        """Reproduces the hardware bug directly: set_fps()'s motion-blur-constant
-        snap (cinepi_controller.py:1025-1027) reads self.shutter_angle_actual, so
-        if set_shutter_a() left it stale, the next fps change -- which every mode
-        switch triggers -- resurrects the stale value instead of snapping the
-        angle that was actually just requested.
+        """Reproduces the hardware bug directly by calling the real
+        set_fps(), not by re-implementing its snap inline. The previous
+        version of this test never called set_fps() at all -- it recomputed
+        the snap by hand against the static c.shutter_a_steps, so it passed
+        regardless of whether set_fps() itself (which actually reads
+        self.shutter_a_steps_dynamic, not shutter_a_steps) was correct.
         """
         c = make_controller(fps=25)
-        c.shutter_angle_actual = 180.0  # stale
+        c.settings = {
+            "arrays": {
+                "shutter_a": {"steps": [1, 45.0, 90.0, 180.0, 270.0, 360.0]},
+                "fps": {"steps": [1, 25, 50]},
+            }
+        }
+        c.fps_lock = False
+        c.lock_override = False
+        c.fps_free = False
+        c.dynamic_resolution_enabled = False
+        c.dynamic_resolution_active = False
+        c.dynamic_resolution_desired_mode = None
+        c.user_fps = 25
+        c.fps_max = 50
+        c.redis_controller.set_value(ParameterKey.FPS_MAX.value, "50")
+        c.shutter_angle_actual = 180.0  # stale, as if left over from an earlier session
 
         c.set_shutter_a(90.0)
+        c.set_fps(25)
 
-        # The exact snap set_fps() performs, using whichever value
-        # shutter_angle_actual holds after set_shutter_a().
-        snapped = min(c.shutter_a_steps, key=lambda x: abs(x - c.shutter_angle_actual))
+        self.assertEqual(c.shutter_angle_actual, 90.0)
 
-        self.assertEqual(snapped, 90.0)
+    def test_sync_mode_set_shutter_a_survives_a_subsequent_fps_change(self):
+        """Mirror of the test above for shutter_a_sync_mode == 1. set_fps()'s
+        sync branch (cinepi_controller.py ~line 1056) derives
+        shutter_angle_actual from self.exposure_time_nominal, not from
+        whatever set_shutter_a() just accepted -- so leaving that attribute
+        stale resurrects the pre-existing nominal angle (often the 180 degree
+        startup default) on the very next fps change, which every mode switch
+        triggers. Confirmed on hardware: `set shutter a 1` correctly set
+        shutter_a=1, but the following mode switch (which changes fps)
+        silently reverted shutter_angle_actual to 180 while shutter_a (the
+        key cinepi-raw actually reads) stayed at 1.
+        """
+        c = make_controller(fps=25)
+        c.fps_lock = False
+        c.lock_override = False
+        c.fps_free = False
+        c.dynamic_resolution_enabled = False
+        c.dynamic_resolution_active = False
+        c.dynamic_resolution_desired_mode = None
+        c.user_fps = 25
+        c.redis_controller.set_value(ParameterKey.FPS_MAX.value, "50")
+        c.shutter_a_sync_mode = 1
+        c.shutter_angle_nom = 180.0
+        c.shutter_angle_actual = 180.0
+        c.exposure_time_nominal = (180.0 / 360.0) / 25  # stale startup default
+
+        c.set_shutter_a(1.0)
+        c.set_fps(25)  # e.g. triggered by a mode switch
+
+        self.assertEqual(c.shutter_angle_actual, 1.0)
 
 
 if __name__ == "__main__":

--- a/_test/test_wide_dynamic_range_retry.py
+++ b/_test/test_wide_dynamic_range_retry.py
@@ -31,21 +31,30 @@ class WideDynamicRangeRetryTests(unittest.TestCase):
         c = make_controller()
         attempts = {"n": 0}
 
-        def fake_run(cmd, capture_output, text):
-            attempts["n"] += 1
-            ok = attempts["n"] >= 3  # fails twice, then succeeds
-            return types.SimpleNamespace(
-                returncode=0 if ok else 1,
-                stderr="" if ok else "Device or resource busy",
-            )
+        # Exactly one subdev exists, so each OUTER retry attempt makes exactly
+        # one subprocess.run call. Before the fix, attempts["n"] could also be
+        # driven past 3 by the inner 16-subdev loop alone (with every subdev
+        # reporting "exists"), letting this test pass without the outer retry
+        # loop ever running more than once.
+        with mock.patch(
+            "module.cinepi_controller.os.path.exists",
+            side_effect=lambda p: p == "/dev/v4l-subdev0",
+        ):
 
-        with mock.patch("module.cinepi_controller.os.path.exists", return_value=True), \
-             mock.patch("module.cinepi_controller.subprocess.run", side_effect=fake_run), \
-             mock.patch("module.cinepi_controller.time.sleep"):
-            result = c._set_wide_dynamic_range(True)
+            def fake_run(cmd, capture_output, text):
+                attempts["n"] += 1
+                ok = attempts["n"] >= 3  # fails twice, then succeeds
+                return types.SimpleNamespace(
+                    returncode=0 if ok else 1,
+                    stderr="" if ok else "Device or resource busy",
+                )
+
+            with mock.patch("module.cinepi_controller.subprocess.run", side_effect=fake_run), \
+                 mock.patch("module.cinepi_controller.time.sleep"):
+                result = c._set_wide_dynamic_range(True)
 
         self.assertTrue(result)
-        self.assertGreaterEqual(attempts["n"], 3)
+        self.assertEqual(attempts["n"], 3)
 
     def test_gives_up_after_exhausting_retries(self):
         c = make_controller()
@@ -63,7 +72,13 @@ class WideDynamicRangeRetryTests(unittest.TestCase):
         self.assertTrue(mock_sleep.called)
         mock_warn.assert_called_once()
 
-    def test_unknown_control_on_unrelated_subdevs_is_not_reported_as_an_error(self):
+    def test_all_subdevs_reporting_unknown_control_is_reported_not_silent(self):
+        """No imx585 driver bound at all -- every subdev says "unknown
+        control" -- is the one unambiguously genuine failure. last_errors is
+        reset at the top of every attempt and only ever collects non-"unknown
+        control" errors, so this case must not fall through silently: the
+        pre-retry code logged it, and this must too.
+        """
         c = make_controller()
 
         def fake_run(cmd, capture_output, text):
@@ -76,7 +91,7 @@ class WideDynamicRangeRetryTests(unittest.TestCase):
             result = c._set_wide_dynamic_range(True)
 
         self.assertFalse(result)
-        mock_warn.assert_not_called()
+        mock_warn.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -601,6 +601,7 @@ class CinePiController:
         """
         value = 1 if enable else 0
         last_errors = {}
+        saw_any_subdev = False
         for attempt in range(5):
             applied = False
             last_errors = {}
@@ -608,6 +609,7 @@ class CinePiController:
                 dev = f"/dev/v4l-subdev{idx}"
                 if not os.path.exists(dev):
                     continue
+                saw_any_subdev = True
                 probe = subprocess.run(
                     ["v4l2-ctl", "-d", dev, "--set-ctrl", f"wide_dynamic_range={value}"],
                     capture_output=True, text=True,
@@ -625,6 +627,16 @@ class CinePiController:
             logging.warning(
                 "No sensor subdev accepted wide_dynamic_range (imx585 ClearHDR) "
                 f"after retrying: {last_errors}"
+            )
+        elif saw_any_subdev:
+            # F-wdr-retry-silent-no-driver: every subdev rejected the control
+            # with "unknown control" -- the one unambiguously genuine failure
+            # (no imx585 driver bound at all) -- and last_errors is reset per
+            # attempt, so this case used to fall through and return False
+            # having logged nothing. The old pre-retry code logged it.
+            logging.warning(
+                "No sensor subdev accepted wide_dynamic_range (imx585 ClearHDR): "
+                "no subdev reported the control at all (imx585 driver not bound?)"
             )
         return False
 
@@ -2013,11 +2025,22 @@ class CinePiController:
         # Redis value with it. The real sensor control (shutter_a) was never
         # wrong; only this attribute, and everything reading it, went stale.
         self.shutter_angle_actual = safe_value
-        # keep nominal angle in sync when not using sync mode
 
         if self.shutter_a_sync_mode == 0:
+            # keep nominal angle in sync when not using sync mode
             self.shutter_angle_nom = safe_value
-        
+            self.redis_controller.set_value(ParameterKey.SHUTTER_A_NOM.value, safe_value)
+        else:
+            # F-shutter-sync-nominal-stale: mirror of the actual-attribute fix
+            # above. In sync mode, set_fps() derives shutter_angle_actual from
+            # exposure_time_nominal (cinepi_controller.py ~line 1056), not from
+            # whatever this call just accepted. Leaving it stale here means the
+            # next fps change -- every mode switch triggers one -- resurrects
+            # the exposure_time_nominal from BEFORE this call (often still the
+            # 180 degree startup default) even though the sensor is now at
+            # safe_value degrees: sensor at 1 degree, GUI snapping back to 180.
+            self.exposure_time_nominal = (safe_value / 360.0) / self.current_fps
+
         self.exposure_time_seconds = (safe_value / 360.0) / self.current_fps
 
         self.exposure_time_fractions = self.seconds_to_fraction_text(


### PR DESCRIPTION
## Summary
Follow-up to PR #171 (already merged to `dev`). A review of that PR's three commits found four problems; none is a regression against what came before, so this wasn't urgent, but it shouldn't sit unrecorded. This PR closes three of the four and rewrites the two tests that didn't discriminate. It does **not** touch the WDR retry's own polling/lock-contention design (see round-8 write-up) -- round 8's hardware investigation confirmed the retry is unrelated to the open ClearHDR pedestal-fill defect (100% reproduction rate identical with the retry disabled), so removing/redesigning it is left as a separate decision.

- **`set_shutter_a()` sync-mode nominal staleness (high).** `11a0622c` fixed the `shutter_angle_actual` attribute resurrection for `shutter_a_sync_mode == 0` only. In sync mode, the identical resurrection runs through `exposure_time_nominal`, which `set_shutter_a()` never updated: with sync mode on (a default GPIO switch action, `settings_default.jsonc:170`), `set shutter a 1` at 25 fps left `exposure_time_nominal` at its stale value, and the next mode switch's `set_fps()` sync branch recomputed `shutter_angle_actual` from that stale nominal -- sensor at 1°, GUI snapping back to whatever angle the stale nominal implied. Fixed by updating `exposure_time_nominal` in the sync-mode branch, mirroring the non-sync fix.
- **`SHUTTER_A_NOM` Redis key never written (medium).** `set_shutter_a()` wrote `self.shutter_angle_nom` (the Python attribute) but never the `SHUTTER_A_NOM` Redis key, so `update_fps()` read the correct attribute while `get_setting` resolved through Redis and read the stale value. Same bug class as the attribute-staleness fix, four lines below it.
- **WDR retry observability regression (high).** `last_errors` is reset at the top of every attempt in `_set_wide_dynamic_range()`, and only accumulates non-"unknown control" errors -- so when *every* subdev reports "unknown control" (no imx585 driver bound at all, the one unambiguously genuine failure), the function returned `False` having logged nothing. Restored a warning for that case.
- **Two vacuous tests rewritten, not just patched.** `test_retries_and_succeeds_after_a_transient_failure` passed against the unfixed (no outer-retry) code because its fail-twice counter was being consumed by the *inner* 16-subdev loop (with every subdev mocked as present) rather than the outer retry loop -- fixed by mocking exactly one subdev as present, so the counter is genuinely driven by outer attempts. `test_a_subsequent_fps_change_snaps_from_the_just_set_angle_not_a_stale_one` never called `set_fps()` -- it re-implemented the snap inline against the static `shutter_a_steps` rather than the dynamic list `set_fps()` actually reads -- fixed by calling the real `set_fps()` (plus a new sync-mode counterpart test for the fix above). Verified both fail against the pre-fix source.
- **Not yet fixed / out of scope here:** grepped for further attribute/Redis twins around `set_shutter_a`/`set_fps`/`set_iso` and found none beyond the one fixed above.

## Test plan
- [x] `python3 -m pytest _test/test_shutter_exposure_time_republish.py _test/test_wide_dynamic_range_retry.py -v` -- 9 passed.
- [x] Confirmed each new/amended test fails against the pre-fix source (reverted the source fix locally, reran -- both failed with the expected assertion; restored before committing).
- [ ] Not re-verified on hardware -- desk-verified only, consistent with the round-8 write-up's framing of this PR (test-level fix, not the open hardware defect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)