### PR TITLE
feat(clearhdr): self-heal the flat-pedestal ClearHDR startup defect

### DIFF
--- a/_test/test_clearhdr_self_heal.py
+++ b/_test/test_clearhdr_self_heal.py
@@ -1,0 +1,155 @@
+"""ClearHDR self-heal (round 8, 2026-08-29): the imx585 ClearHDR combiner can
+start up latched into a flat pedestal (~4.9% of full-scale, confirmed
+identical in both 12-bit CCMP and 16-bit linear ClearHDR -- see
+development/mono-clearhdr-fixes/ROUND8-RESULTS.md) with every sensor register
+reading correct. The only confirmed recovery is a mode bounce. This is a
+mitigation, not a fix -- the underlying cause is unknown.
+
+These tests isolate CinePiManager._clearhdr_self_heal_if_stuck() and
+_preview_frame_is_degenerate() from the rest of start_all() (sensor
+discovery, subprocess launch, the "ready" wait) by calling them directly
+against a bare CinePiManager instance -- none of that machinery is
+exercised or needed for this seam.
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+sys.modules.setdefault("psutil", types.SimpleNamespace())
+
+from module.cinepi_multi import CinePiManager, _CLEARHDR_SELF_HEAL_MAX_ATTEMPTS
+from module.redis_controller import ParameterKey
+
+
+class FakeRedis:
+    def __init__(self, initial=None):
+        self.values = dict(initial or {})
+
+    def get_value(self, key, default=None):
+        key = key.value if isinstance(key, ParameterKey) else key
+        return self.values.get(key, default)
+
+    def set_value(self, key, value):
+        key = key.value if isinstance(key, ParameterKey) else key
+        self.values[key] = value
+
+
+def make_manager(hdr="1", sensor_mode=3):
+    redis_controller = FakeRedis({
+        ParameterKey.HDR.value: hdr,
+        ParameterKey.SENSOR_MODE.value: sensor_mode,
+    })
+    return CinePiManager(redis_controller, sensor_detect=None)
+
+
+class ClearHdrSelfHealGatingTests(unittest.TestCase):
+    def test_skips_entirely_when_hdr_is_not_active(self):
+        mgr = make_manager(hdr="0")
+        with mock.patch.object(mgr, "_preview_frame_is_degenerate") as probe, \
+             mock.patch("module.cinepi_multi.time.sleep") as sleep:
+            mgr._clearhdr_self_heal_if_stuck()
+        probe.assert_not_called()
+        sleep.assert_not_called()
+
+    def test_does_nothing_when_the_preview_looks_healthy(self):
+        mgr = make_manager(hdr="1")
+        with mock.patch.object(mgr, "_preview_frame_is_degenerate", return_value=False), \
+             mock.patch.object(mgr, "start_all") as start_all, \
+             mock.patch("module.cinepi_multi.time.sleep"):
+            mgr._clearhdr_self_heal_if_stuck()
+        start_all.assert_not_called()
+
+
+class ClearHdrSelfHealBounceTests(unittest.TestCase):
+    def test_a_degenerate_preview_triggers_exactly_one_bounce_away_and_back(self):
+        mgr = make_manager(hdr="1", sensor_mode=3)
+        # Fixed by the second self-heal check (attempt=1): healthy afterwards.
+        with mock.patch.object(mgr, "_preview_frame_is_degenerate", side_effect=[True, False]), \
+             mock.patch.object(mgr, "start_all") as start_all, \
+             mock.patch("module.cinepi_multi.time.sleep"):
+            mgr._clearhdr_self_heal_if_stuck()
+
+        self.assertEqual(start_all.call_count, 2)
+        # Away: bounced to a *different* mode. Back: restored to the stuck mode.
+        away_kwargs = start_all.call_args_list[0].kwargs
+        back_kwargs = start_all.call_args_list[1].kwargs
+        self.assertFalse(away_kwargs["_run_self_heal"])
+        self.assertFalse(back_kwargs["_run_self_heal"])
+        self.assertEqual(mgr.redis_controller.get_value(ParameterKey.SENSOR_MODE.value), 3)
+
+    def test_recursion_is_bounded_by_the_attempt_cap_not_by_nested_start_all_calls(self):
+        """The bug this guards against: start_all() itself calls
+        _clearhdr_self_heal_if_stuck() at its own end (see the real
+        start_all(), not the mocked one here). If the bounce calls didn't
+        pass _run_self_heal=False, each nested start_all() would restart its
+        own attempt counter at 0, and the cap on the outer explicit
+        recursion would not bound total recursion depth at all. Mocking
+        start_all() as a no-op here isolates that nested self-triggering
+        risk from this test -- it specifically checks that the *explicit*
+        recursion this method performs stops within a fixed, small number of
+        calls even when the preview never recovers.
+        """
+        mgr = make_manager(hdr="1", sensor_mode=3)
+        with mock.patch.object(mgr, "_preview_frame_is_degenerate", return_value=True), \
+             mock.patch.object(mgr, "start_all") as start_all, \
+             mock.patch("module.cinepi_multi.logging.warning") as warn, \
+             mock.patch("module.cinepi_multi.time.sleep"):
+            mgr._clearhdr_self_heal_if_stuck()
+
+        self.assertEqual(start_all.call_count, 2 * _CLEARHDR_SELF_HEAL_MAX_ATTEMPTS)
+        # One "still stuck, giving up" warning, plus one per bounce attempt.
+        self.assertEqual(warn.call_count, _CLEARHDR_SELF_HEAL_MAX_ATTEMPTS + 1)
+
+
+class PreviewFrameDegenerateTests(unittest.TestCase):
+    def _fake_jpeg_bytes(self, array):
+        from io import BytesIO
+        from PIL import Image
+        buf = BytesIO()
+        Image.fromarray(array).save(buf, format="JPEG")
+        return b"\xff\xd8" + buf.getvalue()[2:]  # keep it simple: real SOI, real payload
+
+    def test_a_flat_frame_is_reported_degenerate(self):
+        import numpy as np
+        flat = np.full((480, 640), 40, dtype=np.uint8)
+        jpeg_bytes = self._fake_jpeg_bytes(flat)
+
+        mgr = make_manager()
+        fake_response = mock.MagicMock()
+        fake_response.read.return_value = jpeg_bytes
+        fake_response.__enter__.return_value = fake_response
+        fake_response.__exit__.return_value = False
+
+        with mock.patch("urllib.request.urlopen", return_value=fake_response):
+            self.assertTrue(mgr._preview_frame_is_degenerate())
+
+    def test_a_varied_frame_is_not_reported_degenerate(self):
+        import numpy as np
+        rng = np.random.default_rng(0)
+        varied = rng.integers(0, 256, size=(480, 640), dtype=np.uint8)
+        jpeg_bytes = self._fake_jpeg_bytes(varied)
+
+        mgr = make_manager()
+        fake_response = mock.MagicMock()
+        fake_response.read.return_value = jpeg_bytes
+        fake_response.__enter__.return_value = fake_response
+        fake_response.__exit__.return_value = False
+
+        with mock.patch("urllib.request.urlopen", return_value=fake_response):
+            self.assertFalse(mgr._preview_frame_is_degenerate())
+
+    def test_a_fetch_failure_fails_open_not_degenerate(self):
+        mgr = make_manager()
+        with mock.patch("urllib.request.urlopen", side_effect=OSError("connection refused")):
+            self.assertFalse(mgr._preview_frame_is_degenerate())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/module/cinepi_multi.py
+++ b/src/module/cinepi_multi.py
@@ -35,6 +35,20 @@ def _settings() -> dict:
 
 _READY_RX   = re.compile(r"Encoder configured")      # line printed by DngEncoder
 _READY_WAIT = 2.0                                   # seconds to wait for all cams
+
+# ClearHDR self-heal: round-8 investigation (2026-08-29) found the imx585
+# ClearHDR combiner can start up latched into a flat pedestal (~4.9% of
+# full-scale, confirmed identical in both 12-bit CCMP and 16-bit linear
+# ClearHDR, ruling out a decompand/software cause) with every sensor
+# register reading correct -- the defect is not visible to anything this
+# process can configure. The only confirmed recovery is a mode bounce
+# (switch away, then back); a live light-level shock also clears it, but
+# that isn't something software can trigger. Neither recovery mechanism is
+# proven 100% reliable (one boot needed it, a second boot never got stuck
+# at all), hence the attempt cap and the loud warning if it persists.
+_CLEARHDR_SELF_HEAL_MAX_ATTEMPTS = 2
+_CLEARHDR_SELF_HEAL_SETTLE_S = 1.5   # let >=20 frames settle at any sane fps
+_CLEARHDR_SELF_HEAL_STREAM_URL = "http://127.0.0.1:8000/stream"
 # Pi-4-family (VC4/Unicam) detection lives in sensor_detect as the single
 # canonical implementation; alias it here so existing call sites keep working.
 # Per-sensor packed-vs-unpacked is data-driven from sensors.json
@@ -730,7 +744,7 @@ class CinePiManager:
         self.stop_all()
         
     # ────────────────────────── start / stop ──────────────────────────
-    def start_all(self, preview_enabled: Optional[bool] = None) -> None:
+    def start_all(self, preview_enabled: Optional[bool] = None, _run_self_heal: bool = True) -> None:
         """Discover sensors, launch one *cinepi-raw* each, wait for readiness."""
         if preview_enabled is not None:
             self.preview_enabled = bool(preview_enabled)
@@ -861,7 +875,87 @@ class CinePiManager:
 
         # record-path housekeeping that was already there
         self.redis_controller.set_value(ParameterKey.LAST_DNG_CAM0.value, "None")
-        self.redis_controller.set_value(ParameterKey.LAST_DNG_CAM1.value, "None")  
+        self.redis_controller.set_value(ParameterKey.LAST_DNG_CAM1.value, "None")
+
+        # ────────────────────────────────────────────────────────────────
+        # NEW ✱ 6. ClearHDR self-heal (see _CLEARHDR_SELF_HEAL_* above)
+        # ────────────────────────────────────────────────────────────────
+        if _run_self_heal:
+            self._clearhdr_self_heal_if_stuck()
+
+    # ───────────── ClearHDR self-heal (round-8 mitigation) ─────────────
+    def _clearhdr_self_heal_if_stuck(self, attempt: int = 0) -> None:
+        """If ClearHDR is active and the live preview looks like the known
+        flat-pedestal failure, bounce to a different sensor mode and back --
+        the only recovery confirmed this round -- then re-check. Mitigation
+        only: the underlying cause is still unknown (see hardware-log.md,
+        2026-08-29 ClearHDR pedestal entries)."""
+        if str(self.redis_controller.get_value(ParameterKey.HDR.value)) != "1":
+            return  # not ClearHDR, nothing to check
+
+        time.sleep(_CLEARHDR_SELF_HEAL_SETTLE_S)
+
+        if not self._preview_frame_is_degenerate():
+            return  # healthy
+
+        if attempt >= _CLEARHDR_SELF_HEAL_MAX_ATTEMPTS:
+            logging.warning(
+                "ClearHDR self-heal: still looks stuck (flat pedestal) after "
+                "%d mode-bounce attempt(s) -- giving up. This is a known, "
+                "not-yet-root-caused defect (round 8, 2026-08-29); a power "
+                "cycle or a manual resolution switch may clear it.",
+                attempt,
+            )
+            return
+
+        stuck_mode = int(self.redis_controller.get_value(ParameterKey.SENSOR_MODE.value) or 0)
+        # Any *different* mode has cleared it in testing so far -- 0 is
+        # always a valid fallback target since it's the SDR default.
+        kick_mode = 0 if stuck_mode != 0 else 1
+        logging.warning(
+            "ClearHDR self-heal: preview looks like the known flat-pedestal "
+            "failure -- bouncing mode %d -> %d -> %d to try to clear it "
+            "(attempt %d/%d).",
+            stuck_mode, kick_mode, stuck_mode,
+            attempt + 1, _CLEARHDR_SELF_HEAL_MAX_ATTEMPTS,
+        )
+        self.redis_controller.set_value(ParameterKey.SENSOR_MODE.value, kick_mode)
+        self.start_all(preview_enabled=self.preview_enabled, _run_self_heal=False)   # away
+        self.redis_controller.set_value(ParameterKey.SENSOR_MODE.value, stuck_mode)
+        self.start_all(preview_enabled=self.preview_enabled, _run_self_heal=False)   # back
+        self._clearhdr_self_heal_if_stuck(attempt=attempt + 1)                       # re-check, bounded by attempt
+
+    def _preview_frame_is_degenerate(self) -> bool:
+        """Grab one frame from the live MJPEG preview (the same stream the
+        web GUI's <img> tag consumes, see app/main/routes.py's stream_url)
+        and check for the signature tools/verify_take.py uses on recorded
+        DNGs: a scan row collapsed to only a handful of unique values.
+        Preview and recording are different, non-calibration-comparable
+        render paths (ccmpPreviewStage vs the ISP path), but a genuinely
+        flat sensor output stays flat through either -- this only needs to
+        detect flatness, not compare absolute levels.
+        """
+        import urllib.request
+        from io import BytesIO
+        try:
+            import numpy as np
+            from PIL import Image
+        except ImportError:
+            logging.debug("ClearHDR self-heal probe skipped: PIL/numpy unavailable")
+            return False
+
+        try:
+            with urllib.request.urlopen(_CLEARHDR_SELF_HEAL_STREAM_URL, timeout=2) as resp:
+                data = resp.read(200_000)
+            start, end = data.find(b"\xff\xd8"), data.find(b"\xff\xd9")
+            if start < 0 or end < 0:
+                return False  # couldn't isolate a frame -- don't false-positive
+            frame = np.array(Image.open(BytesIO(data[start:end + 2])).convert("L"))
+            row = frame[frame.shape[0] // 2]
+            return len(np.unique(row)) <= 5
+        except Exception:
+            logging.debug("ClearHDR self-heal preview probe failed", exc_info=True)
+            return False  # fail open -- never block startup on a probe error
 
     # ───────────────────────── teardown ────────────────────────────
     def stop_all(self) -> None:


### PR DESCRIPTION
## Summary
- Round 8 (2026-08-29) found the imx585 ClearHDR combiner can start up latched into a flat pedestal (~4.9% of full-scale, confirmed identical in both 12-bit CCMP and 16-bit linear ClearHDR — ruling out a decompand/software cause) with every sensor register reading correct. Root cause is still unknown (see `development/mono-clearhdr-fixes/ROUND8-RESULTS.md`), but a mode bounce reliably clears it when it clears at all.
- `CinePiManager.start_all()` — the single choke point both the initial cold start and every explicit resolution switch already funnel through — now probes the live MJPEG preview for the same flatness signature `tools/verify_take.py` uses on recorded DNGs, and if degenerate, automatically bounces the mode (capped at 2 attempts, loud warning if it still doesn't clear).

## NOT hardware-verified
This branch has not been tested on the rig. It's designed, coded, and unit-tested (real PIL-encoded JPEG bytes for the flatness probe, not stubbed fakes) but the `/stream` MJPEG endpoint's exact framing was inferred from `routes.py`'s `stream_url`, not confirmed against a live capture. Please verify on hardware — deliberately reproduce the pedestal fill and confirm the self-heal recovers it — before treating this as done.

## Test plan
- [x] `python3 -m pytest _test/` — 640 passed, 362 subtests
- [x] `ruff check` — clean
- [x] Demonstrated the recursion-safety fix is load-bearing: reverting `_run_self_heal=False` on the internal bounce calls makes `test_a_degenerate_preview_triggers_exactly_one_bounce_away_and_back` fail (KeyError)
- [ ] Hardware: reproduce the pedestal fill, confirm self-heal clears it
- [ ] Hardware: confirm `/stream` framing assumption against a live MJPEG capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)