### PR TITLE
chore(settings): port colour-rig control settings; ignore .settings-backups/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,6 @@ branches/
 # Local copied camera media and benchmarks
 pi-test-takes/
 pi-test-takes-speed-bench/
+
+# Settings editor runtime backups
+.settings-backups/

--- a/settings.jsonc
+++ b/settings.jsonc
@@ -136,7 +136,7 @@
     },
     "shutter_a": {
       "steps": [1, 45, 90, 135, 172.8, 180, 225, 270, 315, 346.6, 360],
-      "free": false,
+      "free": true,
       "free_increment": 1,
       // Separate, finer granularity used only while `set shutter a sync` is
       // on -- sync mode tracks exposure time continuously across fps
@@ -253,7 +253,7 @@
     },
     "preview": {
       "default_zoom": 1.0,
-      "zoom_steps": [1.0, 2.0],
+      "zoom_steps": [1.0, 1.5, 2.0],
       // Dual-sensor HDMI preview source at startup: both | cam0 | cam1 |
       // pip_cam0 | pip_cam1. Switch live with `set preview`. No effect with
       // a single sensor.
@@ -313,7 +313,7 @@
     // dt_pin/button_pin at startup. Set it true (and wire the pins) to use it.
     "rotary_encoders": [
       {
-        "enabled": false,
+        "enabled": true,
         "clk_pin": 9,
         "dt_pin": 11,
         "button_pin": 10,


### PR DESCRIPTION
Captures the last uncommitted piece of the colour rig's verified ClearHDR configuration (2026-08-31): the operator's settings-editor changes to `settings.jsonc`, reconciled against `dev` instead of committing the editor's comment-stripped rewrite.

## What the rig actually changed

- `arrays.shutter_a.free`: `false` → `true` — the rig steps shutter angle continuously (fine shutter control, including the shutter-to-1° ClearHDR flat-pedestal release, is part of how the rig is operated).
- `hdmi_display.preview.zoom_steps`: `[1.0, 2.0]` → `[1.0, 1.5, 2.0]` — the 1.5× step is in the preview zoom cycle used on set.
- `hardware_controls.rotary_encoders[0].enabled`: `false` → `true` — the rig has the GPIO rotary (clk 9 / dt 11 / button 10) wired and in use.

Also adds `.settings-backups/` (the settings editor's runtime backup directory) to `.gitignore`.

## What was deliberately not ported

The editor rewrite also stripped all comments and `$schema`, dropped the `system.web_api` / `system.recovery` / `image_capture.hdr.self_heal` blocks (missing blocks merge to identical defaults — verified against `web_api_settings.py` and the in-file recovery contract), emitted legacy `image_capture.hdr.*_free` keys that nothing under `src/` reads, and left `hdr.blend` at `0` (superseded by the live-verified blend 5 already on dev via 1c42be3f). None of that is behaviour the rig depends on, so the upstream comment-rich file is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)