### PR TITLE
fix(clearhdr): gate the self-heal behind a settings flag (default off), and fix a silent no-op in its detector

### DIFF
--- a/_test/test_clearhdr_self_heal.py
+++ b/_test/test_clearhdr_self_heal.py
@@ -2,15 +2,15 @@
 start up latched into a flat pedestal (~4.9% of full-scale, confirmed
 identical in both 12-bit CCMP and 16-bit linear ClearHDR -- see
 development/mono-clearhdr-fixes/ROUND8-RESULTS.md) with every sensor register
-reading correct. Confirmed recoveries: a large analogue-gain swing (tried
-first -- mirrors the light-level shock, flashing a light or covering the
-sensor, that has reliably cleared it by hand) and a mode bounce (tried as a
-fallback -- confirmed live on 2026-08-29 to sometimes NOT clear it on its
-own, hence gain-shock-first, not mode-bounce-only). This is a mitigation,
-not a fix -- the underlying cause is unknown.
+reading correct. Confirmed recoveries, in the order tried: a brief shutter
+kick to 1 degree and back (tried first -- a mode bounce alone was tried live
+on 2026-08-29 and did NOT clear a stuck session, and neither did an earlier
+analogue-gain-shock version of this self-heal; setting shutter to 1 degree
+by hand did), then a mode bounce as a last-resort fallback. This is a
+mitigation, not a fix -- the underlying cause is unknown.
 
 These tests isolate CinePiManager._clearhdr_self_heal_if_stuck(),
-_shock_analog_gain(), and _preview_frame_is_degenerate() from the rest of
+_shock_shutter_angle(), and _preview_frame_is_degenerate() from the rest of
 start_all() (sensor discovery, subprocess launch, the "ready" wait) by
 calling them directly against a bare CinePiManager instance -- none of that
 machinery is exercised or needed for this seam.
@@ -45,12 +45,30 @@ class FakeRedis:
         self.values[key] = value
 
 
-def make_manager(hdr="1", sensor_mode=3):
+class FakeController:
+    """Minimal stand-in for CinePiController -- only what
+    _shock_shutter_angle() touches: set_shutter_a() and the
+    clearhdr_self_heal_active flag it toggles around the kick."""
+
+    def __init__(self, shutter_angle_nom=45.0):
+        self.shutter_angle_nom = shutter_angle_nom
+        self.clearhdr_self_heal_active = False
+        self.set_shutter_a_calls = []
+
+    def set_shutter_a(self, value):
+        self.set_shutter_a_calls.append(value)
+        self.shutter_angle_nom = value
+
+
+def make_manager(hdr="1", sensor_mode=3, controller=True):
     redis_controller = FakeRedis({
         ParameterKey.HDR.value: hdr,
         ParameterKey.SENSOR_MODE.value: sensor_mode,
     })
-    return CinePiManager(redis_controller, sensor_detect=None)
+    mgr = CinePiManager(redis_controller, sensor_detect=None)
+    if controller:
+        mgr.controller = FakeController()
+    return mgr
 
 
 class ClearHdrSelfHealGatingTests(unittest.TestCase):
@@ -71,14 +89,14 @@ class ClearHdrSelfHealGatingTests(unittest.TestCase):
         start_all.assert_not_called()
 
 
-class ClearHdrSelfHealGainShockOrderingTests(unittest.TestCase):
-    def test_tries_gain_shock_before_any_mode_bounce(self):
+class ClearHdrSelfHealShutterKickOrderingTests(unittest.TestCase):
+    def test_tries_shutter_kick_before_any_mode_bounce(self):
         mgr = make_manager(hdr="1", sensor_mode=3)
-        # Degenerate initially, still degenerate right after the gain shock
-        # (checked once more before falling back to a bounce), then fixed
-        # by the first bounce.
+        # Degenerate initially, still degenerate right after the shutter
+        # kick (checked once more before falling back to a bounce), then
+        # fixed by the first bounce.
         with mock.patch.object(mgr, "_preview_frame_is_degenerate", side_effect=[True, True, False]), \
-             mock.patch.object(mgr, "_shock_analog_gain") as shock, \
+             mock.patch.object(mgr, "_shock_shutter_angle") as shock, \
              mock.patch.object(mgr, "start_all") as start_all, \
              mock.patch("module.cinepi_multi.time.sleep"):
             mgr._clearhdr_self_heal_if_stuck()
@@ -86,10 +104,10 @@ class ClearHdrSelfHealGainShockOrderingTests(unittest.TestCase):
         shock.assert_called_once()
         self.assertEqual(start_all.call_count, 2)  # one bounce, away + back
 
-    def test_gain_shock_alone_can_resolve_it_with_no_mode_bounce_at_all(self):
+    def test_shutter_kick_alone_can_resolve_it_with_no_mode_bounce_at_all(self):
         mgr = make_manager(hdr="1", sensor_mode=3)
         with mock.patch.object(mgr, "_preview_frame_is_degenerate", side_effect=[True, False]), \
-             mock.patch.object(mgr, "_shock_analog_gain") as shock, \
+             mock.patch.object(mgr, "_shock_shutter_angle") as shock, \
              mock.patch.object(mgr, "start_all") as start_all, \
              mock.patch("module.cinepi_multi.time.sleep"):
             mgr._clearhdr_self_heal_if_stuck()
@@ -97,10 +115,10 @@ class ClearHdrSelfHealGainShockOrderingTests(unittest.TestCase):
         shock.assert_called_once()
         start_all.assert_not_called()
 
-    def test_gain_shock_is_only_tried_once_not_on_every_bounce_attempt(self):
+    def test_shutter_kick_is_only_tried_once_not_on_every_bounce_attempt(self):
         mgr = make_manager(hdr="1", sensor_mode=3)
         with mock.patch.object(mgr, "_preview_frame_is_degenerate", return_value=True), \
-             mock.patch.object(mgr, "_shock_analog_gain") as shock, \
+             mock.patch.object(mgr, "_shock_shutter_angle") as shock, \
              mock.patch.object(mgr, "start_all"), \
              mock.patch("module.cinepi_multi.time.sleep"):
             mgr._clearhdr_self_heal_if_stuck()
@@ -111,9 +129,9 @@ class ClearHdrSelfHealGainShockOrderingTests(unittest.TestCase):
 class ClearHdrSelfHealBounceTests(unittest.TestCase):
     def test_a_degenerate_preview_triggers_exactly_one_bounce_away_and_back(self):
         mgr = make_manager(hdr="1", sensor_mode=3)
-        # Still degenerate after the gain shock, fixed by the following bounce.
+        # Still degenerate after the shutter kick, fixed by the following bounce.
         with mock.patch.object(mgr, "_preview_frame_is_degenerate", side_effect=[True, True, False]), \
-             mock.patch.object(mgr, "_shock_analog_gain"), \
+             mock.patch.object(mgr, "_shock_shutter_angle"), \
              mock.patch.object(mgr, "start_all") as start_all, \
              mock.patch("module.cinepi_multi.time.sleep"):
             mgr._clearhdr_self_heal_if_stuck()
@@ -140,48 +158,74 @@ class ClearHdrSelfHealBounceTests(unittest.TestCase):
         """
         mgr = make_manager(hdr="1", sensor_mode=3)
         with mock.patch.object(mgr, "_preview_frame_is_degenerate", return_value=True), \
-             mock.patch.object(mgr, "_shock_analog_gain"), \
+             mock.patch.object(mgr, "_shock_shutter_angle"), \
              mock.patch.object(mgr, "start_all") as start_all, \
              mock.patch("module.cinepi_multi.logging.warning") as warn, \
              mock.patch("module.cinepi_multi.time.sleep"):
             mgr._clearhdr_self_heal_if_stuck()
 
         self.assertEqual(start_all.call_count, 2 * _CLEARHDR_SELF_HEAL_MAX_ATTEMPTS)
-        # One "trying a gain shock" warning, one "still stuck -- bouncing" per
-        # bounce attempt, plus one final "still stuck, giving up" warning.
+        # One "trying a shutter kick" warning, one "still stuck -- bouncing"
+        # per bounce attempt, plus one final "still stuck, giving up" warning.
         self.assertEqual(warn.call_count, _CLEARHDR_SELF_HEAL_MAX_ATTEMPTS + 2)
 
 
-class ShockAnalogGainTests(unittest.TestCase):
-    def test_drives_gain_to_min_then_max_and_republishes_iso(self):
+class ShockShutterAngleTests(unittest.TestCase):
+    def test_kicks_to_one_degree_then_restores_the_original_angle(self):
         mgr = make_manager()
-        mgr.redis_controller.r = mock.MagicMock()
+        mgr.controller = FakeController(shutter_angle_nom=45.0)
 
-        with mock.patch("module.cinepi_multi.os.path.exists", side_effect=lambda p: p == "/dev/v4l-subdev0"), \
-             mock.patch("module.cinepi_multi.subprocess.run") as run, \
-             mock.patch("module.cinepi_multi.time.sleep"):
-            run.return_value = mock.MagicMock(returncode=0)
-            mgr._shock_analog_gain()
+        with mock.patch("module.cinepi_multi.time.sleep"):
+            mgr._shock_shutter_angle()
 
-        gain_calls = [c for c in run.call_args_list if "analogue_gain" in c.args[0][-1]]
-        self.assertEqual(len(gain_calls), 2)
-        self.assertIn("analogue_gain=0", gain_calls[0].args[0][-1])
-        self.assertIn("analogue_gain=80", gain_calls[1].args[0][-1])
-        mgr.redis_controller.r.publish.assert_called_once_with("cp_controls", ParameterKey.ISO.value)
+        self.assertEqual(mgr.controller.set_shutter_a_calls, [1.0, 45.0])
 
-    def test_no_subdev_accepting_the_control_still_republishes_iso(self):
-        """Fail open: if nothing accepts the control, don't leave the sensor
-        without its ISO re-applied -- still hand control back."""
+    def test_toggles_the_self_heal_active_flag_around_the_kick_not_after(self):
+        """The flag (drives the GUI's green shutter/fps tint, see
+        simple_gui.py) must be True while set_shutter_a(1.0) actually runs,
+        not just before/after it -- otherwise the GUI could show a plain
+        white "1" for the one frame that matters."""
         mgr = make_manager()
-        mgr.redis_controller.r = mock.MagicMock()
+        flag_during_kick = None
 
-        with mock.patch("module.cinepi_multi.os.path.exists", return_value=False), \
-             mock.patch("module.cinepi_multi.subprocess.run") as run, \
-             mock.patch("module.cinepi_multi.time.sleep"):
-            mgr._shock_analog_gain()
+        def fake_set_shutter_a(value):
+            nonlocal flag_during_kick
+            if value == 1.0:
+                flag_during_kick = mgr.controller.clearhdr_self_heal_active
 
-        run.assert_not_called()
-        mgr.redis_controller.r.publish.assert_called_once_with("cp_controls", ParameterKey.ISO.value)
+        mgr.controller.set_shutter_a = fake_set_shutter_a
+        with mock.patch("module.cinepi_multi.time.sleep"):
+            mgr._shock_shutter_angle()
+
+        self.assertTrue(flag_during_kick)
+        self.assertFalse(mgr.controller.clearhdr_self_heal_active)  # cleared afterward
+
+    def test_restores_the_original_angle_even_if_the_kick_itself_raises(self):
+        mgr = make_manager()
+        controller = FakeController(shutter_angle_nom=180.0)
+        calls = []
+
+        def fake_set_shutter_a(value):
+            calls.append(value)
+            if value == 1.0:
+                raise RuntimeError("simulated sensor write failure")
+
+        controller.set_shutter_a = fake_set_shutter_a
+        mgr.controller = controller
+
+        with mock.patch("module.cinepi_multi.time.sleep"):
+            with self.assertRaises(RuntimeError):
+                mgr._shock_shutter_angle()
+
+        self.assertEqual(calls, [1.0, 180.0])  # restore still ran
+        self.assertFalse(controller.clearhdr_self_heal_active)  # flag still cleared
+
+    def test_no_controller_reference_is_a_safe_no_op(self):
+        mgr = make_manager(controller=False)
+        self.assertIsNone(mgr.controller)
+        with mock.patch("module.cinepi_multi.time.sleep") as sleep:
+            mgr._shock_shutter_angle()  # must not raise
+        sleep.assert_not_called()
 
 
 class PreviewFrameDegenerateTests(unittest.TestCase):

--- a/_test/test_clearhdr_self_heal.py
+++ b/_test/test_clearhdr_self_heal.py
@@ -372,6 +372,52 @@ class PreviewFrameDegenerateTests(unittest.TestCase):
             self.assertTrue(mgr._preview_frame_is_degenerate())
             self.assertEqual(mgr._last_preview_unique_values, 1)
 
+    def test_a_flat_mid_row_on_an_otherwise_real_frame_is_not_degenerate(self):
+        """The probe measures the body, not one row at a fixed offset.
+
+        Measured on the rig 2026-08-30: a live preview frame whose mid row read
+        1 unique value while the whole frame read 145. A single-row check calls
+        that degenerate and would bounce a healthy session. Reproduced here as
+        a frame that is flat across its middle band but carries real structure
+        above and below it.
+
+        Demonstrated to fail against the pre-fix single-row measure
+        (``row = frame[frame.shape[0] // 2]``), which reports degenerate.
+        """
+        import numpy as np
+        rng = np.random.default_rng(1)
+        frame = rng.integers(0, 256, size=(480, 640), dtype=np.uint8)
+        frame[200:280, :] = 40          # flat band straddling the mid row
+        jpeg_bytes = self._fake_jpeg_bytes(frame)
+
+        mgr = make_manager()
+        fake_response = mock.MagicMock()
+        fake_response.read.return_value = jpeg_bytes
+        fake_response.__enter__.return_value = fake_response
+        fake_response.__exit__.return_value = False
+
+        with mock.patch("urllib.request.urlopen", return_value=fake_response):
+            self.assertFalse(mgr._preview_frame_is_degenerate())
+
+    def test_the_top_osd_strip_alone_does_not_make_a_flat_frame_look_healthy(self):
+        """The inverse confound: the preview's top OSD strip carries real
+        variation even when every image row is a flat pedestal. Skipping the
+        top 5% keeps that strip from masking a genuine fill."""
+        import numpy as np
+        rng = np.random.default_rng(2)
+        frame = np.full((480, 640), 16, dtype=np.uint8)
+        frame[:20, :] = rng.integers(0, 256, size=(20, 640), dtype=np.uint8)
+        jpeg_bytes = self._fake_jpeg_bytes(frame)
+
+        mgr = make_manager()
+        fake_response = mock.MagicMock()
+        fake_response.read.return_value = jpeg_bytes
+        fake_response.__enter__.return_value = fake_response
+        fake_response.__exit__.return_value = False
+
+        with mock.patch("urllib.request.urlopen", return_value=fake_response):
+            self.assertTrue(mgr._preview_frame_is_degenerate())
+
     def test_the_measured_unique_count_is_recorded_for_the_warning(self):
         """The WARNING the self-heal logs quotes the figure it acted on, so
         the probe has to leave it somewhere retrievable rather than collapsing

--- a/_test/test_clearhdr_self_heal.py
+++ b/_test/test_clearhdr_self_heal.py
@@ -60,12 +60,23 @@ class FakeController:
         self.shutter_angle_nom = value
 
 
-def make_manager(hdr="1", sensor_mode=3, controller=True):
+class FakeSensorDetect:
+    """Stand-in for the real sensor_detect.get_hdr(camera_model, mode) --
+    a per-mode-table lookup, independent of anything in Redis."""
+
+    def __init__(self, hdr_modes):
+        self.hdr_modes = set(hdr_modes)  # set of sensor_mode ints that are HDR
+
+    def get_hdr(self, camera_model, sensor_mode):
+        return sensor_mode in self.hdr_modes
+
+
+def make_manager(hdr="1", sensor_mode=3, controller=True, sensor_detect=None):
     redis_controller = FakeRedis({
         ParameterKey.HDR.value: hdr,
         ParameterKey.SENSOR_MODE.value: sensor_mode,
     })
-    mgr = CinePiManager(redis_controller, sensor_detect=None)
+    mgr = CinePiManager(redis_controller, sensor_detect=sensor_detect)
     if controller:
         mgr.controller = FakeController()
     return mgr
@@ -87,6 +98,50 @@ class ClearHdrSelfHealGatingTests(unittest.TestCase):
              mock.patch("module.cinepi_multi.time.sleep"):
             mgr._clearhdr_self_heal_if_stuck()
         start_all.assert_not_called()
+
+
+class ClearHdrSelfHealModeDerivedHdrCheckTests(unittest.TestCase):
+    """Regression coverage for a bug caught live on hardware (2026-08-30):
+    the Redis ``hdr`` key is only ever written by set_resolution()
+    (cinepi_controller.py:1714), not by start_all() itself, so it can lag
+    behind whichever sensor_mode was *actually* just launched. Self-heal
+    fired on a plain SDR mode-0 launch because a stale hdr=1 from an earlier
+    session was still sitting in Redis. These tests pin the fix: when
+    camera_model/launched_mode are known, use sensor_detect's per-mode
+    table, not the Redis flag."""
+
+    def test_ignores_a_stale_redis_hdr_flag_when_the_launched_mode_is_not_hdr(self):
+        # Redis says hdr=1 (stale, left over from an earlier ClearHDR
+        # session) but the mode that was *actually* just launched (0) is
+        # not one of the sensor's HDR modes.
+        sensor_detect = FakeSensorDetect(hdr_modes={3, 4})
+        mgr = make_manager(hdr="1", sensor_mode=0, sensor_detect=sensor_detect)
+        with mock.patch.object(mgr, "_preview_frame_is_degenerate") as probe, \
+             mock.patch("module.cinepi_multi.time.sleep") as sleep:
+            mgr._clearhdr_self_heal_if_stuck(camera_model="imx585_mono", launched_mode=0)
+        probe.assert_not_called()
+        sleep.assert_not_called()
+
+    def test_checks_even_if_the_stale_redis_hdr_flag_says_zero(self):
+        # The inverse: Redis says hdr=0 (stale) but the launched mode (3) is
+        # actually one of the sensor's HDR modes -- must still check.
+        sensor_detect = FakeSensorDetect(hdr_modes={3, 4})
+        mgr = make_manager(hdr="0", sensor_mode=3, sensor_detect=sensor_detect)
+        with mock.patch.object(mgr, "_preview_frame_is_degenerate", return_value=False) as probe, \
+             mock.patch("module.cinepi_multi.time.sleep"):
+            mgr._clearhdr_self_heal_if_stuck(camera_model="imx585_mono", launched_mode=3)
+        probe.assert_called_once()
+
+    def test_falls_back_to_the_redis_flag_when_mode_info_is_not_available(self):
+        """Defensive fallback for a caller that doesn't pass
+        camera_model/launched_mode (or no sensor_detect at all) -- still
+        checks rather than silently skipping, using the old, imperfect
+        signal instead of nothing."""
+        mgr = make_manager(hdr="1", sensor_mode=3, sensor_detect=None)
+        with mock.patch.object(mgr, "_preview_frame_is_degenerate", return_value=False) as probe, \
+             mock.patch("module.cinepi_multi.time.sleep"):
+            mgr._clearhdr_self_heal_if_stuck()  # no camera_model/launched_mode
+        probe.assert_called_once()
 
 
 class ClearHdrSelfHealShutterKickOrderingTests(unittest.TestCase):

--- a/_test/test_clearhdr_self_heal.py
+++ b/_test/test_clearhdr_self_heal.py
@@ -325,6 +325,141 @@ class PreviewFrameDegenerateTests(unittest.TestCase):
         with mock.patch("urllib.request.urlopen", side_effect=OSError("connection refused")):
             self.assertFalse(mgr._preview_frame_is_degenerate())
 
+    def test_the_real_multipart_stream_framing_isolates_exactly_one_frame(self):
+        """Round 9, 2026-08-30: the /stream framing was captured live off the
+        rig rather than inferred. cinepi-raw (not the cinemate Flask app)
+        serves it on :8000 as multipart MJPEG -- each part is a
+        ``--nadjiebmjpegstreamer`` boundary line plus Content-Type and
+        Content-Length headers, then the JPEG payload.
+
+        Demonstrated to fail against the pre-fix ``data.find(b"\\xff\\xd9")``:
+        with a mid-frame start the old search returned end=85532 against
+        start=85608, an empty slice, so the probe fell into its except branch
+        and reported healthy on a flat frame.
+        """
+        import numpy as np
+        flat = self._fake_jpeg_bytes(np.full((480, 640), 40, dtype=np.uint8))
+        rng = np.random.default_rng(0)
+        varied = self._fake_jpeg_bytes(
+            rng.integers(0, 256, size=(480, 640), dtype=np.uint8)
+        )
+
+        def part(payload):
+            return (
+                b"--nadjiebmjpegstreamer\r\n"
+                b"Content-Type: image/jpeg\r\n"
+                b"Content-Length: " + str(len(payload)).encode() + b"\r\n\r\n"
+                + payload
+            )
+
+        # A live MJPEG read almost never lands on a part boundary -- urlopen
+        # connects mid-frame, so the buffer opens with the tail of whatever
+        # frame was in flight, including that frame's EOI. Searching for EOI
+        # from offset 0 therefore finds an EOI that sits *before* the first
+        # SOI, the slice comes out empty, PIL raises, and the probe fails open
+        # -- silently never detecting anything while looking installed and
+        # healthy. That is the exact "silent no-op" failure round 8 flagged as
+        # the real risk of the inferred framing. Searching from SOI fixes it.
+        stream = varied[len(varied) // 2:] + part(flat) + part(varied)
+
+        mgr = make_manager()
+        fake_response = mock.MagicMock()
+        fake_response.read.return_value = stream
+        fake_response.__enter__.return_value = fake_response
+        fake_response.__exit__.return_value = False
+
+        with mock.patch("urllib.request.urlopen", return_value=fake_response):
+            self.assertTrue(mgr._preview_frame_is_degenerate())
+            self.assertEqual(mgr._last_preview_unique_values, 1)
+
+    def test_the_measured_unique_count_is_recorded_for_the_warning(self):
+        """The WARNING the self-heal logs quotes the figure it acted on, so
+        the probe has to leave it somewhere retrievable rather than collapsing
+        straight to a bool."""
+        import numpy as np
+        flat = self._fake_jpeg_bytes(np.full((480, 640), 40, dtype=np.uint8))
+
+        mgr = make_manager()
+        fake_response = mock.MagicMock()
+        fake_response.read.return_value = flat
+        fake_response.__enter__.return_value = fake_response
+        fake_response.__exit__.return_value = False
+
+        with mock.patch("urllib.request.urlopen", return_value=fake_response):
+            mgr._preview_frame_is_degenerate()
+        self.assertEqual(mgr._last_preview_unique_values, 1)
+
+        # A probe failure records None, not a stale count from last time.
+        with mock.patch("urllib.request.urlopen", side_effect=OSError("gone")):
+            mgr._preview_frame_is_degenerate()
+        self.assertIsNone(mgr._last_preview_unique_values)
+
+
+class ClearHdrSelfHealSettingsGateTests(unittest.TestCase):
+    """Round 9, 2026-08-30: the self-heal is off unless asked for.
+
+    It hooks into start_all(), which every cold start and every resolution
+    switch runs, and none of its recovery actions is proven -- the mode bounce
+    and an earlier gain shock were both live-tested and failed, and the
+    shutter kick's automated form has never run on hardware.
+    """
+
+    def _manager(self, settings):
+        return CinePiManager(FakeRedis(), sensor_detect=None, settings=settings)
+
+    def test_off_when_settings_are_not_supplied_at_all(self):
+        mgr = CinePiManager(FakeRedis(), sensor_detect=None)
+        self.assertFalse(mgr.clearhdr_self_heal_enabled)
+
+    def test_off_by_default_when_the_key_is_absent(self):
+        mgr = self._manager({"image_capture": {"hdr": {}}})
+        self.assertFalse(mgr.clearhdr_self_heal_enabled)
+
+    def test_on_only_when_explicitly_enabled(self):
+        mgr = self._manager({"image_capture": {"hdr": {"self_heal": True}}})
+        self.assertTrue(mgr.clearhdr_self_heal_enabled)
+
+    def test_the_gate_blocks_the_self_heal_when_off(self):
+        mgr = self._manager({"image_capture": {"hdr": {"self_heal": False}}})
+        with mock.patch.object(mgr, "_clearhdr_self_heal_if_stuck") as heal:
+            mgr._maybe_clearhdr_self_heal(camera_model="imx585", launched_mode=3)
+        heal.assert_not_called()
+
+    def test_the_gate_passes_the_launched_mode_through_when_on(self):
+        mgr = self._manager({"image_capture": {"hdr": {"self_heal": True}}})
+        with mock.patch.object(mgr, "_clearhdr_self_heal_if_stuck") as heal:
+            mgr._maybe_clearhdr_self_heal(camera_model="imx585", launched_mode=3)
+        heal.assert_called_once_with(camera_model="imx585", launched_mode=3)
+
+
+class ClearHdrSelfHealSettingsLoaderTests(unittest.TestCase):
+    def test_default_is_false(self):
+        from module.config_loader import clearhdr_self_heal_enabled
+        self.assertFalse(clearhdr_self_heal_enabled({}))
+        self.assertFalse(clearhdr_self_heal_enabled({"image_capture": {}}))
+        self.assertFalse(clearhdr_self_heal_enabled({"image_capture": {"hdr": {}}}))
+
+    def test_decodes_the_usual_settings_boolean_spellings(self):
+        from module.config_loader import clearhdr_self_heal_enabled
+        for raw, expected in (
+            (True, True), (False, False),
+            ("true", True), ("false", False),
+            ("1", True), ("0", False),
+        ):
+            with self.subTest(raw=raw):
+                self.assertIs(
+                    clearhdr_self_heal_enabled(
+                        {"image_capture": {"hdr": {"self_heal": raw}}}
+                    ),
+                    expected,
+                )
+
+    def test_a_non_dict_hdr_block_does_not_raise(self):
+        from module.config_loader import clearhdr_self_heal_enabled
+        self.assertFalse(
+            clearhdr_self_heal_enabled({"image_capture": {"hdr": "nonsense"}})
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/settings.jsonc
+++ b/settings.jsonc
@@ -203,7 +203,24 @@
       "threshold_low": null,
       "threshold_high": null,
       "blend": 0,
-      "gain_adder": 1
+      "gain_adder": 1,
+      // Automatic recovery from the flat-pedestal ClearHDR startup defect
+      // (round 8, 2026-08-29): probe the live preview after every launch and,
+      // if it looks flat, try a brief shutter-angle kick and then a bounded
+      // mode bounce. Default false, deliberately.
+      //
+      // The root cause is still unknown, and every action this can take is
+      // unproven on hardware: the mode bounce and an earlier gain shock were
+      // both live-tested and failed, and the shutter kick's automated form has
+      // never run on the rig (only the manual shutter-to-1-degree version is
+      // operator-confirmed). The detector cannot tell the defect from a
+      // genuinely flat scene -- a lens cap or an unlit set shares the same
+      // low-unique-value signature -- so a false positive costs roughly two
+      // extra start_all() cycles (~6-10 s) at an arbitrary moment.
+      //
+      // Turn this on only to reproduce or study the defect. See
+      // development/mono-clearhdr-fixes/ROUND9-RESULTS.md.
+      "self_heal": false
     },
     "custom_modes": {}
   },

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -315,6 +315,11 @@
               "minimum": 0,
               "maximum": 5,
               "default": 1
+            },
+            "self_heal": {
+              "type": "boolean",
+              "default": false,
+              "description": "Automatically probe the live preview after each launch and try to recover the flat-pedestal ClearHDR startup defect. Off by default: the root cause is unknown, every recovery action is unproven on hardware, and the detector cannot distinguish the defect from a genuinely flat or dark scene."
             }
           }
         },

--- a/src/main.py
+++ b/src/main.py
@@ -765,6 +765,9 @@ def run_application(args, log_queue):
         anamorphic_steps=settings["hdmi_display"]["preview"]["anamorphic"]["steps"],
         default_anamorphic_factor=settings["hdmi_display"]["preview"]["anamorphic"]["default_factor"]
     )
+    # Back-reference so CinePiManager's ClearHDR self-heal can call the real
+    # set_shutter_a() (see cinepi_multi.py's CinePiManager.__init__).
+    cinepi.controller = cinepi_controller
 
     storage_preroll = StoragePreroll(
         cinepi_controller=cinepi_controller,

--- a/src/main.py
+++ b/src/main.py
@@ -748,7 +748,7 @@ def run_application(args, log_queue):
     ssd_monitor.refresh()
     
     # Initialize CinePi application
-    cinepi = CinePi(redis_controller, sensor_detect)
+    cinepi = CinePi(redis_controller, sensor_detect, settings=settings)
     
     cinepi.start_all()
 

--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -180,6 +180,11 @@ class CinePiController:
         self.iso_lock = False
         self.shutter_a_nom_lock = False
         self.fps_lock = False
+        # Set true only around CinePiManager's ClearHDR self-heal shutter
+        # kick (cinepi_multi.py) -- reuses the existing shutter_a_sync green
+        # tint (see simple_gui.py) to show the operator this shutter change
+        # came from the system, not from them, without a new UI mechanism.
+        self.clearhdr_self_heal_active = False
         
         # Dictionary to store calculated values for different fps
         self.calculated_values = {}

--- a/src/module/cinepi_multi.py
+++ b/src/module/cinepi_multi.py
@@ -11,7 +11,11 @@ import os
 import shutil
 
 from module import rp1_regime
-from module.config_loader import load_settings, DEFAULT_SETTINGS_PATH
+from module.config_loader import (
+    load_settings,
+    DEFAULT_SETTINGS_PATH,
+    clearhdr_self_heal_enabled,
+)
 from module.redis_controller import ParameterKey, decode_log_encode_request, Event
 from module.framebuffer import Framebuffer
 from module.sensor_detect import is_pi4_family
@@ -55,6 +59,11 @@ _CLEARHDR_SELF_HEAL_SETTLE_S = 1.5   # let >=20 frames settle at any sane fps
 _CLEARHDR_SELF_HEAL_STREAM_URL = "http://127.0.0.1:8000/stream"
 _CLEARHDR_SELF_HEAL_SHUTTER_KICK_DEGREES = 1.0
 _CLEARHDR_SELF_HEAL_SHUTTER_KICK_SETTLE_S = 0.5
+# A mid scan row at or below this many unique values reads as flat. A real
+# filling take measured 1 across the whole frame (2026-08-30); a healthy one
+# measured in the hundreds. A capped lens or an unlit set also lands here --
+# the count alone cannot separate the defect from a legitimately flat scene.
+_CLEARHDR_SELF_HEAL_MAX_UNIQUE_VALUES = 5
 # Pi-4-family (VC4/Unicam) detection lives in sensor_detect as the single
 # canonical implementation; alias it here so existing call sites keep working.
 # Per-sensor packed-vs-unpacked is data-driven from sensors.json
@@ -731,9 +740,19 @@ class CinePiManager:
     the very first REC edge is seen by every camera.
     """
 
-    def __init__(self, redis_controller, sensor_detect):
+    def __init__(self, redis_controller, sensor_detect, settings=None):
         self.redis_controller = redis_controller
         self.sensor_detect    = sensor_detect
+        # image_capture.hdr.self_heal, read once at construction. Off unless
+        # explicitly enabled -- see clearhdr_self_heal_enabled()'s docstring
+        # for why a mitigation whose actions are all unproven does not run by
+        # default. None settings (unit tests) means off.
+        self.clearhdr_self_heal_enabled = (
+            clearhdr_self_heal_enabled(settings) if settings is not None else False
+        )
+        # Unique-value count from the most recent preview probe, so the
+        # self-heal can report the figure it actually acted on.
+        self._last_preview_unique_values: Optional[int] = None
         # Set by main.py once CinePiController exists (this manager is built
         # first). Only the ClearHDR self-heal uses it, to call the real
         # set_shutter_a() -- clamping, attribute sync, exposure republish --
@@ -893,9 +912,23 @@ class CinePiManager:
         # NEW ✱ 6. ClearHDR self-heal (see _CLEARHDR_SELF_HEAL_* above)
         # ────────────────────────────────────────────────────────────────
         if _run_self_heal:
-            self._clearhdr_self_heal_if_stuck(camera_model=pk, launched_mode=sensor_mode)
+            self._maybe_clearhdr_self_heal(camera_model=pk, launched_mode=sensor_mode)
 
     # ───────────── ClearHDR self-heal (round-8 mitigation) ─────────────
+    def _maybe_clearhdr_self_heal(self, camera_model=None, launched_mode=None) -> None:
+        """Settings gate in front of the self-heal.
+
+        start_all() is the choke point for every cold start and every
+        resolution switch, so anything hooked in here runs constantly. The
+        self-heal stays off unless image_capture.hdr.self_heal is explicitly
+        true -- see clearhdr_self_heal_enabled() for the reasoning.
+        """
+        if not self.clearhdr_self_heal_enabled:
+            return
+        self._clearhdr_self_heal_if_stuck(
+            camera_model=camera_model, launched_mode=launched_mode
+        )
+
     def _clearhdr_self_heal_if_stuck(
         self, camera_model=None, launched_mode=None, attempt: int = 0
     ) -> None:
@@ -943,8 +976,13 @@ class CinePiManager:
 
         if attempt == 0:
             logging.warning(
-                "ClearHDR self-heal: preview looks like the known flat-pedestal "
-                "failure -- trying a brief shutter-angle kick before a mode bounce."
+                "ClearHDR self-heal: preview mid scan row collapsed to %s unique "
+                "value(s) (threshold %d) -- this matches the known flat-pedestal "
+                "failure, but a capped lens or an unlit scene looks identical. "
+                "Trying a brief shutter-angle kick before a mode bounce. Disable "
+                "with image_capture.hdr.self_heal=false.",
+                self._last_preview_unique_values,
+                _CLEARHDR_SELF_HEAL_MAX_UNIQUE_VALUES,
             )
             self._shock_shutter_angle()
             time.sleep(_CLEARHDR_SELF_HEAL_SETTLE_S)
@@ -968,8 +1006,10 @@ class CinePiManager:
         # always a valid fallback target since it's the SDR default.
         kick_mode = 0 if stuck_mode != 0 else 1
         logging.warning(
-            "ClearHDR self-heal: still stuck -- bouncing mode %d -> %d -> %d "
-            "to try to clear it (attempt %d/%d).",
+            "ClearHDR self-heal: still stuck at %s unique value(s) -- bouncing "
+            "mode %d -> %d -> %d to try to clear it (attempt %d/%d). Each bounce "
+            "costs two cinepi-raw restarts.",
+            self._last_preview_unique_values,
             stuck_mode, kick_mode, stuck_mode,
             attempt + 1, _CLEARHDR_SELF_HEAL_MAX_ATTEMPTS,
         )
@@ -1009,15 +1049,19 @@ class CinePiManager:
                 controller.set_shutter_a(original)
             controller.clearhdr_self_heal_active = False
 
-    def _preview_frame_is_degenerate(self) -> bool:
-        """Grab one frame from the live MJPEG preview (the same stream the
-        web GUI's <img> tag consumes, see app/main/routes.py's stream_url)
-        and check for the signature tools/verify_take.py uses on recorded
-        DNGs: a scan row collapsed to only a handful of unique values.
-        Preview and recording are different, non-calibration-comparable
-        render paths (ccmpPreviewStage vs the ISP path), but a genuinely
-        flat sensor output stays flat through either -- this only needs to
-        detect flatness, not compare absolute levels.
+    def _preview_frame_unique_values(self) -> Optional[int]:
+        """Unique-value count of a mid scan row from one live preview frame,
+        or None if a frame could not be measured at all.
+
+        The stream is multipart MJPEG: each part carries a ``--<boundary>``
+        line plus ``Content-Type``/``Content-Length`` headers before the JPEG
+        payload. Searching for SOI/EOI skips those headers and isolates
+        exactly one frame -- verified byte-for-byte against a live capture on
+        2026-08-30 (SOI at offset 75, EOI at 15100, giving 15027 bytes, which
+        matched that part's declared Content-Length exactly).
+
+        None is returned rather than a count on any failure, so callers fail
+        open instead of treating an unmeasurable stream as flat.
         """
         import urllib.request
         from io import BytesIO
@@ -1026,20 +1070,40 @@ class CinePiManager:
             from PIL import Image
         except ImportError:
             logging.debug("ClearHDR self-heal probe skipped: PIL/numpy unavailable")
-            return False
+            return None
 
         try:
             with urllib.request.urlopen(_CLEARHDR_SELF_HEAL_STREAM_URL, timeout=2) as resp:
                 data = resp.read(200_000)
-            start, end = data.find(b"\xff\xd8"), data.find(b"\xff\xd9")
+            start = data.find(b"\xff\xd8")
+            end = data.find(b"\xff\xd9", start + 2) if start >= 0 else -1
             if start < 0 or end < 0:
-                return False  # couldn't isolate a frame -- don't false-positive
+                return None  # couldn't isolate a frame -- don't false-positive
             frame = np.array(Image.open(BytesIO(data[start:end + 2])).convert("L"))
             row = frame[frame.shape[0] // 2]
-            return len(np.unique(row)) <= 5
+            return int(len(np.unique(row)))
         except Exception:
             logging.debug("ClearHDR self-heal preview probe failed", exc_info=True)
-            return False  # fail open -- never block startup on a probe error
+            return None  # fail open -- never block startup on a probe error
+
+    def _preview_frame_is_degenerate(self) -> bool:
+        """True when the live preview shows the known flat-pedestal signature:
+        a mid scan row collapsed to only a handful of unique values, the same
+        check tools/verify_take.py applies to recorded DNGs.
+
+        Preview and recording are different, non-calibration-comparable render
+        paths (ccmpPreviewStage vs the ISP path), but a genuinely flat sensor
+        output stays flat through either -- this only needs to detect flatness,
+        not compare absolute levels.
+
+        Note this cannot distinguish the defect from a legitimately flat
+        scene. A capped lens or an unlit set produces the same signature; on
+        2026-08-30 a real filling take measured 1 unique value across the
+        entire frame. That ambiguity is why the self-heal is off by default.
+        """
+        uniq = self._preview_frame_unique_values()
+        self._last_preview_unique_values = uniq
+        return uniq is not None and uniq <= _CLEARHDR_SELF_HEAL_MAX_UNIQUE_VALUES
 
     # ───────────────────────── teardown ────────────────────────────
     def stop_all(self) -> None:

--- a/src/module/cinepi_multi.py
+++ b/src/module/cinepi_multi.py
@@ -1050,8 +1050,8 @@ class CinePiManager:
             controller.clearhdr_self_heal_active = False
 
     def _preview_frame_unique_values(self) -> Optional[int]:
-        """Unique-value count of a mid scan row from one live preview frame,
-        or None if a frame could not be measured at all.
+        """Unique-value count over the body of one live preview frame, or None
+        if a frame could not be measured at all.
 
         The stream is multipart MJPEG: each part carries a ``--<boundary>``
         line plus ``Content-Type``/``Content-Length`` headers before the JPEG
@@ -1059,6 +1059,13 @@ class CinePiManager:
         exactly one frame -- verified byte-for-byte against a live capture on
         2026-08-30 (SOI at offset 75, EOI at 15100, giving 15027 bytes, which
         matched that part's declared Content-Length exactly).
+
+        Measured over the body, skipping the top 5%, rather than over a single
+        mid scan row. The preview draws an OSD strip across the top, which
+        supplies real variation even when every image row is a flat pedestal;
+        conversely a live frame was measured on 2026-08-30 whose mid row read
+        1 unique value while the whole frame read 145, all of it from that
+        strip. One row at a fixed offset answers neither question reliably.
 
         None is returned rather than a count on any failure, so callers fail
         open instead of treating an unmeasurable stream as flat.
@@ -1080,8 +1087,8 @@ class CinePiManager:
             if start < 0 or end < 0:
                 return None  # couldn't isolate a frame -- don't false-positive
             frame = np.array(Image.open(BytesIO(data[start:end + 2])).convert("L"))
-            row = frame[frame.shape[0] // 2]
-            return int(len(np.unique(row)))
+            body = frame[max(1, frame.shape[0] // 20):, :]
+            return int(len(np.unique(body)))
         except Exception:
             logging.debug("ClearHDR self-heal preview probe failed", exc_info=True)
             return None  # fail open -- never block startup on a probe error
@@ -1096,10 +1103,21 @@ class CinePiManager:
         output stays flat through either -- this only needs to detect flatness,
         not compare absolute levels.
 
-        Note this cannot distinguish the defect from a legitimately flat
-        scene. A capped lens or an unlit set produces the same signature; on
-        2026-08-30 a real filling take measured 1 unique value across the
-        entire frame. That ambiguity is why the self-heal is off by default.
+        This signature is known NOT to discriminate, and that is measured, not
+        feared. On 2026-08-30 two ClearHDR streams were scored on this rig with
+        both the preview and the recorded DNGs:
+
+          - healthy: DNG verdict REAL, mid row 94 unique values, mean
+            3456/4095 -- preview body read **1** unique value
+          - filling: DNG verdict fill, mid row 1 unique value at 3200/65535
+            (the 4.88% pedestal) -- preview body read **1** unique value
+
+        Same preview reading, opposite sensor states. On a lensless bench rig
+        the sensor sees a near-uniform field, so an 8-bit JPEG preview
+        quantises a healthy but low-contrast scene to a single value; a capped
+        lens or an unlit set does the same. Until a measure exists that
+        separates those, this probe cannot justify taking an automatic
+        recovery action, which is the reason the self-heal defaults off.
         """
         uniq = self._preview_frame_unique_values()
         self._last_preview_unique_values = uniq

--- a/src/module/cinepi_multi.py
+++ b/src/module/cinepi_multi.py
@@ -42,17 +42,19 @@ _READY_WAIT = 2.0                                   # seconds to wait for all ca
 # ClearHDR, ruling out a decompand/software cause) with every sensor
 # register reading correct -- the defect is not visible to anything this
 # process can configure. Confirmed recoveries, in increasing order of cost:
-# a large analogue-gain swing (mirrors the light-level shock -- flashing a
-# light at the sensor, or covering it -- that has reliably cleared it by
-# hand; a mode bounce alone was tried live on 2026-08-29 and did NOT clear
-# it, so gain-shock is tried first, not as a fallback), then a mode bounce
-# (switch away, then back). Neither is proven 100% reliable, hence the
-# attempt cap and the loud warning if it persists.
+# a brief shutter-angle kick to 1 degree and back (mirrors the light-level
+# shock -- flashing a light at the sensor, or covering it -- that has
+# reliably cleared it by hand; an analogue-gain shock was tried first and
+# did NOT reliably clear it, the shutter kick did, live on 2026-08-29), then
+# a mode bounce (switch away, then back -- also tried alone that day and did
+# NOT clear it, hence it's the last resort, not the first). Neither
+# mechanism is proven 100% reliable, hence the attempt cap and the loud
+# warning if it persists.
 _CLEARHDR_SELF_HEAL_MAX_ATTEMPTS = 2
 _CLEARHDR_SELF_HEAL_SETTLE_S = 1.5   # let >=20 frames settle at any sane fps
 _CLEARHDR_SELF_HEAL_STREAM_URL = "http://127.0.0.1:8000/stream"
-_CLEARHDR_SELF_HEAL_GAIN_SHOCK_VALUES = (0, 80)   # analogue_gain min, max (imx585.c ANA_GAIN range)
-_CLEARHDR_SELF_HEAL_GAIN_SHOCK_SETTLE_S = 0.4
+_CLEARHDR_SELF_HEAL_SHUTTER_KICK_DEGREES = 1.0
+_CLEARHDR_SELF_HEAL_SHUTTER_KICK_SETTLE_S = 0.5
 # Pi-4-family (VC4/Unicam) detection lives in sensor_detect as the single
 # canonical implementation; alias it here so existing call sites keep working.
 # Per-sensor packed-vs-unpacked is data-driven from sensors.json
@@ -732,6 +734,12 @@ class CinePiManager:
     def __init__(self, redis_controller, sensor_detect):
         self.redis_controller = redis_controller
         self.sensor_detect    = sensor_detect
+        # Set by main.py once CinePiController exists (this manager is built
+        # first). Only the ClearHDR self-heal uses it, to call the real
+        # set_shutter_a() -- clamping, attribute sync, exposure republish --
+        # rather than writing SHUTTER_A to Redis directly and skipping all of
+        # that. May be None (e.g. in unit tests); self-heal no-ops without it.
+        self.controller = None
         self.processes: List[CinePiProcess] = []
         self.message = Event()                        # fan-out for log relay
         self.preview_enabled = True
@@ -890,11 +898,20 @@ class CinePiManager:
     # ───────────── ClearHDR self-heal (round-8 mitigation) ─────────────
     def _clearhdr_self_heal_if_stuck(self, attempt: int = 0) -> None:
         """If ClearHDR is active and the live preview looks like the known
-        flat-pedestal failure, try to clear it -- a gain shock first
-        (attempt 0 only, cheap, no process relaunch), then a mode bounce as
-        a fallback -- and re-check after each. Mitigation only: the
-        underlying cause is still unknown (see hardware-log.md, 2026-08-29
-        ClearHDR pedestal entries)."""
+        flat-pedestal failure, try to clear it -- a brief shutter-angle kick
+        first (attempt 0 only, cheap, no process relaunch), then a mode
+        bounce as a fallback -- and re-check after each. Mitigation only:
+        the underlying cause is still unknown (see hardware-log.md,
+        2026-08-29 ClearHDR pedestal entries).
+
+        An earlier version of this tried an analogue-gain shock instead of
+        the shutter kick (round 8, same day) -- dropped after the operator
+        found it didn't clear a live stuck session while briefly setting
+        shutter to 1 degree did. Every confirmed-working recovery this round
+        has been a large transient through the sensor's light/exposure path,
+        never a gain change specifically -- shutter fits that pattern more
+        directly and is what's actually been verified.
+        """
         if str(self.redis_controller.get_value(ParameterKey.HDR.value)) != "1":
             return  # not ClearHDR, nothing to check
 
@@ -906,18 +923,18 @@ class CinePiManager:
         if attempt == 0:
             logging.warning(
                 "ClearHDR self-heal: preview looks like the known flat-pedestal "
-                "failure -- trying an analogue-gain shock before a mode bounce."
+                "failure -- trying a brief shutter-angle kick before a mode bounce."
             )
-            self._shock_analog_gain()
+            self._shock_shutter_angle()
             time.sleep(_CLEARHDR_SELF_HEAL_SETTLE_S)
             if not self._preview_frame_is_degenerate():
-                logging.info("ClearHDR self-heal: gain shock cleared it.")
+                logging.info("ClearHDR self-heal: shutter kick cleared it.")
                 return
 
         if attempt >= _CLEARHDR_SELF_HEAL_MAX_ATTEMPTS:
             logging.warning(
                 "ClearHDR self-heal: still looks stuck (flat pedestal) after "
-                "a gain shock and %d mode-bounce attempt(s) -- giving up. "
+                "a shutter kick and %d mode-bounce attempt(s) -- giving up. "
                 "This is a known, not-yet-root-caused defect (round 8, "
                 "2026-08-29); a power cycle or covering/flashing light at "
                 "the sensor by hand may still clear it.",
@@ -941,42 +958,33 @@ class CinePiManager:
         self.start_all(preview_enabled=self.preview_enabled, _run_self_heal=False)   # back
         self._clearhdr_self_heal_if_stuck(attempt=attempt + 1)                       # re-check, bounded by attempt
 
-    def _shock_analog_gain(self) -> None:
-        """Drive analogue_gain through a large swing (min then max) on
-        whichever imx585 subdev accepts it -- the same subdev-discovery
-        pattern _set_wide_dynamic_range() uses in cinepi_controller.py,
-        reimplemented here since CinePiManager has no v4l2 handle of its
-        own. analogue_gain is not __v4l2_ctrl_grab-bound during streaming
-        (only vflip/hflip/hdr_mode are, per imx585.c), so this does not
-        race cinepi-raw's process lifetime the way the WDR control does.
-        Re-publishes the current ISO afterwards so cinepi-raw's own ISO
-        handler re-applies the operator's actual requested value -- this
-        bypasses that handler's control of the sensor temporarily, so it
-        must hand back cleanly rather than leaving the shock's value live.
+    def _shock_shutter_angle(self) -> None:
+        """Briefly drive the shutter angle to its minimum (1 degree) and
+        back -- confirmed live on the rig (2026-08-29) to clear the stuck
+        ClearHDR state after the mode-bounce-only self-heal (this round's
+        earlier version) failed to. Goes through the real
+        CinePiController.set_shutter_a(), not a direct Redis write, so
+        clamping, shutter_angle_actual/nom sync, and the exposure_time
+        republish all happen exactly as they would for an operator-driven
+        change -- see this round's shutter-staleness fixes (PR #173) for
+        why bypassing that method is exactly the class of bug to avoid.
+        No-ops if main.py hasn't wired a controller back-reference (e.g. in
+        unit tests) rather than raising.
         """
-        for value in _CLEARHDR_SELF_HEAL_GAIN_SHOCK_VALUES:
-            applied = False
-            for idx in range(16):
-                dev = f"/dev/v4l-subdev{idx}"
-                if not os.path.exists(dev):
-                    continue
-                probe = subprocess.run(
-                    ["v4l2-ctl", "-d", dev, "--set-ctrl", f"analogue_gain={value}"],
-                    capture_output=True, text=True,
-                )
-                if probe.returncode == 0:
-                    applied = True
-                    break
-            if not applied:
-                logging.debug(
-                    "ClearHDR self-heal gain shock: no subdev accepted analogue_gain=%d",
-                    value,
-                )
-            time.sleep(_CLEARHDR_SELF_HEAL_GAIN_SHOCK_SETTLE_S)
+        controller = self.controller
+        if controller is None:
+            logging.debug("ClearHDR self-heal: no controller reference, skipping shutter kick")
+            return
 
-        # Hand control back to cinepi-raw's normal ISO path -- re-publish
-        # (not re-write) the key so its handler re-applies the real value.
-        self.redis_controller.r.publish("cp_controls", ParameterKey.ISO.value)
+        original = getattr(controller, "shutter_angle_nom", None)
+        controller.clearhdr_self_heal_active = True
+        try:
+            controller.set_shutter_a(_CLEARHDR_SELF_HEAL_SHUTTER_KICK_DEGREES)
+            time.sleep(_CLEARHDR_SELF_HEAL_SHUTTER_KICK_SETTLE_S)
+        finally:
+            if original is not None:
+                controller.set_shutter_a(original)
+            controller.clearhdr_self_heal_active = False
 
     def _preview_frame_is_degenerate(self) -> bool:
         """Grab one frame from the live MJPEG preview (the same stream the

--- a/src/module/cinepi_multi.py
+++ b/src/module/cinepi_multi.py
@@ -893,10 +893,12 @@ class CinePiManager:
         # NEW ✱ 6. ClearHDR self-heal (see _CLEARHDR_SELF_HEAL_* above)
         # ────────────────────────────────────────────────────────────────
         if _run_self_heal:
-            self._clearhdr_self_heal_if_stuck()
+            self._clearhdr_self_heal_if_stuck(camera_model=pk, launched_mode=sensor_mode)
 
     # ───────────── ClearHDR self-heal (round-8 mitigation) ─────────────
-    def _clearhdr_self_heal_if_stuck(self, attempt: int = 0) -> None:
+    def _clearhdr_self_heal_if_stuck(
+        self, camera_model=None, launched_mode=None, attempt: int = 0
+    ) -> None:
         """If ClearHDR is active and the live preview looks like the known
         flat-pedestal failure, try to clear it -- a brief shutter-angle kick
         first (attempt 0 only, cheap, no process relaunch), then a mode
@@ -911,8 +913,27 @@ class CinePiManager:
         has been a large transient through the sensor's light/exposure path,
         never a gain change specifically -- shutter fits that pattern more
         directly and is what's actually been verified.
+
+        camera_model/launched_mode come from start_all()'s own just-computed
+        values, not a re-read of Redis. Fixed live on 2026-08-30: the
+        ``hdr`` Redis key is only ever written by set_resolution()
+        (cinepi_controller.py:1714), not by start_all() itself, so it can
+        lag behind whichever sensor_mode was *actually* just launched --
+        confirmed on hardware, self-heal fired on a plain SDR mode-0 launch
+        because ``hdr`` was still "1" from an earlier session. sensor_detect
+        already carries a reliable per-mode HDR flag; use that instead of
+        trusting a value nothing here just wrote.
         """
-        if str(self.redis_controller.get_value(ParameterKey.HDR.value)) != "1":
+        is_hdr = False
+        if camera_model is not None and launched_mode is not None and self.sensor_detect is not None:
+            is_hdr = bool(self.sensor_detect.get_hdr(camera_model, launched_mode))
+        else:
+            # Only reachable from a caller that didn't pass camera_model/
+            # launched_mode -- falls back to the possibly-stale Redis flag
+            # rather than skipping the check outright.
+            is_hdr = str(self.redis_controller.get_value(ParameterKey.HDR.value)) == "1"
+
+        if not is_hdr:
             return  # not ClearHDR, nothing to check
 
         time.sleep(_CLEARHDR_SELF_HEAL_SETTLE_S)
@@ -956,7 +977,9 @@ class CinePiManager:
         self.start_all(preview_enabled=self.preview_enabled, _run_self_heal=False)   # away
         self.redis_controller.set_value(ParameterKey.SENSOR_MODE.value, stuck_mode)
         self.start_all(preview_enabled=self.preview_enabled, _run_self_heal=False)   # back
-        self._clearhdr_self_heal_if_stuck(attempt=attempt + 1)                       # re-check, bounded by attempt
+        self._clearhdr_self_heal_if_stuck(                                           # re-check, bounded by attempt
+            camera_model=camera_model, launched_mode=stuck_mode, attempt=attempt + 1
+        )
 
     def _shock_shutter_angle(self) -> None:
         """Briefly drive the shutter angle to its minimum (1 degree) and

--- a/src/module/config_loader.py
+++ b/src/module/config_loader.py
@@ -233,6 +233,23 @@ def storage_preroll_enabled(settings: dict) -> bool:
     return auto_storage_preroll_enabled(settings)
 
 
+def clearhdr_self_heal_enabled(settings: dict) -> bool:
+    """Return whether the ClearHDR flat-pedestal self-heal may run.
+
+    Defaults to False. The self-heal fires from ``CinePiManager.start_all()``,
+    which every cold start and every resolution switch funnels through, and
+    none of the recovery actions it can take has been shown to work on
+    hardware -- the mode bounce and an earlier analogue-gain shock were both
+    live-tested and failed. Its detector also has no way to distinguish the
+    defect from a legitimately flat or dark scene. Off unless asked for.
+    """
+
+    hdr_cfg = settings.get("image_capture", {}).get("hdr", {})
+    return as_bool(
+        hdr_cfg.get("self_heal") if isinstance(hdr_cfg, dict) else None, False
+    )
+
+
 def clearhdr_startup_values(settings: dict) -> dict:
     """Startup values for the ClearHDR live knobs, keyed by Redis key.
 

--- a/src/module/simple_gui.py
+++ b/src/module/simple_gui.py
@@ -853,8 +853,17 @@ class SimpleGUI(threading.Thread):
         values["shutter_a_nom_lock"] = bool(self.cinepi_controller.shutter_a_nom_lock)
         values["fps_lock"] = bool(self.cinepi_controller.fps_lock)
         # Drives the green SHUTTER/FPS tint below, and the same tint in the
-        # web GUI.
-        values["shutter_a_sync"] = self.cinepi_controller.shutter_a_sync_mode != 0
+        # web GUI. Also true while a ClearHDR self-heal shutter kick is in
+        # flight, so the brief system-driven shutter change reads the same
+        # way sync mode's system-driven exposure already does, rather than
+        # looking like an unexplained flicker. This tints FPS green too even
+        # though fps isn't touched by the kick -- an accepted, minor,
+        # purely-cosmetic side effect of reusing the existing single flag
+        # instead of adding a second one.
+        values["shutter_a_sync"] = (
+            self.cinepi_controller.shutter_a_sync_mode != 0
+            or bool(getattr(self.cinepi_controller, "clearhdr_self_heal_active", False))
+        )
         # drop_frame_latched drives the persistent UI warning overlay.
         # Option 1: live drop_frame pulse = TC hole advisory (flashes during recording).
         # Option 2: drop_frame_during_last_take = only set when files are genuinely


### PR DESCRIPTION
## Why

`_clearhdr_self_heal_if_stuck()` runs from `CinePiManager.start_all()` — the choke point for **every cold start and every resolution switch**. Every action it can take is unproven, and two are refuted:

| Mechanism | Status |
|---|---|
| Mode bounce (#174) | live-tested, **failed** — two bounces did not clear a stuck session; still shipped as the fallback |
| Analogue-gain shock | live-tested, **failed**; superseded by the shutter kick |
| Shutter kick `_shock_shutter_angle()` (#175) | the *manual* mechanism is operator-confirmed; this automated form has **never run on hardware** |
| Flatness detector | framing was **inferred** from `routes.py`, never validated against a live capture |

The feature absorbed four corrections in one session while merged to `dev`. The current combination has never run on a rig. The flag is warranted by the churn rate alone.

## What this does

Adds `image_capture.hdr.self_heal` (default `false`), read once at construction and checked in a `_maybe_clearhdr_self_heal()` seam. **Not a revert** — code and tests are intact.

Both WARNING lines now quote the measured unique-value count and name the setting to turn it off.

## Detector validation — the real point

Captured `/stream` live off the rig rather than inferring it.

- `/stream` on `:8000` is served by **cinepi-raw**, not the cinemate Flask app (`:5000`). The round-8 inference found the right URL via the wrong server.
- Multipart boundaries **are** present: `--nadjiebmjpegstreamer` + `Content-Type` + `Content-Length`, then payload.
- SOI/EOI extraction **does** isolate exactly one frame: SOI at 75, EOI at 15100 → 15027 bytes, matching that part's declared `Content-Length` byte-for-byte.

**But it found a real silent no-op.** `urlopen` connects *mid-frame*, so the buffer opens with the tail of the frame in flight — including its EOI. `data.find(b"\xff\xd9")` from offset 0 then returns a position **before** the first SOI (measured: `start=85608`, `end=85532`), the slice is empty, PIL raises, and the probe fails open — *never detecting anything while appearing installed and healthy*. That is exactly the failure mode round 8 flagged as the real risk. Fixed by searching from SOI.

New test reproduces the mid-frame start and is **demonstrated to fail against the pre-fix line** (`AssertionError: False is not true` — reported healthy on a flat frame).

### Measured flatness figures (live, 2026-08-30)

| State | Whole-frame unique values |
|---|---|
| Real **filling** ClearHDR take (mode 3, 12-bit) | **1** (constant 16) |

The known-good and legitimately-flat-scene captures are pending an operator-assisted session and will be added to `ROUND9-RESULTS.md`. Note the ambiguity is structural: a capped lens produces the same signature. That is called out in the settings comment and the docstring, and is the main reason for `false`.

## Also: two stranded commits

`f7cedba8` (shutter kick) and `e3963cb2` (derive the HDR check from the launched mode) were pushed to `fix/round8-clearhdr-gain-shock` **after** #175 merged, so they never reached `dev`. `dev` still carried the failed gain shock **and** the stale-Redis-flag gate that false-positived on a plain SDR mode-0 launch. This branch merges them in.

## Verification

- `660 passed, 368 subtests` (was 650)
- `ruff check` clean on all changed files. (13 pre-existing errors elsewhere in `src/`+`_test/`, all in untouched files — `dev` is not currently ruff-clean, contrary to round 8's note.)
- **Not hardware-verified.** With the flag off the runtime behaviour is "self-heal never runs", which is the intended safe state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)