### PR TITLE
Web UI: merge round2 + portrait, reconcile the duplicate download client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,10 @@ branches/
 # Local copied camera media and benchmarks
 pi-test-takes/
 pi-test-takes-speed-bench/
+
+# Self-signed TLS material minted at runtime by module/https_settings.py.
+# A private key must never be committed, and every camera should mint its own.
+resources/certs/
+*.crt
+*.key
+*.pem

--- a/_test/test_https_and_preview_proxy.py
+++ b/_test/test_https_and_preview_proxy.py
@@ -1,0 +1,162 @@
+"""HTTPS for the web UI, and the preview proxy that keeps it usable.
+
+Serving the UI over TLS is not a free upgrade, and these tests pin the two
+things that make it survivable:
+
+1. cinepi-raw's MJPEG preview is plain HTTP on 8000/8001 and cannot speak TLS.
+   A secure page may not load an insecure subresource, so a naive switch to
+   HTTPS blacks out the live preview. main.routes serves the stream through a
+   same-origin proxy when, and ONLY when, the page was served over TLS -- a
+   plain-HTTP rig keeps talking straight to cinepi-raw and pays nothing.
+
+2. cinepi.local and the hotspot's 10.42.0.1 can never hold a publicly-trusted
+   certificate, so this is always self-signed and always shows an interstitial.
+   It is therefore opt-in, and a camera that cannot mint a certificate falls
+   back to plain HTTP rather than failing to serve at all.
+
+Verified live, beyond these unit checks: Flask serving with the minted cert
+over TLS returns the proxy path in the page; the proxy relays a real multipart
+MJPEG stream (200, boundary preserved, JPEG SOI present); with no upstream it
+returns 503 so the page's <img> error handler retries; and plain HTTP still
+emits the direct http://<host>:8000/stream URL.
+"""
+
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+sys.modules.setdefault("smbus", types.SimpleNamespace(SMBus=object))
+_APP_PKG = types.ModuleType("module.app")
+_APP_PKG.__path__ = [str(ROOT / "src" / "module" / "app")]
+sys.modules.setdefault("module.app", _APP_PKG)
+
+from flask import Flask
+
+from module.app.main.routes import main_routes
+from module.https_settings import (
+    DEFAULT_HTTPS_SETTINGS,
+    ensure_certificate,
+    https_settings,
+    ssl_context_for,
+)
+
+TEMPLATE = ROOT / "src" / "module" / "app" / "templates" / "settings_editor.html"
+
+
+def _app():
+    app = Flask(
+        __name__, template_folder=str(ROOT / "src" / "module" / "app" / "templates")
+    )
+    app.config["SIMPLE_GUI"] = types.SimpleNamespace(get_background_color=lambda: "black")
+    app.config["SETTINGS"] = {}
+    app.register_blueprint(main_routes)
+    return app
+
+
+class HttpsSettingsTests(unittest.TestCase):
+    def test_off_by_default(self):
+        self.assertFalse(DEFAULT_HTTPS_SETTINGS["enabled"])
+        self.assertFalse(https_settings({})["enabled"])
+        self.assertIsNone(ssl_context_for({}))
+
+    def test_partial_block_keeps_the_other_defaults(self):
+        cfg = https_settings({"system": {"https": {"enabled": True}}})
+        self.assertTrue(cfg["enabled"])
+        self.assertEqual(cfg["cert_file"], DEFAULT_HTTPS_SETTINGS["cert_file"])
+
+    def test_unknown_keys_are_ignored(self):
+        cfg = https_settings({"system": {"https": {"nonsense": 1}}})
+        self.assertNotIn("nonsense", cfg)
+
+
+@unittest.skipUnless(__import__("shutil").which("openssl"), "openssl not installed")
+class CertificateTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.cfg = {
+            "enabled": True,
+            "cert_file": str(self.tmp / "c.crt"),
+            "key_file": str(self.tmp / "c.key"),
+            "valid_days": 30,
+        }
+
+    def test_a_certificate_is_minted_with_the_names_a_camera_is_reached_by(self):
+        cert, key = ensure_certificate(self.cfg)
+        self.assertTrue(cert.is_file() and key.is_file())
+        text = subprocess.run(
+            ["openssl", "x509", "-in", str(cert), "-noout", "-text"],
+            capture_output=True, text=True,
+        ).stdout
+        for name in ("cinepi.local", "127.0.0.1", "10.42.0.1"):
+            self.assertIn(name, text)
+
+    def test_the_private_key_is_not_world_readable(self):
+        _, key = ensure_certificate(self.cfg)
+        self.assertEqual(key.stat().st_mode & 0o077, 0)
+
+    def test_an_existing_certificate_is_reused(self):
+        cert, _ = ensure_certificate(self.cfg)
+        stamp = cert.stat().st_mtime_ns
+        ensure_certificate(self.cfg)
+        self.assertEqual(cert.stat().st_mtime_ns, stamp)
+
+    def test_a_camera_that_cannot_mint_one_still_serves(self):
+        # Falling back to plain HTTP beats not answering on :5000 at all.
+        with mock.patch("module.https_settings.shutil.which", return_value=None):
+            self.assertIsNone(ensure_certificate(self.cfg))
+
+
+class PreviewProxyTests(unittest.TestCase):
+    def test_plain_http_talks_straight_to_cinepi_raw(self):
+        html = _app().test_client().get("/").get_data(as_text=True)
+        self.assertIn(":8000/stream", html)
+        self.assertNotIn('src="/preview/', html)
+
+    def test_https_uses_the_same_origin_proxy(self):
+        # An absolute http:// stream URL on a secure page is blocked as mixed
+        # content, and the preview goes black.
+        html = _app().test_client().get(
+            "/", base_url="https://cinepi.local:5000"
+        ).get_data(as_text=True)
+        self.assertIn('src="/preview/0/stream"', html)
+        self.assertNotIn("http://cinepi.local:8000/stream", html)
+
+    def test_the_proxy_reports_unavailable_rather_than_hanging(self):
+        # Nothing is listening on 8000 in the test environment.
+        resp = _app().test_client().get("/preview/0/stream")
+        self.assertEqual(resp.status_code, 503)
+
+    def test_only_the_two_real_cameras_are_proxied(self):
+        self.assertEqual(_app().test_client().get("/preview/7/stream").status_code, 404)
+
+
+class FolderDownloadTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = TEMPLATE.read_text(encoding="utf-8")
+
+    def test_the_button_is_hidden_until_the_api_is_known_to_exist(self):
+        # showDirectoryPicker is undefined on a plain-HTTP origin and in
+        # Safari/Firefox entirely, so the button must not be offered blindly.
+        self.assertIn('id="bulkDownloadFolder" hidden', self.html)
+        self.assertIn("typeof window.showDirectoryPicker === 'function'", self.html)
+
+    def test_takes_are_written_one_at_a_time(self):
+        # The old bulk path fired n top-level navigations 800ms apart, which
+        # cancel each other; this chains them instead.
+        self.assertIn("names.reduce(function(chain, name, i)", self.html)
+        self.assertIn("res.body.pipeTo(w)", self.html)
+
+    def test_dismissing_the_picker_is_not_reported_as_a_failure(self):
+        self.assertIn("err.name === 'AbortError'", self.html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_https_and_preview_proxy.py
+++ b/_test/test_https_and_preview_proxy.py
@@ -142,17 +142,27 @@ class FolderDownloadTests(unittest.TestCase):
     def setUpClass(cls):
         cls.html = TEMPLATE.read_text(encoding="utf-8")
 
-    def test_the_button_is_hidden_until_the_api_is_known_to_exist(self):
+    def test_folder_download_is_gated_on_a_real_capability_check(self):
         # showDirectoryPicker is undefined on a plain-HTTP origin and in
-        # Safari/Firefox entirely, so the button must not be offered blindly.
-        self.assertIn('id="bulkDownloadFolder" hidden', self.html)
-        self.assertIn("typeof window.showDirectoryPicker === 'function'", self.html)
+        # Safari/Firefox entirely, so nothing must assume it exists. There is
+        # no longer a dedicated hidden button for this (the per-row download
+        # button and the bulk button both branch on CAN_PICK_FOLDER instead,
+        # falling back to the existing <a download> path) -- see
+        # test_web_ui_combined_download_reconciliation.py for the merge that
+        # replaced round2's separate bulkDownloadFolder button with this.
+        self.assertIn(
+            "var CAN_PICK_FOLDER = !!(window.isSecureContext && window.showDirectoryPicker);",
+            self.html,
+        )
 
     def test_takes_are_written_one_at_a_time(self):
         # The old bulk path fired n top-level navigations 800ms apart, which
-        # cancel each other; this chains them instead.
+        # cancel each other; the merged client chains them through a single
+        # picked folder instead -- one take's writes (savePickedTakeIntoRow,
+        # a manual reader/writer pump with real per-file progress, not a
+        # bulk res.body.pipeTo(w)) complete before the next take starts.
         self.assertIn("names.reduce(function(chain, name, i)", self.html)
-        self.assertIn("res.body.pipeTo(w)", self.html)
+        self.assertIn("savePickedTakeIntoRow(dirRoot, name,", self.html)
 
     def test_dismissing_the_picker_is_not_reported_as_a_failure(self):
         self.assertIn("err.name === 'AbortError'", self.html)

--- a/_test/test_raw_files_delete_idempotent.py
+++ b/_test/test_raw_files_delete_idempotent.py
@@ -1,0 +1,98 @@
+"""Deleting a clip must not report failure for a delete that worked.
+
+The operator report was "deleting a clip shows error". The delete itself is
+fine -- method, URL escaping, folder-vs-file and permissions all check out.
+What was wrong is that it was not idempotent:
+
+  * nothing disabled the row while the request was in flight, and showConfirm
+    closes the modal before running its callback, so the row is instantly
+    clickable again;
+  * rmtree is thousands of unlinks, and the refresh behind it stats every file
+    on the card, so the deleted row stays on screen for a long time;
+  * a second tap hit a take that was already gone and got
+    "Delete failed: Take '...' not found" -- on a delete that had succeeded.
+
+The bulk path had it worse: `all_ok = all(...)`, so one already-gone name
+turned a whole batch into "Some deletes failed".
+
+A partial rmtree was also unrecoverable: once the *.dng files were gone the
+directory no longer satisfied _is_take_dir(), so it neither listed nor
+deleted, and sat on the card taking space.
+"""
+
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+sys.modules.setdefault("smbus", types.SimpleNamespace(SMBus=object))
+
+_APP_PKG = types.ModuleType("module.app")
+_APP_PKG.__path__ = [str(ROOT / "src" / "module" / "app")]
+sys.modules.setdefault("module.app", _APP_PKG)
+
+from module.app import raw_files
+
+
+class DeleteTakeTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.root = self.tmp / "RAW"
+        (self.root).mkdir()
+        self.take = self.root / "CINEPI_25-07-01_220547_F10_C00000_cam0"
+        self.take.mkdir()
+        (self.take / "000000.dng").write_bytes(b"x")
+        (self.take / "audio.wav").write_bytes(b"y")
+        self.patch = mock.patch.object(raw_files, "MEDIA_ROOT", self.tmp)
+        self.patch.start()
+        self.addCleanup(self.patch.stop)
+
+    def test_first_delete_succeeds(self):
+        ok, msg = raw_files.delete_take(self.take.name)
+        self.assertTrue(ok, msg)
+        self.assertFalse(self.take.exists())
+
+    def test_second_delete_is_also_a_success(self):
+        raw_files.delete_take(self.take.name)
+        ok, msg = raw_files.delete_take(self.take.name)
+        self.assertTrue(ok, msg)          # the actual bug
+        self.assertIn("already", msg.lower())
+
+    def test_a_partially_deleted_take_can_still_be_removed(self):
+        # No *.dng left: not an _is_take_dir any more, so the old resolve
+        # returned None and the orphan was undeletable.
+        (self.take / "000000.dng").unlink()
+        self.assertTrue(self.take.exists())
+        ok, msg = raw_files.delete_take(self.take.name)
+        self.assertTrue(ok, msg)
+        self.assertFalse(self.take.exists())
+
+    def test_traversal_is_still_refused(self):
+        for bad in ("../escape", "a/b", "a\\b", "..", ".", ""):
+            ok, _ = raw_files.delete_take(bad)
+            self.assertFalse(ok, f"{bad!r} should be refused")
+
+    def test_a_real_failure_is_still_a_failure_and_is_readable(self):
+        import errno
+        with mock.patch.object(
+            raw_files.shutil, "rmtree",
+            side_effect=OSError(errno.EROFS, "Read-only file system")
+        ):
+            ok, msg = raw_files.delete_take(self.take.name)
+        self.assertFalse(ok)
+        self.assertIn("read-only", msg.lower())
+        self.assertNotIn("Errno", msg)     # not a raw errno string
+
+    def test_resolve_take_still_only_matches_real_takes(self):
+        self.assertIsNotNone(raw_files.resolve_take(self.take.name))
+        (self.take / "000000.dng").unlink()
+        self.assertIsNone(raw_files.resolve_take(self.take.name))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_raw_files_download.py
+++ b/_test/test_raw_files_download.py
@@ -1,0 +1,197 @@
+"""W9: the RAW pane's download path used to build a whole take into a temp
+file on /tmp before a single byte reached the browser, with no cap on how
+many downloads could run at once against the storage volume. These tests
+cover the streaming replacement, the recording interlock, and the semaphore
+-- none of which the existing suite touched.
+"""
+
+import io
+import sys
+import tempfile
+import types
+import unittest
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+sys.modules.setdefault("smbus", types.SimpleNamespace(SMBus=object))
+
+_APP_PKG = types.ModuleType("module.app")
+_APP_PKG.__path__ = [str(ROOT / "src" / "module" / "app")]
+sys.modules.setdefault("module.app", _APP_PKG)
+
+from flask import Flask
+
+from module.app import raw_files
+from module.app.settings_editor import settings_editor_bp
+from module.redis_controller import ParameterKey
+
+
+class FakeRedis:
+    def __init__(self, values=None):
+        self.values = dict(values or {})
+
+    def get_value(self, key, default=None):
+        key = key.value if isinstance(key, ParameterKey) else key
+        return self.values.get(key, default)
+
+
+def make_app(redis_values=None):
+    app = Flask(__name__)
+    app.testing = True
+    app.config["REDIS_CONTROLLER"] = FakeRedis(redis_values)
+    app.config["SETTINGS"] = {}
+    app.register_blueprint(settings_editor_bp)
+    return app
+
+
+class RawFilesFixture(unittest.TestCase):
+    """A real on-disk take under a temp MEDIA_ROOT, so resolve_take() and
+    friends run against real Path.rglob()/stat() rather than a mock."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.media_root = Path(self._tmp.name)
+        self.raw_root = self.media_root / "RAW"
+        self.take_name = "A001_20260101_120000"
+        self.take_dir = self.raw_root / self.take_name
+        self.take_dir.mkdir(parents=True)
+        self.frame_names = ["f000001.dng", "f000002.dng"]
+        for n in self.frame_names:
+            (self.take_dir / n).write_bytes(b"fake-dng-bytes-" + n.encode())
+
+        self._patcher = mock.patch.object(raw_files, "MEDIA_ROOT", self.media_root)
+        self._patcher.start()
+        self.addCleanup(self._patcher.stop)
+        self.addCleanup(self._tmp.cleanup)
+
+    def tearDown(self):
+        # BoundedSemaphore has no reset(); tests that acquire it directly
+        # release what they took so later tests in the module see it full.
+        pass
+
+
+class NullByteTakeNameTests(RawFilesFixture):
+    def test_percent00_is_404_json_not_500(self):
+        app = make_app()
+        res = app.test_client().get("/settings-editor/api/raw/takes/%00abc/download")
+        self.assertEqual(res.status_code, 404)
+        self.assertFalse(res.get_json()["ok"])
+
+
+class StreamTakeZipRoundTripTests(RawFilesFixture):
+    def test_round_trip_is_byte_exact(self):
+        data = b"".join(raw_files.stream_take_zip(self.take_dir))
+        zf = zipfile.ZipFile(io.BytesIO(data))
+        self.assertIsNone(zf.testzip())
+        names = sorted(zf.namelist())
+        self.assertEqual(names, sorted(f"{self.take_name}/{n}" for n in self.frame_names))
+        for n in self.frame_names:
+            self.assertEqual(
+                zf.read(f"{self.take_name}/{n}"),
+                (self.take_dir / n).read_bytes(),
+            )
+
+
+class RecordingInterlockTests(RawFilesFixture):
+    def _recording_app(self):
+        return make_app(redis_values={
+            ParameterKey.IS_RECORDING.value: "1",
+            ParameterKey.LAST_DNG_CAM0.value: str(self.take_dir / self.frame_names[0]),
+        })
+
+    def test_delete_refuses_active_take_with_409(self):
+        app = self._recording_app()
+        res = app.test_client().delete(f"/settings-editor/api/raw/takes/{self.take_name}")
+        self.assertEqual(res.status_code, 409)
+        self.assertTrue(self.take_dir.is_dir())
+
+    def test_delete_allows_a_different_take(self):
+        other = self.raw_root / "A001_20260101_130000"
+        other.mkdir()
+        (other / "f000001.dng").write_bytes(b"x")
+        app = self._recording_app()
+        res = app.test_client().delete("/settings-editor/api/raw/takes/A001_20260101_130000")
+        self.assertEqual(res.status_code, 200)
+        self.assertFalse(other.is_dir())
+
+    def test_bulk_delete_is_whole_request_409_and_deletes_nothing(self):
+        other = self.raw_root / "A001_20260101_130000"
+        other.mkdir()
+        (other / "f000001.dng").write_bytes(b"x")
+        app = self._recording_app()
+        res = app.test_client().post(
+            "/settings-editor/api/raw/bulk",
+            json={"action": "delete", "names": [self.take_name, "A001_20260101_130000"]},
+        )
+        self.assertEqual(res.status_code, 409)
+        self.assertTrue(self.take_dir.is_dir())
+        self.assertTrue(other.is_dir())
+
+
+class SemaphoreTests(RawFilesFixture):
+    def test_third_concurrent_acquire_is_429_with_retry_after(self):
+        self.assertTrue(raw_files.DOWNLOAD_SEMAPHORE.acquire(blocking=False))
+        self.assertTrue(raw_files.DOWNLOAD_SEMAPHORE.acquire(blocking=False))
+        try:
+            app = make_app()
+            res = app.test_client().get(
+                f"/settings-editor/api/raw/takes/{self.take_name}/download"
+            )
+            self.assertEqual(res.status_code, 429)
+            self.assertEqual(res.headers.get("Retry-After"), "5")
+        finally:
+            raw_files.DOWNLOAD_SEMAPHORE.release()
+            raw_files.DOWNLOAD_SEMAPHORE.release()
+
+    def test_permit_releases_when_generator_closes_early(self):
+        # Simulate the route: it acquired one permit before handing the
+        # generator to the response.
+        self.assertTrue(raw_files.DOWNLOAD_SEMAPHORE.acquire(blocking=False))
+        gen = raw_files.guarded_stream(raw_files.stream_take_zip(self.take_dir))
+        next(gen)
+        gen.close()  # GeneratorExit -> guarded_stream's finally -> sem.release()
+        # If the release ran, the semaphore has its permit back.
+        self.assertTrue(raw_files.DOWNLOAD_SEMAPHORE.acquire(blocking=False))
+        raw_files.DOWNLOAD_SEMAPHORE.release()
+
+
+class PerFileRouteTests(RawFilesFixture):
+    def test_traversal_is_404(self):
+        app = make_app()
+        for bad in ("../../etc/passwd", "..%2F..%2Fetc%2Fpasswd"):
+            res = app.test_client().get(
+                f"/settings-editor/api/raw/takes/{self.take_name}/files/{bad}"
+            )
+            self.assertEqual(res.status_code, 404)
+
+    def test_good_file_is_200(self):
+        app = make_app()
+        res = app.test_client().get(
+            f"/settings-editor/api/raw/takes/{self.take_name}/files/{self.frame_names[0]}"
+        )
+        self.assertEqual(res.status_code, 200)
+
+
+class ManifestTests(RawFilesFixture):
+    def test_manifest_shape_matches_fixture(self):
+        app = make_app()
+        res = app.test_client().get(f"/settings-editor/api/raw/takes/{self.take_name}/files")
+        body = res.get_json()
+        self.assertTrue(body["ok"])
+        self.assertEqual(body["file_count"], len(self.frame_names))
+        self.assertEqual({f["name"] for f in body["files"]}, set(self.frame_names))
+        self.assertFalse(body["recording"])
+
+    def test_missing_take_manifest_is_404_json(self):
+        app = make_app()
+        res = app.test_client().get("/settings-editor/api/raw/takes/definitely-not-a-take/files")
+        self.assertEqual(res.status_code, 404)
+        self.assertFalse(res.get_json()["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_raw_files_download.py
+++ b/_test/test_raw_files_download.py
@@ -158,6 +158,68 @@ class SemaphoreTests(RawFilesFixture):
         self.assertTrue(raw_files.DOWNLOAD_SEMAPHORE.acquire(blocking=False))
         raw_files.DOWNLOAD_SEMAPHORE.release()
 
+    def test_head_does_not_leak_a_permit(self):
+        # A HEAD response's body is never iterated by Werkzeug, so
+        # guarded_stream()'s generator -- including its `finally` -- never
+        # runs: the acquire() the route makes before building the Response
+        # used to have no release path at all for this verb. Two curl -I
+        # calls alone exhausted the two-permit cap, permanently, since
+        # nothing but a restart could hand the permits back.
+        #
+        # `with c.head(...) as r:` matters here, not `c.head(...)` alone --
+        # Response.call_on_close() fires when the WSGI layer closes the
+        # response, and Flask's test client only does that within a `with`
+        # block (or an explicit r.close()); a real WSGI server does it
+        # unconditionally per the WSGI close() contract, so this is the test
+        # client reproducing production behaviour, not a testing artifact.
+        app = make_app()
+        url = f"/settings-editor/api/raw/takes/{self.take_name}/download"
+        with app.test_client() as c:
+            with c.head(url) as r1:
+                self.assertEqual(r1.status_code, 200)
+            with c.head(url) as r2:
+                self.assertEqual(r2.status_code, 200)
+
+        # Both permits must be back: two independent non-blocking acquires
+        # succeed, matching the fixed two-permit cap. try/finally so a
+        # failure here (a partial leak) does not also corrupt every test
+        # that runs after this one in the same process.
+        got = []
+        try:
+            got.append(raw_files.DOWNLOAD_SEMAPHORE.acquire(blocking=False))
+            got.append(raw_files.DOWNLOAD_SEMAPHORE.acquire(blocking=False))
+        finally:
+            for ok in got:
+                if ok:
+                    raw_files.DOWNLOAD_SEMAPHORE.release()
+        self.assertEqual(got, [True, True])
+
+    def test_permit_releases_only_once_even_if_both_paths_fire(self):
+        # _Permit must not double-release: guarded_stream()'s finally and
+        # Response.call_on_close() can both fire for an ordinary GET whose
+        # body is fully consumed (finally on generator exhaustion,
+        # call_on_close on the WSGI close() that follows). A genuine second
+        # sem.release() on a BoundedSemaphore already back at its initial
+        # count raises ValueError immediately -- verified in isolation
+        # (threading.BoundedSemaphore(2): acquire, release, release ->
+        # "Semaphore released too many times") -- so _Permit's guard is what
+        # stands between a completed download and a crashed request thread.
+        self.assertTrue(raw_files.DOWNLOAD_SEMAPHORE.acquire(blocking=False))
+        try:
+            permit = raw_files._Permit(raw_files.DOWNLOAD_SEMAPHORE)
+            permit.release()
+            permit.release()  # must be a silent no-op, not a second release
+        except ValueError:
+            self.fail("_Permit.release() called twice raised -- it must "
+                       "guard the underlying semaphore, not just forward")
+
+        # Semaphore is back at its starting count (one acquire, one real
+        # release): both permits are available again.
+        self.assertTrue(raw_files.DOWNLOAD_SEMAPHORE.acquire(blocking=False))
+        self.assertTrue(raw_files.DOWNLOAD_SEMAPHORE.acquire(blocking=False))
+        raw_files.DOWNLOAD_SEMAPHORE.release()
+        raw_files.DOWNLOAD_SEMAPHORE.release()
+
 
 class PerFileRouteTests(RawFilesFixture):
     def test_traversal_is_404(self):

--- a/_test/test_rec_tone_config.py
+++ b/_test/test_rec_tone_config.py
@@ -1,0 +1,89 @@
+"""hardware_outputs.rec_tone must actually reach GPIOOutput.
+
+Commit c171975e regrouped the flat `rec_tone_*` keys under a nested `rec_tone`
+object and updated main.py's section name but not its leaf reads, so every
+rec_tone value silently fell back to a hardcoded default:
+
+  * the configured tone pin was ignored, and the pwm_pin fallback used instead
+  * frequency_hz and duty_cycle could not be changed at all
+  * relay_drop_frames could never be true, so
+    GPIOOutput.relay_drop_frame_on_rec_tone() returned at its guard every time
+    -- the "Drop a frame for the relay" toggle has never done anything on this
+    settings shape
+
+settings.schema.json declares rec_tone with additionalProperties:false, so the
+flat keys cannot appear in a current settings file at all.
+"""
+
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+sys.modules.setdefault("smbus", types.SimpleNamespace(SMBus=object))
+
+from module.config_loader import (
+    _apply_settings_defaults,
+    rec_tone_config,
+    strip_jsonc,
+)
+
+
+class RecToneConfigTests(unittest.TestCase):
+    def test_nested_values_are_read(self):
+        cfg = rec_tone_config(
+            {"rec_tone": {"pin": [18], "frequency_hz": 440, "duty_cycle": 25,
+                          "relay_drop_frames": True}}
+        )
+        self.assertEqual(cfg["pin"], [18])
+        self.assertEqual(cfg["frequency_hz"], 440)
+        self.assertEqual(cfg["duty_cycle"], 25)
+        self.assertIs(cfg["relay_drop_frames"], True)
+
+    def test_relay_drop_frames_can_now_be_true(self):
+        # The whole point: the guard in relay_drop_frame_on_rec_tone() was
+        # unreachable-by-configuration before this.
+        cfg = rec_tone_config({"rec_tone": {"relay_drop_frames": True}})
+        self.assertIs(cfg["relay_drop_frames"], True)
+
+    def test_missing_block_falls_back_to_documented_defaults(self):
+        cfg = rec_tone_config({})
+        self.assertEqual(cfg["pin"], [])
+        self.assertEqual(cfg["frequency_hz"], 1000)
+        self.assertEqual(cfg["duty_cycle"], 50)
+        self.assertIs(cfg["relay_drop_frames"], False)
+
+    def test_pre_rename_flat_keys_still_work(self):
+        cfg = rec_tone_config(
+            {"rec_tone_pin": [12], "rec_tone_frequency_hz": 880,
+             "rec_tone_duty_cycle": 10, "rec_tone_relay_drop_frames": True}
+        )
+        self.assertEqual(cfg["pin"], [12])
+        self.assertEqual(cfg["frequency_hz"], 880)
+        self.assertEqual(cfg["duty_cycle"], 10)
+        self.assertIs(cfg["relay_drop_frames"], True)
+
+    def test_nested_wins_over_a_stale_flat_key(self):
+        cfg = rec_tone_config({"rec_tone": {"frequency_hz": 440},
+                                "rec_tone_frequency_hz": 880})
+        self.assertEqual(cfg["frequency_hz"], 440)
+
+    def test_the_shipped_settings_file_reaches_gpio_output(self):
+        raw = json.loads(strip_jsonc((ROOT / "settings.jsonc").read_text(encoding="utf-8")))
+        gpio_cfg = _apply_settings_defaults(raw)["hardware_outputs"]
+        cfg = rec_tone_config(gpio_cfg)
+        self.assertEqual(cfg["pin"], gpio_cfg["rec_tone"]["pin"])
+        self.assertEqual(cfg["frequency_hz"], gpio_cfg["rec_tone"]["frequency_hz"])
+        self.assertEqual(cfg["duty_cycle"], gpio_cfg["rec_tone"]["duty_cycle"])
+
+    def test_defaults_match_config_loader(self):
+        from_loader = _apply_settings_defaults({})["hardware_outputs"]["rec_tone"]
+        self.assertEqual(rec_tone_config({}), from_loader)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_settings_editor_clearhdr_thresholds.py
+++ b/_test/test_settings_editor_clearhdr_thresholds.py
@@ -1,0 +1,67 @@
+"""The editor must not re-create the degenerate 0/0 ClearHDR threshold pair.
+
+bfea0be8 removed the seeded 0/0 data-selection pair from settings.jsonc. The
+settings editor could put it straight back.
+
+applyControlValue() returns early on `undefined`, so when
+image_capture.hdr.threshold_low/high are ABSENT the input's static markup value
+survives hydration. Both inputs shipped `value="0"`, and absent is exactly the
+stock-defaults case: resources/settings/settings_default.jsonc's hdr block is
+just {sdr, imx585_clear_hdr}, and that file is served both when
+/home/pi/cinemate/settings.jsonc is missing and for "Revert to defaults".
+buildState() then read parseFloat("0") for both and Save wrote 0/0.
+
+That pair is not rejected downstream -- cinepi_controller.cpp only refuses
+high < low, not high == low -- so it reaches EXP_TH_H == EXP_TH_L, the
+weighted-blend fallback the imx585 driver documents as leaving the combiner
+clamped near black level.
+
+The driver's own pair is low 0 / high 4095 (hdr_thresh_def[2] = {0x0FFF,
+0x0000}, with th[0] -> EXP_TH_H and th[1] -> EXP_TH_L), and null on both sides
+means "leave it alone", which is what blank must round-trip to.
+
+Verified in a browser with the keys absent: both fields blank, placeholder
+"driver", and a save would carry null/null rather than 0/0.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "src" / "module" / "app" / "templates" / "settings_editor.html"
+
+
+class ClearHdrThresholdMarkupTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = TEMPLATE.read_text(encoding="utf-8")
+
+    def _input(self, field_id):
+        m = re.search(rf'<input[^>]*id="{field_id}"[^>]*>', self.html)
+        self.assertIsNotNone(m, f"{field_id} not found")
+        return m.group(0)
+
+    def test_thresholds_do_not_ship_a_literal_zero(self):
+        for fid in ("f-hdr-thlow", "f-hdr-thhigh"):
+            tag = self._input(fid)
+            self.assertIn('value=""', tag, f"{fid} must hydrate blank, not 0")
+            self.assertNotIn('value="0"', tag)
+
+    def test_thresholds_are_not_dirty_against_a_zero_original(self):
+        for fid in ("f-hdr-thlow", "f-hdr-thhigh"):
+            self.assertIn('data-original=""', self._input(fid))
+
+    def test_blank_is_explained_to_the_operator(self):
+        # A blank box that silently means "keep the driver's pair" is not
+        # self-describing; the card has to say so.
+        self.assertIn("Leave a threshold blank", self.html)
+        self.assertIn("low 0, high 4095", self.html)
+
+    def test_both_thresholds_still_bound_to_their_settings_keys(self):
+        self.assertIn('data-path="image_capture.hdr.threshold_low"', self.html)
+        self.assertIn('data-path="image_capture.hdr.threshold_high"', self.html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_settings_editor_gpio_tone.py
+++ b/_test/test_settings_editor_gpio_tone.py
@@ -1,0 +1,80 @@
+"""The GPIO-out pane must hide what it says it hides, and show the tone's Hz.
+
+Three operator reports, one shared root cause and one real one.
+
+1. `[hidden]` did nothing. The page hides 15 elements with `el.hidden`, and
+   every one of them carries an author `display` rule -- .card is grid, .pill
+   and .btn are flex, .action-args is inline-flex. An author display
+   declaration beats the UA stylesheet's `[hidden]{display:none}` at any
+   specificity, and the file declared no `[hidden]` rule of its own. Measured
+   in a browser on this page: a hidden #saveBtn stayed 109px wide, the
+   unsaved-count pill 98px, a .card 834px. For GPIO out this meant the REC
+   tone's "at [1000] Hz" field rendered on every tally row, where a frequency
+   is meaningless -- gpio_output.py never gives a tally pin a PWM object, it
+   writes a bare level.
+
+2. The slate tone's frequency had no card, only a per-row widget carried in a
+   module-global, so the duty-cycle card showed a pulse width with no pitch
+   beside it.
+
+3. Under both: main.py read flat rec_tone_* keys that have not existed since
+   c171975e -- see test_rec_tone_config.py.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "src" / "module" / "app" / "templates" / "settings_editor.html"
+
+
+class HiddenAttributeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = TEMPLATE.read_text(encoding="utf-8")
+
+    def test_the_page_declares_its_own_hidden_rule(self):
+        self.assertRegex(self.html, r"\[hidden\]\{\s*display:none\s*!important;\s*\}")
+
+    def test_el_hidden_is_still_used_enough_to_need_it(self):
+        # If this ever drops to zero the rule above can go too.
+        self.assertGreater(len(re.findall(r"\.hidden\s*=", self.html)), 5)
+
+
+class SlateToneTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = TEMPLATE.read_text(encoding="utf-8")
+
+    def test_frequency_has_a_card_bound_to_the_settings_key(self):
+        self.assertIn('id="f-tonehz"', self.html)
+        self.assertIn('data-path="hardware_outputs.rec_tone.frequency_hz"', self.html)
+
+    def test_frequency_card_is_labelled_in_hertz(self):
+        m = re.search(r'id="f-tonehz".*?</div>', self.html, re.S)
+        self.assertIsNotNone(m)
+        self.assertIn("Hz", m.group(0))
+
+    def test_duty_cycle_card_still_bound(self):
+        self.assertIn('data-path="hardware_outputs.rec_tone.duty_cycle"', self.html)
+
+    def test_both_tone_cards_share_a_container_that_can_be_retired(self):
+        self.assertIn('id="toneCards"', self.html)
+        self.assertIn("function syncToneCards()", self.html)
+        self.assertIn("cards.hidden = !anyTone;", self.html)
+
+    def test_frequency_is_synced_both_ways(self):
+        self.assertIn("function syncToneHz(", self.html)
+        # The card seeds from settings, and the row fields mirror it.
+        self.assertIn("syncToneHz(loadedHz)", self.html)
+        self.assertIn("syncToneHz(v, freqInput)", self.html)
+        self.assertIn("syncToneHz(v, card)", self.html)
+
+    def test_removing_the_last_tone_row_retires_the_cards(self):
+        # Rows are removed by a generic button that knows nothing about tones.
+        self.assertIn("MutationObserver(syncToneCards)", self.html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_settings_editor_page_restore.py
+++ b/_test/test_settings_editor_page_restore.py
@@ -1,0 +1,69 @@
+"""A reload must land on the page the operator was on, not always Settings.
+
+The editor used to bootstrap with a literal setActivePage('settings'), so every
+reload dropped the operator back on the Settings pane -- including the reloads
+the page triggers itself after a resolution change. The rail already writes a
+section id into the hash and every section declares its page via data-page, so
+the hash already carried the answer; nothing read it.
+
+These are structural guards. The behaviour itself is JavaScript and was
+verified in a browser against the desk harness at 1440x800:
+  reload #bootconfig -> config pane, section at 74px (its scroll-margin-top)
+  reload #live       -> live pane
+  reload #clips      -> raw pane
+  stale/absent hash  -> settings (the default)
+  tab click          -> pushState, so a rail deep-link is not destroyed
+  back / forward     -> pane restored, section back at 74px
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "src" / "module" / "app" / "templates" / "settings_editor.html"
+
+
+class PageRestoreTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = TEMPLATE.read_text(encoding="utf-8")
+
+    def test_bootstrap_no_longer_hardcodes_the_settings_page(self):
+        self.assertNotIn("setActivePage('settings');", self.html)
+
+    def test_bootstrap_restores_the_page_from_the_hash(self):
+        self.assertIn("setActivePage(pageFromHash()", self.html)
+
+    def test_every_page_has_a_landing_section_that_exists(self):
+        m = re.search(r"var PAGE_LANDING = \{([^}]*)\}", self.html)
+        self.assertIsNotNone(m, "PAGE_LANDING table missing")
+        landings = dict(re.findall(r"(\w+):\s*'([^']+)'", m.group(1)))
+
+        pages = set(re.findall(r'data-page-tab="([a-z]+)"', self.html))
+        self.assertTrue(pages, "no page tabs found")
+        self.assertEqual(set(landings) , pages, "a page has no landing section")
+
+        for page, section_id in landings.items():
+            self.assertRegex(
+                self.html,
+                rf'id="{re.escape(section_id)}"[^>]*data-page="{re.escape(page)}"',
+                f"landing section #{section_id} for page {page} is missing "
+                f"or does not belong to that page",
+            )
+
+    def test_page_switches_push_history_rather_than_replacing_it(self):
+        # replaceState would overwrite the rail deep-link the operator is
+        # standing on, silently eating one entry from the back button.
+        self.assertIn("history.pushState(null, '', '#' + PAGE_LANDING[page])", self.html)
+        self.assertNotIn("history.replaceState(null, '', '#' + PAGE_LANDING[page])", self.html)
+
+    def test_hashchange_scrolls_after_the_pane_is_visible(self):
+        # The browser's own fragment scroll fires before hashchange, when the
+        # target section is still display:none and therefore box-less.
+        self.assertIn("addEventListener('hashchange'", self.html)
+        self.assertIn("scrollIntoView({ behavior: 'auto', block: 'start' })", self.html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_settings_editor_sensor_db.py
+++ b/_test/test_settings_editor_sensor_db.py
@@ -1,0 +1,96 @@
+"""The sensor-database card must tell the truth, and must not eat the key.
+
+Two defects lived in the same read-only card:
+
+1. It printed the literal string "resources/sensors.json" regardless of what
+   `sensors.database_file` actually said, and regardless of where that
+   relative path resolved to. On a source install /home/pi/cinemate is a
+   symlink (cinemate-install.sh), which Path.resolve() follows, so only the
+   backend can name the file Cinemate really opens.
+
+2. Worse, and invisible: buildState() in the editor collects only [data-path]
+   elements. The card had none, so a Save posted no `sensors.database_file`
+   at all -- and _apply_settings_defaults() setdefaults the stock relative
+   path back in, which then gets written to settings.jsonc. An operator with
+   a custom database silently lost it the first time they pressed Save, and
+   the card's hardcoded label became "true" again in the process.
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+sys.modules.setdefault("smbus", types.SimpleNamespace(SMBus=object))
+
+_APP_PKG = types.ModuleType("module.app")
+_APP_PKG.__path__ = [str(ROOT / "src" / "module" / "app")]
+sys.modules.setdefault("module.app", _APP_PKG)
+
+from flask import Flask
+
+from module.app.settings_editor import settings_editor_bp
+from module.config_loader import _apply_settings_defaults
+from module.sensor_database import resolve_database_path
+
+TEMPLATE = ROOT / "src" / "module" / "app" / "templates" / "settings_editor.html"
+
+
+def _client(settings):
+    app = Flask(__name__)
+    app.config["SETTINGS"] = settings
+    app.register_blueprint(settings_editor_bp)
+    return app.test_client()
+
+
+class SensorDatabaseCardTests(unittest.TestCase):
+    def test_card_renders_the_resolved_absolute_path(self):
+        html = _client({"sensors": {"database_file": "resources/sensors.json"}}).get(
+            "/settings-editor/"
+        ).get_data(as_text=True)
+
+        expected = str(resolve_database_path("resources/sensors.json"))
+        self.assertTrue(Path(expected).is_absolute(), expected)
+        self.assertIn(expected, html)
+
+    def test_card_follows_an_operator_override(self):
+        html = _client({"sensors": {"database_file": "/mnt/ssd/my-sensors.json"}}).get(
+            "/settings-editor/"
+        ).get_data(as_text=True)
+
+        self.assertIn("/mnt/ssd/my-sensors.json", html)
+        # The stock path must not also appear in the card.
+        self.assertNotIn(
+            ">resources/sensors.json</span>", html.replace("\n", "")
+        )
+
+    def test_missing_sensors_block_does_not_500(self):
+        resp = _client({}).get("/settings-editor/")
+        self.assertEqual(resp.status_code, 200)
+
+
+class SensorDatabaseRoundTripTests(unittest.TestCase):
+    def test_template_carries_a_data_path_so_save_round_trips_the_key(self):
+        # buildState() only collects [data-path]; without this the key is
+        # dropped from every Save payload. This is the regression guard.
+        self.assertIn(
+            'data-path="sensors.database_file"',
+            TEMPLATE.read_text(encoding="utf-8"),
+        )
+
+    def test_a_payload_carrying_the_key_keeps_it(self):
+        out = _apply_settings_defaults({"sensors": {"database_file": "/mnt/ssd/x.json"}})
+        self.assertEqual(out["sensors"]["database_file"], "/mnt/ssd/x.json")
+
+    def test_a_payload_missing_the_key_is_what_destroyed_it(self):
+        # Documents the hazard the [data-path] field exists to prevent: this
+        # is exactly what the editor used to post.
+        out = _apply_settings_defaults({"sensors": {}})
+        self.assertEqual(out["sensors"]["database_file"], "resources/sensors.json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_web_gui_free_stepping.py
+++ b/_test/test_web_gui_free_stepping.py
@@ -1,0 +1,74 @@
+"""Free stepping must grey the picker only where greying is true.
+
+Free stepping swaps a preset table for a fine grid -- shutter_a.free ships
+true with increment 1, so the SHUTTER picker carries ~360 entries -- AND
+changes what the setter does with them. For SHUTTER and FPS the setter stops
+snapping to the table ("In sync mode, or free-stepping, just accept it
+verbatim"; the fps branch clamps to 1..fps_max), so the interior entries are a
+sample of a continuum rather than the legal set, and greying them is honest.
+
+It is NOT honest for the other two, which is why they are excluded:
+
+  * WB  -- set_wb() picks the closest entry of wb_steps unconditionally, and
+           initialize_wb_cg_rb_array() gives every entry a real cg_rb pair, so
+           under wb_free the interior IS the exact legal set.
+  * ISO -- set_iso() clamps to the ends and never snaps, in every mode, so
+           iso_free changes what is offered, not what is accepted.
+
+Verified in a browser against a harness fed the shipped free-stepping default:
+  free on : SHUTTER 361 options / 358 disabled, ends live; FPS 5 / 3 disabled
+            ISO 0 disabled, WB 0 disabled
+  free off: SHUTTER 7 options / 0 disabled, ISO/WB/FPS 0 disabled
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "src" / "module" / "app" / "templates" / "template.html"
+
+
+class FreeSteppingSelectTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = TEMPLATE.read_text(encoding="utf-8")
+        m = re.search(r"function renderSelectors\(\).*?\n    \}", cls.html, re.S)
+        assert m, "renderSelectors not found"
+        cls.render = m.group(0)
+
+    def test_shutter_and_fps_are_gated_on_their_free_flags(self):
+        self.assertIn("freeStepBounds(steps.shutter_a, truthy(V.shutter_a_free)", self.render)
+        self.assertIn("freeStepBounds(steps.fps, truthy(V.fps_free)", self.render)
+
+    def test_wb_and_iso_are_not_gated(self):
+        # Greying either would state something the setters do not do.
+        for line in self.render.splitlines():
+            if "s-wb" in line or "s-iso" in line:
+                self.assertNotIn("freeStepBounds", line, line.strip())
+
+    def test_only_the_interior_is_disabled(self):
+        m = re.search(r"function freeStepBounds\(.*?\n    \}", self.html, re.S)
+        self.assertIsNotNone(m)
+        self.assertIn("i > 0 && i < list.length - 1", m.group(0))
+        # A two-entry list has no interior to grey.
+        self.assertIn("list.length > 2", m.group(0))
+
+    def test_the_live_value_is_carried_into_a_grid_that_lacks_it(self):
+        # Toggling free on at a preset 172.8 leaves a 1-degree grid with no
+        # such entry; without this the picker reads 1 while the camera runs
+        # at 172.8.
+        m = re.search(r"function freeStepBounds\(.*?\n    \}", self.html, re.S)
+        body = m.group(0)
+        self.assertIn("!list.some((v) => Number(v) === live)", body)
+        self.assertIn("opts.splice(", body)
+
+    def test_disabled_state_is_part_of_the_fill_cache_key(self):
+        # fillSelect skips a repaint when the value list is unchanged; a free
+        # toggle can change only which entries are selectable.
+        m = re.search(r"function fillSelect\(.*?\n    \}", self.html, re.S)
+        self.assertIn("(o.disabled ? '!' : '')", m.group(0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_web_gui_stream_reload.py
+++ b/_test/test_web_gui_stream_reload.py
@@ -1,0 +1,74 @@
+"""The preview reload must not put a query string on the MJPEG URL.
+
+cinepi-raw's preview is served by nadjieb cpp-mjpeg-streamer, which publishes
+exactly one topic -- `streamer_->publish("/stream", ...)` in
+mjpegPreviewStage.cpp -- and routes by the RAW request-target:
+
+    mjpeg_streamer.hpp:68   std::getline(iss, target_, ' ');   // query included
+    mjpeg_streamer.hpp:724  bool pathExists(p) { return topics_.find(p) != end; }
+    mjpeg_streamer.hpp:890  if (!publisher_.pathExists(req.getTarget())) -> 404
+
+So `GET /stream?reload=1756800000000` misses the map and the server answers 404
+and closes the connection. template.html appended exactly that cache-buster,
+and every recovery path funnels through the one function that did it:
+`reload_stream` from the socket, the socket-reconnect path, the end of a
+resolution switch, and the naturalWidth watchdog. None could succeed, and the
+`error` handler re-armed the same broken request once a second forever.
+
+It was worse than inert. cinepi-raw deliberately keeps the MJPEG listener and
+its clients alive across a camera reconfigure (mjpegPreviewStage.cpp Teardown/
+Configure), so the operator's existing connection would have survived a
+resolution change on its own -- the reload code aborted a working stream and
+replaced it with a permanent 404. Recovery only came from a full page reload,
+which requests the clean server-rendered URL, and which is suppressed while
+recording. Hence "flaky" rather than "always broken".
+
+Verified against a harness made faithful to that routing (the stock desk
+harness did `self.path.split("?")[0]`, which is why this never reproduced):
+`/stream?reload=...` -> 404, `/stream` -> 200, and a stream drop/restore cycle
+now produces two clean `/stream` requests and no 404s.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "src" / "module" / "app" / "templates" / "template.html"
+
+
+class StreamReloadTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = TEMPLATE.read_text(encoding="utf-8")
+        m = re.search(r"function scheduleStreamReload\(.*?\n    \}", cls.html, re.S)
+        assert m, "scheduleStreamReload not found"
+        cls.fn = m.group(0)
+        # Assert on code, not on comments -- the comment quotes the broken URL
+        # on purpose, as the explanation for why it must not be built.
+        cls.code = re.sub(r"//[^\n]*", "", cls.fn)
+        cls.html_code = re.sub(r"//[^\n]*", "", cls.html)
+
+    def test_no_cache_buster_is_appended_to_the_stream_url(self):
+        self.assertNotIn("?reload=", self.code)
+        self.assertNotIn("?reload=", self.html_code)
+
+    def test_the_reload_requests_the_bare_stream_base(self):
+        self.assertIn("img.src = img.dataset.streamBase;", self.code)
+
+    def test_it_still_forces_a_refetch_of_an_identical_url(self):
+        # Reassigning the same src is a no-op; dropping it first is what makes
+        # the browser reconnect, and is why the cache-buster existed at all.
+        self.assertIn("img.removeAttribute('src')", self.code)
+        self.assertLess(
+            self.code.index("img.removeAttribute('src')"),
+            self.code.index("img.src = img.dataset.streamBase;"),
+        )
+
+    def test_no_query_string_is_built_onto_any_stream_url(self):
+        for m in re.finditer(r"dataset\.streamBase\s*\+", self.html_code):
+            self.fail(f"stream URL is being concatenated at offset {m.start()}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_web_ui_combined_download_reconciliation.py
+++ b/_test/test_web_ui_combined_download_reconciliation.py
@@ -1,0 +1,120 @@
+"""feature/web-ui-combined shipped two independent folder-picker download
+clients: fix/web-ui-round2's single bulk IIFE (res.body.pipeTo(w), no
+?storage=, a 429 treated as fatal) and fix/web-ui-portrait's per-row client
+(a progress bar, a cancel button, AbortController cleanup, a documented error
+taxonomy, a pre-flight listed check, and ?storage= on every request). They
+auto-merged with zero conflict markers because they occupy disjoint regions
+of settings_editor.html.
+
+Portrait's client survived; round2's was deleted and its multi-take
+sequencing (pick the folder once, write takes one after another, "Saving N
+of M" between them) was grafted onto portrait's per-take functions instead.
+These tests pin that shape so a future merge or edit cannot silently bring
+either half of the duplication back, or drop the reconciliation.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "src" / "module" / "app" / "templates" / "settings_editor.html"
+
+
+class NoDuplicateClientTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = TEMPLATE.read_text(encoding="utf-8")
+
+    def test_round2_bulk_iife_is_gone(self):
+        for token in ("bulkDownloadFolder", "folderDownloadSupported", "pipeTo"):
+            self.assertNotIn(token, self.html, f"round2 download client leftover: {token}")
+
+    def test_only_one_showdirectorypicker_call_site(self):
+        # pickFolder() is the sole caller; nothing else should invoke the
+        # API directly, or the folder-picked-once invariant is bypassable.
+        self.assertEqual(self.html.count("window.showDirectoryPicker("), 1)
+
+    def test_no_duplicate_element_ids(self):
+        ids = re.findall(r'id="([^"]+)"', self.html)
+        dupes = sorted({i for i in ids if ids.count(i) > 1})
+        self.assertEqual(dupes, [])
+
+    def test_the_file_stays_es5(self):
+        # var + function + .then, never async/await/arrow -- the page
+        # targets older iOS (see template.html's own comment on this).
+        self.assertNotRegex(self.html, r"async function|await |=> *\{")
+
+
+class MergedClientShapeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = TEMPLATE.read_text(encoding="utf-8")
+
+    def test_folder_is_picked_once_and_shared(self):
+        self.assertIn("function pickFolder(){", self.html)
+        self.assertIn(
+            "id: 'cinemate-raw-downloads', mode: 'readwrite', startIn: 'downloads',",
+            self.html,
+        )
+
+    def test_per_take_save_is_a_reusable_function(self):
+        self.assertIn(
+            "function savePickedTakeIntoRow(dirRoot, name, storage, row){",
+            self.html,
+        )
+
+    def test_single_row_path_still_owns_its_own_refresh_suppression(self):
+        m = re.search(r"function startPickedDownload\(.*?\n  \}", self.html, re.S)
+        self.assertIsNotNone(m)
+        self.assertIn("refreshSuppressed = true;", m.group(0))
+        self.assertIn("refreshSuppressed = false;", m.group(0))
+
+    def test_bulk_path_picks_once_and_chains_sequentially(self):
+        m = re.search(
+            r"document\.getElementById\('bulkDownload'\)\.addEventListener\('click', function\(\).*?\n  \}\);",
+            self.html, re.S,
+        )
+        self.assertIsNotNone(m, "bulkDownload click handler not found")
+        body = m.group(0)
+        self.assertIn("pickFolder().then(function(dirRoot){", body)
+        self.assertIn("refreshSuppressed = true;", body)
+        self.assertIn("names.reduce(function(chain, name, i){", body)
+        self.assertIn("savePickedTakeIntoRow(dirRoot, name,", body)
+        self.assertIn("Saving ' + (i + 1) + ' of ' + names.length", body)
+        # Cleared once at the end, not per take -- a mid-batch refresh would
+        # destroy the row the batch is currently writing progress into.
+        self.assertEqual(body.count("refreshSuppressed = false;"), 2)  # success + failure arm
+
+    def test_bulk_button_disables_only_on_the_non_picker_fallback(self):
+        m = re.search(r"function updateBulkBar\(\).*?\n  \}", self.html, re.S)
+        self.assertIsNotNone(m)
+        self.assertIn("!CAN_PICK_FOLDER && names.length > 1", m.group(0))
+
+    def test_footer_names_the_right_reason_for_a_missing_picker(self):
+        # Two different reasons (plain HTTP vs. Safari/Firefox) used to read
+        # as the same missing button.
+        self.assertIn("window.isSecureContext", self.html)
+        self.assertIn("turn on ' +\n          'system.https in settings.jsonc", self.html)
+        self.assertIn("Chromium only, today", self.html)
+
+
+class DeleteStorageAndReasonTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = TEMPLATE.read_text(encoding="utf-8")
+
+    def test_single_delete_sends_storage(self):
+        self.assertIn(
+            "deleteUrl += '?storage=' + encodeURIComponent(storage);",
+            self.html,
+        )
+
+    def test_bulk_delete_distinguishes_the_409_from_a_partial_failure(self):
+        self.assertIn("if (status === 409) {", self.html)
+        self.assertIn("res.recording", self.html)
+        self.assertNotIn("Some deletes failed — see console", self.html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dev-track/C8-web-ui-review/PLAN.md
+++ b/dev-track/C8-web-ui-review/PLAN.md
@@ -20,6 +20,17 @@ That fixed the operator-reported bug: the settings editor had **no doctype and n
 meta at all**, so phones laid it out at the 980px fallback viewport and its `≤860px`
 hamburger — which already existed — never fired in portrait. **This step is the rest.**
 
+## Status
+
+**Code written, hardware gate open.** All ten findings (W1–W10) have code against them on
+`fix/web-ui-portrait`, merged into `feature/web-ui-combined` (which also reconciles W9/W10's
+download client against a second one built independently on `fix/web-ui-round2` — see that
+branch's merge commit for the conflict-by-conflict resolution). Every desk gate in the
+Verification section below passes on that branch. None of it has run on a camera. The
+Verification section's original "two items the desk cannot close" undersold this: it is not
+just W5 and the W1 tap targets — nothing here has been loaded on a Pi, so every item stays a
+code-level claim, not a fixed one, until G-series hardware gates say otherwise.
+
 ## The remaining findings
 
 W1 was a decision at the time this table was written; it no longer is. The operator ruled on

--- a/dev-track/C8-web-ui-review/PLAN.md
+++ b/dev-track/C8-web-ui-review/PLAN.md
@@ -14,7 +14,7 @@ shellcheck):
 | commit | change |
 |---|---|
 | `ab17fdb4` | settings editor · `<!DOCTYPE html>` + viewport meta + `.mode-table{line-height:1.3}` |
-| `4b3d5093` | web GUI · select tap targets 44×18 → 56×34, px font floors on clip name + WAV badge, `docs/web-gui.md` qualifier |
+| `4b3d5093` | web GUI · select tap targets ~44×18 → 34px tall (widths vary by label, none is a uniform 56px — see W8's measured width table), px font floors on clip name + WAV badge, `docs/web-gui.md` qualifier |
 
 That fixed the operator-reported bug: the settings editor had **no doctype and no viewport
 meta at all**, so phones laid it out at the 980px fallback viewport and its `≤860px`
@@ -22,48 +22,53 @@ hamburger — which already existed — never fired in portrait. **This step is 
 
 ## The remaining findings
 
-Nothing below is started. W1 is a decision, not a patch; W2–W7 are self-contained.
+W1 was a decision at the time this table was written; it no longer is. The operator ruled on
+2026-09-01 (see `WEB-UI-REVIEW-PLAN.md`'s W1 section): rails stay left and right at every
+viewport and the layout shrinks rather than reflows. W1 is now an implementation task, folded
+into W2's mechanism. Two findings surfaced after this table was written are not in it: **W9**
+(clip download, server half) and **W10** (clip download + destination folder, client half) —
+see `WEB-UI-REVIEW-PLAN.md` for both; they are candidate rows here, not added to preserve this
+table's evidence/disposition shape without doing the same work for them.
 
 | # | Finding | Evidence | Shape of the fix |
 |---|---|---|---|
-| W1 | **Portrait phone wastes most of the screen.** The preview renders 501×281 inside a 375×812 viewport, vertically centred, with large empty bands above and below it and the rails hugging the left edge | 375×812 harness screenshot | **Decide, don't patch** — see "W1 is an ADR question" below |
+| W1 | **Portrait phone wastes most of the screen.** The preview renders 285×160 (15.0% of screen) inside a 375×812 viewport, vertically centred, with large empty bands above and below it and the rails hugging the left edge | 375×812 harness measurement | Shrink the rail chrome via the width term of W2's `--fit` scalar (operator ruling: shrink, never restack) |
 | W2 | **Left rail clips silently.** At 812×375 the rail's `scrollHeight` is 444 against a 282 `clientHeight`; the SYS section (storage type *and filesystem*) scrolls out of view with no visible scrollbar. The rule's own comment says "scroll rather than clip, so a real status … never silently disappears" — visually it does disappear | measured; visible in the `?state=warn` screenshot, SSD/ext4 cut mid-box | Bottom fade-mask (or a scroll affordance) when the rail overflows, and/or shrink `--box-size`/gaps at short heights instead of overflowing |
 | W3 | **DROP badge fails contrast, and crowds its own count.** Black on `rgb(120,40,180)` ≈ **2.8:1** (WCAG AA wants 4.5:1); white on that purple ≈ 7.6:1. Separately, "DROP 17" wraps tightly inside the fixed `--box-size`×`--box-height` box | computed from the token value | Change the text colour **in `src/module/design_tokens.py`** so both surfaces move together (that is what the token pipeline is for — `tools/design_token_diff.py --strict` gates it), and let a warning box carrying a count auto-width |
 | W4 | **Locked reads as selected.** A locked FPS/SHUTTER/EI draws as an inverted white pill — which reads "highlighted", not "locked" — and the transparent `<select>` over it still opens the picker on tap, so a locked parameter looks changeable | `?state=warn`, `.group.locked .value` | Faithful to `draw_rounded_box()`, so a change is a deliberate divergence: either a lock glyph, or `pointer-events:none` on the select while locked (the reject toast already explains the refusal, so this is polish, not correctness) |
 | W5 | **FULLSCREEN is dead on iPhone.** `(el.requestFullscreen \|\| el.webkitRequestFullscreen).call(el)` throws when both are undefined — iOS Safari has no element-fullscreen API | code read, **not** observed on a device | Feature-detect and hide the button when neither API exists |
-| W6 | **~150 lines of dead theme CSS in the settings editor.** The light "paper" palette, the `@media (prefers-color-scheme: dark)` block and the `:root[data-theme="light"/"dark"]` hooks are all permanently overridden by `#app.skin-hud`, which the markup carries unconditionally — its own comment says "there's no Manual/HUD switch anymore" | `settings_editor.html` `:root` blocks vs `#app.skin-hud`; it misled the review itself mid-session (a light-scheme test rendered dark) | Delete the dead palettes, **or** reconnect a real toggle. Deleting is the smaller change and the honest one unless a theme switch is actually wanted |
+| W6 | **42 lines of dead theme CSS in the settings editor** (not ~150): the `@media (prefers-color-scheme: dark)` block and the `:root[data-theme="light"/"dark"]` hooks, plus one empty rule and one shadowed declaration. The `:root` "paper" palette itself is **not** dead — it is live outside `#app` (the raw-file drawer, toast and confirm modal), which `#app.skin-hud` never reaches, and it is the sole declaration of `--focus` (every keyboard focus ring on the page) | `settings_editor.html` `:root` blocks vs `#app.skin-hud`; it misled the review itself mid-session (a light-scheme test rendered dark, which is consistent with `#app` being the one region genuinely immune) | Promote the HUD palette to `:root` (re-homing `--focus` safely) and delete the 42 dead lines, **or** move the 4 fixed-position nodes inside `#app`, **or** reconnect a real toggle. See `WEB-UI-REVIEW-PLAN.md` W6 for the three options — this one is a hard operator decision, not mechanical |
 | W7 | **Save can scroll out of reach.** The topbar is a nowrap flex row that scrolls inside itself by design at narrow widths — but "Save changes", the one action that matters, is last in that row and can sit off-screen with no affordance | `.topbar{overflow-x:auto}` + narrow-width render | Pin Save (and probably the unsaved-count chip) outside the scrolling region |
 | W8 | **Wrapped-portrait select overlap** — accepted trade-off from PR #160, recorded so it is not rediscovered as a bug. Where the top row wraps, rows sit ~4px apart, so a lower row's enlarged select reaches ~4px into the row above; a tap on those descender pixels opens the lower group's picker | adversarial review of #160; documented in the rule's comment | Optional hardening: cap the vertical extension against the row gap, or raise `#top-row`'s row-gap to match |
 
-Explicitly **not** doing: the `inset` shorthand's lack of a fallback for iOS 14.0–14.4 (that
-window is the only engine that renders this page but drops `inset`; the degradation is a
-worse tap target, not a broken page).
+Explicitly **not** doing: a fallback for the `inset` shorthand on iOS 14.0–14.4. The exclusion
+stands, but the original reasoning here was wrong on both halves: that engine drops `inset`
+**and** flexbox `row-gap` together (both land in Safari/iOS 14.1), so W8's "4px of overlap"
+premise does not exist there at all, and the actual degradation is not merely "a worse tap
+target" — with `inset` dropped, every top-row `<select>` falls back to its intrinsic size
+(15×15 to 68×15px) and the picker no longer covers the text it controls. See
+`WEB-UI-REVIEW-PLAN.md`'s W8 section for the measurements.
 
-## W1 is an ADR question, not a CSS task
+## W1 — settled by operator ruling, 2026-09-01
 
-The portrait layout is the way it is **on purpose**. B11.7 / F-297 deliberately removed the
-old `@media (max-width:900px), (orientation:portrait)` restack — which turned the rails into
-horizontal strips above and below the preview — on the grounds that `simple_gui.py` scales
-its whole 1920×1080 layout by a single ratio and never restacks, so the browser should not
-either. That reasoning is sound for the surface it was written about.
+This used to be an open ADR question with three options (below, for the record). It no longer
+is. The operator ruled: *"the left and right columns with grey boxes should always be in the
+left and right. not reflowed but rather shrunk in order to fit."* Consequences: the rails stay
+left and right at every viewport including portrait phone; the layout shrinks, never restacks;
+option 3 below (reinstating the restack) is rejected; option 1 (do nothing + a rotate hint) is
+rejected. W1 is now an implementation task — see `WEB-UI-REVIEW-PLAN.md`'s W1/W2 sections,
+which is where its mechanism actually lives (one `--fit` scalar shared with W2, no second
+mechanism). The original three options, for the record:
 
-The counter-argument this review raises is narrow and worth stating plainly: **the HDMI GUI
-never meets a portrait viewport, and a phone does.** A single-ratio scale of a 16:9-authored
-instrument panel into a 9:19.5 window necessarily leaves most of that window empty. So this
-is not "B11.7 was wrong"; it is "B11.7's premise does not reach the portrait case."
+1. Do nothing; add a "rotate for the full HUD" hint in portrait. — **Rejected.**
+2. Keep the three-column grid but shrink its geometry tokens so the rails and preview all
+   scale down together without restacking. — **This is the ruling**, implemented as W1+W2.
+3. Reinstate a portrait-only restack (what B11.7 removed). — **Rejected.**
 
-Before changing anything here, read `system-review/decisions/ADR-001-gui-harmonization.md`
-(it already worked this through against measured DRM/RAM/refresh constraints) and the
-handbook's `architecture/gui-state-model.md`. Options worth weighing, cheapest first:
-
-1. Do nothing; add a "rotate for the full HUD" hint in portrait.
-2. Keep the three-column grid but let the stage centre as a unit and give the preview
-   priority width, reclaiming the dead bands without restacking.
-3. Reinstate a portrait-only restack (what B11.7 removed) — the largest usable preview, and
-   the option that most directly contradicts the existing decision. Needs the operator.
-
-**Do not just re-add the media query.** If option 3 wins, it should land as an amendment to
-the decision, with the reasoning recorded, not as a silent revert of a deliberate change.
+`system-review/decisions/ADR-001-gui-harmonization.md` was read before this ruling was acted
+on; its "a 1920 instrument panel and a phone browser should not share a grid" argument
+constrains a future shared layout engine, not this file, and is compatible with shrink-not-
+restack.
 
 ## Verification
 

--- a/dev-track/C8-web-ui-review/SONNET-PROMPT.md
+++ b/dev-track/C8-web-ui-review/SONNET-PROMPT.md
@@ -1,0 +1,118 @@
+# Kickoff prompt for the implementing session
+
+Paste everything below the line into a fresh Sonnet thread.
+
+Note: single repo (cinemate), ten findings W1–W10, no cinepi-raw changes, no rebuild. Two of
+the ten (W9, W10 — clip download) are new work added by the operator on 2026-09-01 and are
+not in `PLAN.md`. W1's ADR question was settled by operator ruling the same day: the rails
+stay left and right and the layout shrinks, it never restacks. The findings were measured in
+a desk harness and then adversarially re-verified against the pinned dev tree; the full spec
+records where the original review was wrong. Hardware gates are unrun — the prompt tells the
+implementer to produce the desk-verifiable work and stop before the Pi and the phone.
+
+---
+
+Implement C8 — the web UI review findings PR #160 did not fix: ten items across the live web
+GUI and the settings editor, from a portrait layout that wastes most of a phone screen to a
+clip download that does not work.
+
+The full spec is at:
+`/Users/patrikeriksson/Documents/cinemate/development/worktrees/c8-web-ui-review/dev-track/C8-web-ui-review/WEB-UI-REVIEW-PLAN.md`
+on branch `fix/web-ui-portrait` — ledger entry C8 in `PLAN.md` beside it.
+
+Read the spec in full before touching anything. It supersedes `PLAN.md` wherever the two
+differ, and it says exactly where `PLAN.md` is wrong (W1's framing, W3's prescribed file,
+W6's line range, W1's portrait measurement). Then read
+`/Users/patrikeriksson/Documents/cinemate/cinemate-handbook/README.md` plus
+`orientation/the-traps.md` and `architecture/gui-state-model.md`, and `docs/web-gui.md`'s
+"scales rather than reflows" paragraph — this work rides the shared `populate_values()` state
+dict and the design-token pipeline. Every number in the spec came from a measured harness run
+and an adversarial re-check: implement them, don't relitigate.
+
+Ground rules:
+
+- One repo, one branch: `cinemate`. A worktree is already cut for you at
+  `/Users/patrikeriksson/Documents/cinemate/development/worktrees/c8-web-ui-review` on branch
+  `fix/web-ui-portrait` off `dev`. Work there — the main clone is on another feature branch.
+  `cd` does not persist between shell calls: use `git -C` and absolute paths.
+- **Never `git add -A`** (LFS pointer trap) — stage named files only. This is not theoretical:
+  that worktree checked out four `docs/images/*.png` as 130-byte LFS pointers over real
+  binaries. They show as modified. Leave them alone.
+- Do not merge to `dev`, do not push without asking, and **do not touch the Pi**. You are
+  producing the desk-verifiable half.
+- The web template's JS is ES5 (`var`, `function(){}`) — match it. The template embeds base64
+  font data: filter greps with `awk 'length($0) < 250'`.
+- Commit messages: `c8.<n>: <scope> — <one-line outcome>`.
+- Colours that exist on both GUIs live in `src/module/design_tokens.py`, not in the template.
+  `tools/design_token_diff.py --strict` gates it. But `--box-text` is deliberately *excluded*
+  from that table — W3's fix does not go where `PLAN.md` says it does.
+
+**Ask the operator these before writing code**, in one message. Each gates code, not
+commentary. Defaults are in the spec's "Order of work" — take the default, proceed, and record
+the assumption, except for W6:
+
+- W3 lighten the token or white text; W4 silent-inert or explicit refusal; W5 hide or disable;
+  W7 pin the chip too; W9 concurrency cap; W10 whether to write the directory-picker branch.
+- **W6 is a hard block.** Its three options ship visibly different products. Do not guess.
+
+Order matters — the spec's "Order of work" table is the authority. Five PRs:
+
+1. **W5** (PR A) — 14 lines of JS, touches nothing else. Land first to prove the harness loop.
+2. **W3** (PR B) — changes the DROP box's width, which moves the rail width, which is W1/W2's
+   input. Must land before the geometry work or you measure a moving target.
+3. **W4** (PR B, 2nd commit) — same file, same parity question, no geometry.
+4. **W1 + W2** (PR C, one PR) — they are one implementation. W2's `--fit` scalar *is* W1's
+   shrink; W1 contributes the width term. Splitting them produces two conflicting `.rail`
+   overrides at equal specificity where source order decides.
+5. **W8** (PR C, 3rd commit) — one line, measured after W1's shrink lands.
+6. **W6 → W7** (PR D, one PR, that order) — until you know `#app.skin-hud` is what renders,
+   every colour you measure in that file is wrong. That trap misled the original review.
+7. **W9 + W10** (PR E, one PR) — server and client halves of one feature.
+
+Four things will bite you. All are written up in the spec; re-read those sections before
+writing them:
+
+1. **The checked-in harness is stale and does not say so.** `development/web-ui-review/harness/index.html`
+   is a build of `c02f8e67` — 965 lines against dev's 1783, predating PR #160 and the whole
+   EXPERIMENT drawer. Its mtime lies. Rebuild with the spec's recipe (copy `build.sh` out,
+   pass an explicit tree, check the line counts match) and never measure the checked-in copy.
+2. **W3's fix is not where `PLAN.md` sends you.** `--box-text` is CSS-only by deliberate design
+   (`design_tokens.py:12-16` explains why), applied by the generic `.box` rule — so editing the
+   token recolours every status box, not just DROP. The spec gives two scoped routes.
+3. **W6's deletion as written breaks five focus rings.** The dead-palette line range in
+   `PLAN.md` is wrong. Some variables in those blocks are not shadowed by `#app.skin-hud` and
+   must survive. The spec lists which.
+4. **`origin/feature/no-camera-start` is a live merge hazard.** It adds `.box.no-cam`
+   immediately above `.box.drop`, so if it lands on `dev` before PR B, W3 collides in the same
+   hunk. Its NO CAM badge also repeats W3's defect (black on `rgb(220,30,30)` = 4.25:1, below
+   AA). Probe the code on the fetched tip, not the log — a squashed merge need not carry the
+   branch name.
+
+Gates, all local, all currently green: `ruff check src/`; `python3 -m pytest _test/ -q`;
+`shellcheck` over committed `*.sh` plus `python3 tools/check_generated_scripts.py`; the six
+contract-drift scripts (`redis_key_diff.py` needs `--cinepi-raw
+/Users/patrikeriksson/Documents/cinemate/cinepi-raw` or it exits 2 from a worktree);
+`python3 -m mkdocs build --strict`. Seven tests read the two templates as raw text and will
+fire if you move a substring they match — the spec names them.
+
+Done means:
+
+1. Each item either implemented with its proof measured, or explicitly deferred with the
+   reason. The spec gives every item a "How to prove it" with the number that counts.
+2. Before/after numbers for every geometry and contrast change, measured at 1440×800, 812×375
+   and 375×812 on a freshly rebuilt harness in `?state=warn`. A screenshot is not evidence for
+   a contrast ratio or a font size.
+3. All gates green, including the drift six.
+4. Ledger edits applied: `PLAN.md`'s portrait figure is wrong (it records 501×281, which is the
+   **landscape** measurement mis-filed; portrait is 285×160) and so is the same line in
+   `development/web-ui-review/README.md`. W8's `inset` reasoning in `PLAN.md:38-40` is also
+   wrong and needs correcting in prose.
+5. A closing summary: files touched per commit, per-item status, the measured numbers, every
+   decision taken on default, and everything left for hardware.
+
+**Never report a hardware-gated item as done.** W5 needs a physical iPhone. W1, W2, W7 and W8
+need a real finger on a real phone. W3, W4, W9 and W10 need the Pi. The spec's "What the desk
+cannot close" table says exactly what each one needs and why. Write the code, state the gate,
+stop there.
+
+Stop after that summary. Do not start a Pi session, do not run hardware gates, do not merge.

--- a/dev-track/C8-web-ui-review/WEB-UI-REVIEW-PLAN.md
+++ b/dev-track/C8-web-ui-review/WEB-UI-REVIEW-PLAN.md
@@ -1,0 +1,2330 @@
+# C8 — Web UI review: full spec (W1–W10)
+
+The implementing session is kicked off by `SONNET-PROMPT.md` beside this file, which points here.
+Read this document in full before writing code.
+
+Repo: `/Users/patrikeriksson/Documents/cinemate/cinemate`. Branch off `dev`. Ten findings, W1–W10.
+Every item was re-measured against the pinned dev tree and then adversarially re-verified. Where the
+verification contradicted the original review, the verification is what is written here.
+
+| Surface | File |
+|---|---|
+| Live web GUI | `src/module/app/templates/template.html` |
+| Settings editor | `src/module/app/templates/settings_editor.html` |
+| Shared colour table | `src/module/design_tokens.py` |
+| HDMI GUI (parity source) | `src/module/simple_gui.py` |
+| RAW pane server | `src/module/app/raw_files.py`, `src/module/app/settings_editor.py` |
+
+This document supersedes `dev-track/C8-web-ui-review/PLAN.md` wherever the two differ.
+
+| Item | What PLAN.md gets wrong |
+|---|---|
+| W1 | The framing. Settled by operator ruling, not an open ADR question |
+| W3 | The prescribed file |
+| W6 | The line range. Deleting it as written breaks five focus rings |
+| W8 | Nothing. A later "3× worse" restatement was wrong |
+| W9, W10 | Absent from PLAN.md |
+
+## Before you touch anything
+
+**Start point.** Branch off `dev`. Verified today: `origin/dev` is `c0eb9ff7`, three commits past the
+`981b6bf1` the findings were pinned at. Those three commits touch `innomaker585/ccmp12-lut/**` only —
+`git diff --name-only 981b6bf1..origin/dev | grep -v '^innomaker585/'` is empty — so no `src/`,
+`docs/`, `tools/` or `_test/` file moved and every line anchor in this document is still exact at
+`origin/dev`.
+
+**The clone is shared.** At the time of writing it was on `claude/cinemate-docs-review-h4pxp6`
+(`6663e84e`), working tree clean — another session's branch, not yours. It has moved between branches
+several times in the last day. Check before you do anything, and never `git checkout` / `git switch` /
+`git stash` over someone else's in-flight work.
+
+**`fix/web-ui-portrait` already exists, and a worktree already holds it.** Verified today:
+`git branch -a --list '*web-ui*'` returns `fix/web-ui-mobile` (merged) **and** `fix/web-ui-portrait`,
+and `git worktree list` shows the latter checked out at
+`/Users/patrikeriksson/Documents/cinemate/development/worktrees/c8-web-ui-review` at `c0eb9ff7` —
+origin/dev tip, zero commits on it. A `worktree add -b fix/web-ui-portrait` therefore aborts with
+`fatal: a branch named 'fix/web-ui-portrait' already exists`. Do **not** recover with `-B` (that
+force-resets another session's branch) and do **not** `git checkout` in the shared clone.
+
+```bash
+REPO=/Users/patrikeriksson/Documents/cinemate/cinemate
+git -C "$REPO" fetch origin dev
+git -C "$REPO" rev-parse --abbrev-ref HEAD   # note what you found; do not change it
+git -C "$REPO" worktree list | grep fix/web-ui-portrait
+
+# 1. A worktree already holds it (expected). Confirm it is unstarted, then reuse it:
+TREE=/Users/patrikeriksson/Documents/cinemate/development/worktrees/c8-web-ui-review
+git -C "$TREE" log --oneline origin/dev..HEAD    # must be empty
+git -C "$TREE" merge --ff-only origin/dev        # bring it to tip if it is behind
+
+# 2. Branch exists, no worktree — attach one, no -b:
+# git -C "$REPO" worktree add <path> fix/web-ui-portrait
+
+# 3. Neither exists — only then:
+# git -C "$REPO" worktree add <path> -b fix/web-ui-portrait origin/dev
+```
+
+Whichever path you take, that directory is `$TREE` for the rest of this document — the harness recipe
+and the `settings-editor-harness` re-point both need it. Note the existing worktree is named
+`c8-web-ui-review`, **not** `web-ui-portrait`. `development/worktrees/` is outside every tracked tree,
+which is the convention; `/private/tmp` is the convention only for a dirty-tree rescue, not for feature
+work.
+
+**`git status --porcelain` is not empty in a worktree, and that is correct.** The shared clone is clean
+today. Your worktree reports exactly four modified paths the moment it is created:
+
+```
+ M docs/images/camera-stack.png
+ M docs/images/camera-stack2.png
+ M docs/images/camera-stack3.png
+ M docs/images/check-name-image-file.png
+```
+
+That is the LFS smudge/clean asymmetry below, not your edit. **Leave them alone: never stage them,
+never `git restore` them, never `git checkout -- docs/images/`.** Treat the tree as clean if and only
+if `git status --porcelain` shows those four and nothing else.
+
+**Never `git add -A`.** This repo has a live git-LFS trap and it is armed before you add anything:
+
+| fact | evidence |
+|---|---|
+| `*.png`, `*.jpg`, `*.ipynb` route through the LFS clean filter | `.gitattributes:1-3`; `git check-attr filter -- shot.png` → `filter: lfs` |
+| Four already-committed real PNGs show as modified in a clean tree | `git status --porcelain` in a fresh checkout → ` M docs/images/camera-stack.png` ×4 |
+| A bare add rewrites them to 130-byte pointers | `git diff --stat -- docs/images/` → `Bin 53639 -> 130 bytes` (×4) |
+
+So `git add -A`, `git add .` and `git add docs/images/` all corrupt four committed images even if you
+never create a screenshot. **Add named files only, and run `git diff --cached --name-only` before every
+commit.** Harness screenshots and measurement JSON stay in the external workspace
+(`/Users/patrikeriksson/Documents/cinemate/development/web-ui-review/`) or your scratchpad — never in
+the tracked tree.
+
+**Commits.** One commit per W item. Subject line `<step>: <files> — <what>`, lowercase, em-dash
+separator:
+
+```
+w3: template.html + design_tokens.py — DROP badge to 7.61:1, warning box auto-widths
+```
+
+Body carries the detail, matching recent history (see `4b3d5093` for the house shape): what was
+measured before and after with numbers, which gate was re-run, and any deliberate HDMI/web divergence
+stated in one sentence. Recent commits carry a `Co-Authored-By:` trailer — keep it.
+
+**"In the PR body" means the commit body.** You cut **one** branch and make **one commit per W item**.
+The PR A–E groupings in *Order of work* are a landing order for a human later, not five branches. Every
+instruction below that says to state something "in the PR" goes into that item's commit body. Do not
+write a summary `.md` file for it.
+
+**Do not push.** Neither this repo nor `cinemate-handbook` (a separate repo, its own push-approval
+rule). Docs deploy from `main` only, so nothing goes live from `dev` regardless.
+
+**Ledger edits — the complete list, nowhere else.** Every in-repo text correction this batch owes is
+here. Do not hunt for them in the W sections.
+
+| File · line | Becomes | Ships with |
+|---|---|---|
+| `dev-track/C8-web-ui-review/PLAN.md:25` | "Nothing below is started. W1 is a decision, not a patch" → record that W1 is settled by the 2026-09-01 operator ruling and is an implementation task, and that W9/W10 exist and are not in the findings table | W1's commit |
+| `PLAN.md:29` | Replace 501×281 with 285×160 / 15.0%; fix column "Decide, don't patch" → the shrink-to-fit task | W1's commit |
+| `PLAN.md:42-66` | Delete the whole "W1 is an ADR question, not a CSS task" section; replace with the operator ruling. Do **not** carry forward any claim that ADR-001 contradicts B11.7 — read in context, ADR-001:250 and :378-380 constrain a *future shared layout engine*, not this file, and the two positions are compatible | W1's commit |
+| `PLAN.md:17` | "select tap targets 44×18 → 56×34" is wrong; no select is 56 wide. Use W8's measured width table | W8's commit |
+| `PLAN.md:34` | "~150 lines" → the real accounting (42 dead lines), and record that the paper palette was live outside `#app` | W6's commit |
+| `PLAN.md:38-40` | The stated reason for excluding iOS 14.0–14.4 is measurably wrong on both halves. Correct the reasoning; the exclusion itself stands | W8's commit |
+| `dev-track/README.md:29` | The C8 State cell reads "remaining 8 findings not started, W1 needs an operator decision" — both halves are now false. Restate against what actually landed | last commit of the run |
+
+Two things this table does **not** decide, and you should not decide silently:
+
+- **W9/W10 rows in PLAN.md.** They are findings the plan never had. Adding rows is reasonable; do it
+  only if you also give them evidence and disposition columns matching the existing shape. Otherwise
+  report them as candidate rows and leave PLAN.md's table at W1–W8.
+- **Which branch the ledger edits ride.** `dev-track/README.md:39-44` says implementation happens on
+  the step branch but process ledgers "are updated and committed **on this branch**"
+  (`feature/dev-track`), with `c<n>: <scope> — <outcome>` subjects. Folding them into `w1:`/`w6:`/`w8:`
+  commits on `fix/web-ui-portrait` is a deliberate deviation. Take it — a split across two branches you
+  cannot push is worse — and say so in one sentence in the report.
+
+`/Users/patrikeriksson/Documents/cinemate/development/web-ui-review/README.md:69` carries the same
+wrong 501×281. Fix it in place, but **it cannot be in any commit**: `git ls-files development/` is
+empty, that whole workspace is untracked. Say in the report that you fixed it.
+
+**Read first, in this order:**
+
+1. `dev-track/C8-web-ui-review/PLAN.md` — the original review. Read it knowing this document overrides it.
+2. `dev-track/README.md:29` (the C8 row) and `:35-47` (step convention, commit style, the `add -A` ban).
+3. `src/module/app/templates/template.html` — the whole file. It is 1783 lines and most of it is comment-documented design decisions you must not silently revert.
+4. `src/module/design_tokens.py` — all 34 lines, especially the docstring at `:12-16`.
+5. `system-review/decisions/ADR-001-gui-harmonization.md:240-260, 370-385` — the parity argument W1/W3/W4 all sit on.
+6. `docs/web-gui.md:26-43` — user-facing prose that becomes false if the rail geometry changes.
+7. `src/module/app/templates/settings_editor.html:19-186, 880-1010` — only if you are doing W6/W7.
+8. `src/module/app/raw_files.py` and `src/module/app/settings_editor.py` — only if you are doing W9/W10.
+
+## Ground truth
+
+Every line number below was read from the pinned tree today. Use them; do not rediscover the codebase.
+
+| File · lines | What is there |
+|---|---|
+| `template.html:34` | `--box-text: #000;` — CSS-only, **not** a shared token |
+| `template.html:36` | `--drop: rgb(120, 40, 180);` — generated from `design_tokens.py` |
+| `template.html:47` | `--gap: clamp(8px, 1.4vw, 22px);` (row-gap is half this) |
+| `template.html:95` | `#top-row` `gap: calc(var(--gap) * 0.5) var(--gap);` — the 4px row gap behind W8 |
+| `template.html:119-125` | `/* draw_rounded_box(): a locked parameter is drawn inverted. */` + `.group.locked .value` — W4 |
+| `template.html:127-137` | The PR #160 tap-target trade-off comment — W8's subject |
+| `template.html:138-146` | `.group select { position: absolute; inset: -8px -6px; opacity: 0; … }` |
+| `template.html:155,160` | `.badge { color: #000 }`, `.badge.sdr` — a **separate** literal from `--box-text` |
+| `template.html:183-200` | The `.rail` rule and its "scroll rather than clip" comment — W2 |
+| `template.html:203` | `.section { display:flex; flex-direction:column; align-items:center; }` |
+| `template.html:217-228` | `.box` (`color: var(--box-text)` at `:221`) |
+| `template.html:231` | `.box.small { font-size: calc(var(--box-height) * 0.48); }` |
+| `template.html:234` | `.box.drop { background: var(--drop); }` — W3's insertion point |
+| `template.html:336-337` | `#bottom-row` re-scopes `--value-size` / `--label-size` — the idiom W1 reuses |
+| `template.html:350` | `font-size: max(10px, calc(var(--value-size) * 0.44))` — PR #160's clip-name floor |
+| `template.html:404-419` | EXPERIMENT drawer comment ("opening it does NOT reflow anything") |
+| `template.html:434-435` | `#experiment` re-scopes the same properties — second instance of the idiom |
+| `template.html:563-585` | The F-297 removal comment + **the file's only `@media`** (`:579`, width-or-orientation) |
+| `template.html:623` | `<img id="stream" src="{{ stream_url }}">` |
+| `template.html:663` | `<button id="btn-fullscreen">FULLSCREEN</button>` — the only button in the row with no `title=` |
+| `template.html:683,700` | `const API = '/api/v1/cmd';` and the `fetch` that writes controls |
+| `template.html:765` | `const extra = (part === 'MONO' \|\| part.length > 3) ? ' small' : '';` |
+| `template.html:786-794` | The F-211 comment: the HDMI box never shows a count, the browser does |
+| `template.html:798-799` | ``const label = count > 0 ? `DROP ${count}` : 'DROP';`` |
+| `template.html:1618-1680` | Ten `socket.on(...)` handlers; the harness fakes exactly one |
+| `template.html:1623-1626` | `data.control_ranges` — absent from the harness mock |
+| `template.html:1760-1762` | `ResizeObserver` driving `sizePreview()` |
+| `template.html:1769` | `(el.requestFullscreen \|\| el.webkitRequestFullscreen).call(el);` — W5 |
+| `design_tokens.py:12-16` | Docstring: `--box-text` and `--sync-tint` deliberately excluded, "would invent a link that isn't real" |
+| `design_tokens.py:19-34` | `DESIGN_TOKENS` — exactly 14 entries; `"drop": (120, 40, 180)` at `:25` |
+| `simple_gui.py:15` | `from module.design_tokens import DESIGN_TOKENS` |
+| `simple_gui.py:481` | `self.colors = {` — still a hand-written table of literal tuples; only 2 of its fields read tokens |
+| `simple_gui.py:1286,1298` | `_draw_status_box(...)`; `text_color` also draws the strike-through line |
+| `simple_gui.py:1307,1470` | `TEXT_COLOR = (0, 0, 0)` — hard-coded **twice** (left rail, right rail) |
+| `simple_gui.py:1928` | `"exposure_time": "shutter_a_nom_lock"` — the HDMI lock mapping the web GUI lacks |
+| `simple_gui.py:2041` | `draw_rounded_box(...)` — the value pill; **not** what draws the DROP box |
+| `settings_editor.html:19-105` | `:root` + `prefers-color-scheme` + two `[data-theme]` blocks — W6; only **66-105** is dead |
+| `settings_editor.html:40,63` | The only two `--focus` declarations — deleting them kills five focus rings |
+| `settings_editor.html:109-112` | `body{ background: var(--bg) }` — **outside** `#app`, so `:root` is live there |
+| `settings_editor.html:174-186` | `.topbar{ overflow-x:auto; scrollbar-width:none }` + hidden webkit bar — W7 |
+| `settings_editor.html:890-911` | `#app.skin-hud{` — the palette that actually renders |
+| `settings_editor.html:980` | `<div class="app skin-hud" id="app">` — unconditional |
+| `settings_editor.html:1005` | `#saveBtn`, last child of the scrolling topbar |
+| `settings_editor.html:2204` | "Save &amp; reboot Pi" — currently only animates |
+| `raw_files.py:182` | `zf.write(f, arcname=f"{path.name}/{f.relative_to(path)}")` — zip entries already prefix the take |
+| `tools/design_token_diff.py:29-31` | Only literal `rgb(r,g,b)` / `(r,g,b)` are compared; `#000` and named colours are not |
+| `tools/design_token_diff.py:236` | `print("The 14 shared tokens above …")` — a hardcoded 14 next to a dynamic list |
+| `tools/redis_key_diff.py:150` | `--cinepi-raw` argument — the escape hatch when the sibling clone is not at `../` |
+| `.github/workflows/checks.yml:29,59,71,79` | ruff (src/ only), pytest (`-p no:randomly`), shellcheck ×2 |
+| `.github/workflows/checks.yml:92` | `# These four exist because …` — stale, six run |
+| `.github/workflows/checks.yml:97,104,107,112,115,127` | The **six** drift scripts |
+| `.github/workflows/docs.yml:48,77` | `mkdocs build --clean` (no `--strict`); deploy gated to `main` |
+| `docs/web-gui.md:29` | "fullscreen toggle" — W5's docs obligation |
+| `docs/web-gui.md:36-43` | The "scales rather than reflows" paragraph — must stay true |
+| `dev-track/README.md:29` | The C8 row. Its State cell is stale on both halves — see *Ledger edits* |
+| `ADR-001-gui-harmonization.md:250,378-380` | "a 1920 instrument panel and a phone browser should **not** share a grid" |
+
+### The design-token pipeline
+
+`src/module/design_tokens.py` is the source of record for every colour both GUIs share. `simple_gui.py`
+imports `DESIGN_TOKENS` at `:15`. The `:root` block in `template.html` is **hand-maintained on the other
+side** — there is no generator (`tools/` holds seven scripts, all checkers). Every token change is two
+edits. `tools/design_token_diff.py --repo . --strict` is the CI gate that compares them; it exits 0 at
+dev tip with 14 shared tokens, 0 drifted.
+
+Four gate properties:
+
+1. **Never hardcode, in the template, a colour the token owns.** If a colour has an entry in
+   `DESIGN_TOKENS`, edit both sides in the same commit and re-run the gate.
+2. **The gate is one-directional.** `check_shared_tokens` iterates `design_tokens.py` and looks each key
+   up in the CSS; it never walks the CSS looking for orphans. A CSS-only colour can never fail `--strict`.
+3. **It only compares literal `rgb(r, g, b)` / `(r, g, b)`** (`design_token_diff.py:29-31`). `#000` and
+   `lightgreen` are printed under "NOT COMPARABLE" and are ungated. `--box-text` is one of the two.
+4. **Adding a key without a matching CSS literal fails loudly, not silently.** Adding
+   `"box_text": (255,255,255)` while `--box-text` stays `#000` makes `RGB_RE.search("#000")` return
+   `None`, prints `<-- DRIFTED`, and `--strict` exits 1. Do not "fix" that by rewriting the CSS to
+   `rgb(0, 0, 0)` unless the item tells you to.
+
+After any colour edit, `python3 tools/design_token_diff.py --repo . --strict` must exit 0 **and**
+`--box-text  #000` must still appear under NOT COMPARABLE unless the item explicitly changes that.
+
+### The HDMI-GUI parity constraint
+
+**The rule: a web-only change to anything the HDMI GUI also draws is a divergence, and a divergence must
+be deliberate, stated in a comment at the site, and repeated in the commit body.**
+
+| Fact | Evidence |
+|---|---|
+| `simple_gui.py` draws the camera's own 1920×1080 framebuffer panel; the web GUI mirrors its regions, colours and box shapes | `template.html:119` names `draw_rounded_box()` |
+| Same "scale, never restack" model, per B11.7 / F-297 | `docs/web-gui.md:36-43` states it in user-facing prose |
+| Parity means "never restacks", not "uses the same mechanism" | `simple_gui.py:1893-1896` scales a fixed canvas by `disp_width / 1920`; the browser has no analogue and is not expected to grow one |
+| It does not reach the settings editor — W6, W7, W9, W10 are not parity-constrained | `working/changing-the-gui.md:55-60` scopes the settings editor and recovery console out of the GUI state model; they edit files on disk, not live state |
+
+## Table of contents
+
+Nothing in this list is already fixed at dev tip. Four items carry numbers that PLAN.md gets wrong;
+those corrections are at the top of each item's section.
+
+| # | Item | One line | Status vs PLAN.md |
+|---|---|---|---|
+| W1 | Portrait/narrow viewport: shrink to fit, rails pinned left and right | Preview is 285×160 = 15.0% of a 375×812 screen with 253px dead bands; shrink the rail chrome via the width term of W2's `--fit` scalar | **Task changed.** Operator ruled 2026-09-01: rails always left/right, shrink, never restack. PLAN's "decide, don't patch" framing and its 501×281 figure are both dead |
+| W2 | Left rail clips silently at short heights | 282px of rail hidden at 812×375 warn, 129px at 1440×800 (the whole SYS section), 66% hidden with the drawer open | Still true and **worse** than PLAN's 444/282: it is no longer phone-only. **W1 and W2 are one implementation** — see W2 for the mechanism |
+| W3 | DROP badge fails contrast and crowds its count | Black on `rgb(120,40,180)` = 2.761:1 (AA wants 4.5); white = 7.605:1. "DROP 17" wraps to two line boxes at every viewport | Still true. **PLAN's prescribed file is wrong** — `--box-text` is not in `DESIGN_TOKENS` and is not gated |
+| W4 | Locked reads as selected | A locked FPS / SHUTTER / ISO draws as an inverted white pill and its transparent `<select>` still opens the picker (`pointer-events: auto`) | Partially drifted; the page now ships two contradictory lock treatments. **PLAN's "FPS/SHUTTER/EI" is wrong — there is no EI group** |
+| W5 | FULLSCREEN is dead on iPhone | `(el.requestFullscreen \|\| el.webkitRequestFullscreen).call(el)` throws when both are undefined | Still true, unchanged at dev tip. Two adjacent defects found in the same 14 lines |
+| W6 | Dead theme CSS in the settings editor | **42** lines are dead, not ~150 | Partially drifted. **Deleting PLAN's range breaks five focus rings** — `--focus` is declared only at `:40` and `:63` |
+| W7 | Save can scroll out of reach | `.topbar` scrollWidth 803 vs clientWidth 375 at phone width; `#saveBtn`'s right edge sits 410px past the viewport behind a suppressed scrollbar | Still true |
+| W8 | Wrapped-portrait select overlap | Two distinct quantities: 4.000px of group intrusion and 12.00px of select-to-select overlap at 375×812. The comment's 4px is right; its "descender pixels" is wrong | Still true, and **PLAN is not wrong** — a later "3× worse" reading of it was |
+| W9 | Clip download, server half | `build_take_zip` writes a whole take to a temp file before the first byte reaches the browser | **NEW** — not in PLAN.md |
+| W10 | Clip download + destination folder, client half | `window.location` bulk download races itself; `showDirectoryPicker` is Chromium-desktop-only and needs a secure context | **NEW** — not in PLAN.md |
+
+### How each item is structured
+
+Every W section carries the same six headings, in this order.
+
+| Heading | What it holds |
+|---|---|
+| **What is wrong** | Verified evidence only: real `file:line`, real source text, real measured numbers |
+| **Current state at dev tip 981b6bf1** | Drift from PLAN.md, or an already-fixed flag |
+| **What to change** | The exact selectors, functions and code. If a change is not written as code or as a named line edit, it is not in this item — it belongs under *Decision required* |
+| **How to prove it** | The exact command or measurement, and the number that counts as proof |
+| **Constraints and risks** | CI gates, HDMI-GUI parity, interactions with other W items |
+| **Decision required from the operator** | Or "None — mechanical." |
+
+Anything marked "unverified — check first" was not measured. Do not promote it to fact, and do not
+report it as done. Enumerate them before you finish: `grep -n "unverified — check first"` over this
+document, and answer every hit in the report.
+
+## W1 — Portrait/narrow viewport: shrink to fit, rails pinned left and right
+
+**W1's task changed.** `dev-track/C8-web-ui-review/PLAN.md:29` says "Decide, don't patch" and lines
+42–66 frame W1 as an open ADR question with three options. That framing is dead. Operator ruling,
+2026-09-01: *"the left and right columns with grey boxes should always be in the left and right. not
+reflowed but rather shrunk in order to fit."* Settled consequences:
+
+| | |
+|---|---|
+| Rails | Stay left and right at **every** viewport, portrait phone included |
+| Reflow / restack | **Never.** The layout shrinks. B11.7 / `d8bfbbd1` stands |
+| PLAN option 3 (reinstate the removed portrait restack) | **REJECTED** |
+| PLAN option 1 (do nothing + "rotate your phone" hint) | **REJECTED** |
+| W1 status | Implementation task, not a decision gate |
+| W2 (left rail clipping) | **The same implementation.** One mechanism, one floor table, one fade — all of it is written in W2 |
+| Scope of the ruling | `#stage`'s three columns and `.rail`'s `flex-direction`. `#top-row`'s `flex-wrap` (W8) is a pre-existing behaviour outside it and is not in scope for the ruling |
+
+**W1's fix lives in W2's "What to change".** Do not build a second mechanism here. W1 contributes one
+thing to it: a **width** ratio, folded into the same `--fit` scalar via `Math.min`, plus two collateral
+declarations on `#stage` and `#app` that are not `.rail` properties and therefore cannot collide with
+`--fit`. Everything else below is W1's evidence, its proof gates and its own edits.
+
+Also correct before you quote it: **the plan's portrait measurement is wrong.** `PLAN.md:29` and
+`/Users/patrikeriksson/Documents/cinemate/development/web-ui-review/README.md:69` both record
+"501×281" for portrait. 501×281 is the **812×375 landscape** figure, mis-filed into the portrait row.
+Portrait is 285×160. Correcting both lines is part of this task — see *Ledger edits*.
+
+### What is wrong
+
+Measured on a harness built from template.html at `981b6bf1`, headless Chrome, `?state=idle`.
+All figures ±2px — they are font-metric dependent and differ slightly between machines.
+
+| Viewport | `#stage` `grid-template-columns` | `#preview-frame` | Frame ÷ screen |
+|---|---|---|---|
+| 375×812 portrait | `38px 285px 20px` | **285×160** | **15.0%** |
+| 375×812 portrait, `?state=dual` | `38px 267px 38px` | **267×75** | **6.6%** |
+| 812×375 landscape | `38px 708.5px 20.05px` | 502×282 | 46.5% |
+
+- `#preview-wrap` is 671.3px tall in portrait against a 160px frame — **511px of dead band**, split
+  evenly above and below by `align-items: center` (`src/module/app/templates/template.html:297-303`).
+- The preview is **width-limited, not height-limited**. `sizePreview()` at `template.html:932-948`
+  takes the `let w = avail.width` branch at :940 and never enters the `if (h > avail.height)` clamp at
+  :942. Anything that only adds vertical room is a no-op.
+- The rails cost 58px + two 8px gaps + two 8px `#app` paddings = **90px of 375 (24%)** of viewport
+  width, and the boxes are already sitting on their `:root` clamp **minimums**: at 375px wide,
+  `--box-size` = `clamp(38px, 3.6vw, 60px)` → **38px** (3.6vw = 13.5px), `--gap` → **8px**,
+  `--box-height` → **28px**, `--label-size` → **11.52px** (`template.html:47-51`). Those minimums were
+  authored for a laptop and were never re-derived for a phone.
+- W2, same root cause on the other axis: at 812×375 `?state=warn` the left rail reports `scrollHeight`
+  **542** vs `clientHeight` **260** (idle is 446 vs 282 — do not mix the two states). `.rail` has
+  `overflow-y: auto` (`template.html:192`) so it scrolls rather than clips, but there is no visible
+  affordance, so the SYS section reads as absent.
+- Ceiling arithmetic: a 16:9 picture in a 375px-wide window is at most
+  375×210.9 = **26.0%** of a 375×812 screen. With **both rails deleted outright** the frame measures
+  359×201 = **23.7%**. The old restack measures 359×201 too — identical. The vertical band is
+  geometric, not a layout defect.
+
+### Current state at dev tip 981b6bf1
+
+- The layout system is **byte-identical** to `4affc53e`, the tip PLAN.md was written against: sha256 of each
+  extracted block matches for `#app`, `#stage`, `.rail`, `#preview-wrap`, `#preview-frame`,
+  `sizePreview`. No drift. Every line number above is confirmed at the tip.
+- **Drift that changes scope:** the EXPERIMENT drawer landed *after* PLAN.md was written. Opening it at 375×812
+  fills **324.8px** of the dead band (`#experiment` = 359×324.8) at **zero cost to the preview** — the
+  frame stays 285×160, because it is width-limited. The vertical band is therefore already reclaimable
+  on demand. Do not add height-driven scaling; it would only shrink the picture.
+- **But the drawer induces W2 in portrait.** Drawer closed at 375×812: rail `scrollHeight` 671 =
+  `clientHeight` 671, no overflow. Drawer open: stage drops to 342.9 and the rail goes
+  `scrollHeight` **427** vs `clientHeight` **343**. Your fix must cover this state.
+- The surviving media query at `template.html:579` is `@media (max-width: 900px), (orientation: portrait)`.
+  The comma is an **OR**. Verified at 812×375: `(max-width:900px)` matches, `(orientation:portrait)`
+  does not — so this block **fires on landscape phones**. Do not add anything orientation-specific to it.
+- `docs/web-gui.md:36-42` already documents the intended behaviour ("The layout scales rather than
+  reflows … shrinking smoothly on a narrow or portrait screen instead of restacking"). **No docs change
+  is needed** — this task makes the code match the docs.
+- The design-token CI gate is not a risk. `css_tokens()` (`tools/design_token_diff.py:137-145`) parses
+  only the first `:root` block, and `main()` at :167-168 explicitly excludes `gap`, `value-size`,
+  `label-size`, `box-size`, `box-height` from the colour comparison.
+- Harness: rebuild it first. See **Verification and gates → Rebuild the harness**. Do not measure the
+  checked-in `index.html`. Related provenance note: `development/web-ui-review/README.md:59` heads its
+  measurement table "Measurements taken (dev `4affc53e`, before PR #160)", but the checked-in
+  `index.html` (38359 B, 965 lines) is a build of `c02f8e67`. That says nothing about when the numbers
+  were taken — it says the checked-in artifact no longer matches the tree they were taken against.
+  Treat that `index.html` as unprovenanced; do not "correct" the README heading.
+
+### What to change
+
+Pick **(b): shrink the geometry tokens.** Reject **(a): one `transform: scale()` on the stage.** Why:
+
+1. **(a) moves W1 backwards.** The preview is width-limited (proof above). `transform: scale(k<1)` on
+   `#stage` shrinks the *preview* along with the rails. To get a net win you need a second,
+   compensating `width: calc(100% / k)` — which destroys (a)'s single-number advantage.
+2. **(a) breaks `sizePreview()`.** It reads `wrap.getBoundingClientRect()` (`template.html:935`), which
+   returns **post-transform** geometry. Under a stage transform the px it writes back to
+   `#preview-frame` get scaled again, landing the frame at k². (b) leaves `sizePreview()` and
+   `#preview-frame` untouched — it changes only the rail's own tokens, so the preview is never measured
+   through a transform.
+3. **(b) is already this file's idiom, twice.** `#bottom-row` re-scopes `--value-size`/`--label-size`
+   (`template.html:336-337`); `#experiment` does the same (`template.html:434-435`).
+4. **(b) matches the shipped parity claim.** `d8bfbbd1`'s own message says the web GUI keeps its tokens
+   "all `clamp()`-based, shrinking smoothly with viewport width". Parity with `simple_gui.py` is *never
+   restacks*, not *uses a transform*. `simple_gui.py:1893-1896` is `shrink_x = disp_width / 1920` —
+   a fixed-canvas mechanism with no browser analogue that keeps text crisp.
+5. **The "multiplies tuned values" objection to (b) is answered by scoping.** Re-derive the four
+   geometry tokens on `.rail` and every dependent `calc()` follows automatically: `.rail` `gap` (:191),
+   `padding-top` (:199), `.section + .section` margin (:204), `.section .boxes` gap (:214), `.box`
+   width/height/glyph (:217-228, glyph `font-size` at :223), `#vu-meter` `padding-top` (:257). **Four
+   numbers, not twenty.**
+
+**W1 adds exactly two things to W2's mechanism. Nothing else in this section is new CSS.**
+
+**Addition 1 — the width ratio, folded into the same `--fit`.** W2's `fitRails()` computes a height
+ratio; W1 computes a width ratio in the same measurement pass and takes `Math.min`. One variable, one
+write, one floor table. **The code is W2's Edit 2 listing** — the `RAIL_WIDTH_SHARE` constant and the
+`fitW` line are already in it, marked W1. Do not write a second mechanism here.
+
+Why 0.085: each rail gets 8.5% of viewport width. At 375 that is 31.9px against a 38px natural box, so
+`fitW` = 0.839 and `--box-size` lands just above its 31px floor. The term is **inert above 447px of
+viewport width** (447 × 0.085 = 38), so nothing in landscape or on desktop changes — every viewport in
+W2's fit/floor table is ≥ 812 wide, where 812 × 0.085 = 69 exceeds even the 60px `--box-size` cap.
+
+**Addition 2 — two collateral declarations that are not `.rail` properties.** `#stage`'s gap and
+`#app`'s padding are fixed chrome around the rails; `--fit` cannot reach them and they cannot collide
+with it. One narrow-width block, placed after `:579`, containing **nothing else**. Never put a `.rail`
+declaration in it — that is exactly how two conflicting geometry mechanisms get shipped.
+
+```css
+/* Narrow width only: claw back the fixed chrome around the rails. The rails
+   themselves shrink through --fit (see fitRails), never through this block.
+   Width-keyed, so 812x375 landscape does NOT match — unlike :579, whose comma
+   is an OR and fires on landscape phones. */
+@media (max-width: 540px) {
+    #stage { gap: 6px; }
+    #app   { padding-left: 4px; padding-right: 4px; }
+}
+```
+
+Do **not** change the five existing `:root` values at `template.html:47-51` — those minimums are correct
+for a laptop. W2's Edit 1 *adds* four `*-base` siblings to that block; that is the only `:root` change
+in this PR.
+
+**The legibility floor is W2's table, not a second one.** `--box-size` 31px, `--box-height` 23px,
+`--label-size` 11px, `--gap` 6px, written into the CSS as `max()`. There is no separate W1 floor.
+
+**The overflow affordance is W2's** — `.clipped` + `.more-above` / `.more-below` with `mask-image`,
+toggled from `fitRails()` and a passive `scroll` listener. There is no `.rail.overflowing`. It is a
+**fallback only, permitted solely once the floor binds**, i.e. only if the rail still overflows after
+shrinking as far as the floor allows.
+
+**The gain, as arithmetic, at 375×812 idle.** Baseline columns are `38px 285px 20px`; the two `#stage`
+gaps are 8px each and the two `#app` paddings 8px each, and 38 + 285 + 20 + 16 + 16 = 375, which
+checks out.
+
+| Term | Before | After | Reclaimed |
+|---|---|---|---|
+| left rail (`--box-size` × 0.839) | 38.00 | 31.90 | 6.10 |
+| right rail (20.05 natural, budget 31.9 → `fitW` = 1) | 20.05 | 20.05 | 0 |
+| two `#stage` gaps | 16.00 | 12.00 | 4.00 |
+| two `#app` paddings | 16.00 | 8.00 | 8.00 |
+| **`#preview-frame` width** | **285** | **≈ 303** | **≈ 18** |
+
+≈ 303 × 170.4 ÷ (375 × 812) = **≈ 17.0%** of screen, up from 15.0%. Gate on **≥ 300px**, not 305 —
+303 ± 2px of font-metric variance. If the measurement misses, report the number; do not go below the
+floor to reach it.
+
+### How to prove it
+
+Harness: rebuild it first. See **Verification and gates → Rebuild the harness**. **Assert the viewport
+before every measurement**: `window.innerWidth`/`innerHeight` must read back exactly 375/812 or 812/375.
+Chrome's `--window-size` is ignored under `--headless=new` with `--dump-dom` on this machine (it
+silently gives a 500×725 viewport); use `preview_resize` or a fixed-size same-origin iframe. Mis-sized
+viewports are precisely how 501×281 got filed as portrait.
+
+`$` is **not** reachable from the console — it is declared at `template.html:726` inside the page-wide
+IIFE that opens at `:677`, and the file makes zero `window.X =` assignments. Every expression below uses
+`document.getElementById` / `document.querySelector`.
+
+| Check | Where | Passes when |
+|---|---|---|
+| Baseline reproduces | 375×812, `?state=idle` | frame **285×160**, cols `38px 285px 20px` (±2px) |
+| Portrait widened | 375×812, `?state=idle`, after fix | frame width **≥ 300px** (arithmetic gives 303: 375 − 31.9 − 20.05 − 12 − 8); left rail track **≤ 32px** |
+| Rails still left and right | 375×812 | `getComputedStyle(document.getElementById('stage')).gridTemplateColumns` resolves to three tracks; `#rail-left`.x < `#preview-wrap`.x < `#rail-right`.x |
+| No restack | 375×812 and 812×375 | `getComputedStyle(document.getElementById('rail-left')).flexDirection === 'column'` in both |
+| Dual improves | 375×812, `?state=dual` | frame width **≥ 285px** (was 267) |
+| W2 closed where it can be | 812×375, `?state=warn` — baseline **542 vs 260** | computed `--box-height` is **exactly 23px** (the floor binds) **and** `railL.classList.contains('clipped') && railL.classList.contains('more-below')`. Zero overflow is **not** achievable here: 13 boxes × 23px = 299px of irreducible box against a 260px viewport |
+| W2 closed where it must be | 1440×800, `?state=warn` — baseline `[638, 767, 129]` | `railL.scrollHeight - railL.clientHeight === 0` |
+| W2 with drawer | 375×812, click `#btn-experiment` — baseline **427 vs 343** | Marginal by arithmetic (`fitH` = 343/427 = 0.803 against a 0.821 box-height floor), so **either** outcome passes: `railL.scrollHeight <= railL.clientHeight + 1`, **or** `--box-height` computes to exactly 23px with `clipped` + `more-below` set. Report which one you measured |
+| Floor honoured | 375×812 and 812×375 | every row of W2's floor table holds under `getComputedStyle` |
+| Landscape not regressed | 812×375 | frame still ≥ 500×280; no rule added to the `:579` block |
+| Desktop untouched | 1440×800 | `#stage` columns and `#preview-frame` byte-identical to pre-change; `--fit` and the narrow-width block are both inert |
+| CI gate | repo root | `python3 tools/design_token_diff.py --strict` exits **0** |
+
+Expected gain: **15.0% → ≈17.0%** of screen in portrait idle. Hard ceiling with zero rails is 23.7%;
+geometric 16:9 ceiling is 26.0%. Deliverable: no clipping, rails pinned, dead horizontal band reclaimed.
+
+### Constraints and risks
+
+- **Never add rules to `template.html:579`.** `(max-width: 900px), (orientation: portrait)` is an OR and
+  fires at 812×375. Use the width-keyed block above.
+- **The narrow-width block must contain no `.rail` declaration.** A `.rail` rule inside a media query is
+  a later, equal-specificity `.rail` rule; it would silently overwrite W2's `max()` floors wholesale and
+  make `--fit` inert at exactly the viewports it exists for.
+- **Never re-add the restack.** `git show d8bfbbd1` removed it deliberately; `docs/web-gui.md:36-38`
+  documents its absence as intended behaviour. Do not touch `#stage`'s `grid-template-columns`.
+- **Scope every token override to `.rail`.** `.section`, `.section .boxes` and `.box` are shared with
+  desktop rendering; an unscoped `--box-size` change regresses 1440×800.
+- Interacts with **W3** (DROP badge contrast + auto-width warning boxes). W3's `.box.wide` makes a
+  count-carrying warning box auto-width, which is what lets "DROP 17" (41.79px at the 23px floor) live
+  in a 31px box. W3 lands first — *Order of work*, row 2. Re-measure the DROP box after W1's shrink,
+  because W1 moves the `--box-size` floor W3's auto-width sits on.
+- **W2 is the same PR and the same code.** Re-measure both in `?state=warn`, `?state=dual` and
+  drawer-open, not just `?state=idle`.
+- `tools/design_token_diff.py --strict` is safe (colour-only), but a non-zero exit means your edit
+  strayed into the `:root` block at :29-51. CI also builds mkdocs — if you touch `docs/`, keep it valid.
+- **Desk verification cannot close this.** Everything above is headless Chrome. Real iOS Safari, the
+  dynamic viewport units with the URL bar showing/hidden, safe-area insets, the home indicator and
+  actual finger accuracy are phone-on-the-rig checks. The 812×375 figures in particular are a synthetic
+  viewport and are an upper bound.
+
+### Decision required from the operator
+
+None — mechanical. The (a)/(b) sub-choice is settled as (b), the mechanism is W2's, and the legibility
+floor is W2's px table.
+
+The floor is already known to bind in four cases — W2's own fit/floor table: **812×375, 844×390,
+932×430, and 1440×800 with the drawer open.** Ship the fade fallback in those four, say so in the commit
+body, and do not go below the floor to avoid it. That is a stated outcome, not an escalation.
+
+## W2 — Left rail clips silently at short heights
+
+Single file: `src/module/app/templates/template.html`. All line numbers verified at dev tip `981b6bf1`.
+
+**Operator decision (binding, overrides anything else you read):** the left and right rails stay on the left and right at every viewport, including portrait phone. The layout never reflows or restacks — it **shrinks to fit**. Portrait restack (removed by B11.7 / F-297) is not coming back. "Rotate your phone" is not the answer. A scroll fade is a **fallback only**, permitted solely once the legibility floor below binds. The ruling scopes to `#stage`'s three columns and `.rail`'s `flex-direction`.
+
+**This section holds the whole W1 + W2 mechanism.** One `--fit` scalar, one floor table, one fade. W1 contributes the width term named in Edit 2 and the two non-`.rail` declarations in its own section.
+
+### What is wrong
+
+| Fact | Evidence |
+|---|---|
+| `.rail` is a column flex scroller | `template.html:188-200`: `display:flex; flex-direction:column; gap:calc(var(--gap)*0.5)` (:191); `overflow-y:auto` (:192); `overflow-x:hidden` (:193); `scrollbar-width:thin` (:194); `padding-top: calc(var(--box-height)*1.3)` (:199) |
+| It is an `auto` track of `#stage`'s `auto minmax(0,1fr) auto` grid | `:175-181` |
+| `#stage` is the single `1fr` row of `#app`'s `grid-template-rows: auto 1fr auto` | `:78-84` |
+| `html/body` are `overflow:hidden`, so rail content has nowhere to go but its own scroller | `:70` |
+
+The five geometry tokens are declared **exactly once**, in `:root` (:47-51), with no `@media` override and no JS `setProperty` anywhere in the file:
+
+| token | value at :47-51 |
+|---|---|
+| `--gap` | `clamp(8px, 1.4vw, 22px)` |
+| `--value-size` | `clamp(1.05rem, 2.05vw, 1.9rem)` |
+| `--label-size` | `clamp(0.72rem, 1.45vw, 1.35rem)` |
+| `--box-size` | `clamp(38px, 3.6vw, 60px)` |
+| `--box-height` | `clamp(28px, 2.5vw, 40px)` |
+
+Every clamp keys off **width only**. Nothing in the file keys off viewport height — the sole `@media` block (:579-586) is `(max-width: 900px), (orientation: portrait)` and touches only `#button-row`, `.vu-track`, `#experiment`, `.xp-slider .label`. So a wide-but-short window gets the same 40px boxes and 52px rail padding as a 1080p one, and the rail overflows.
+
+Measured (headless Chrome against a harness rebuilt from the 981b6bf1 template + unmodified `mock-io.js`; reproduced independently by a second measurement pass, pixel-for-pixel). `?state=warn` = 13 boxes:
+
+| viewport | `--box-height` | rail clientH | scrollH | hidden |
+|---|---|---|---|---|
+| 812x375 idle | 28 | 282 | 446 | 164 |
+| 812x375 warn | 28 | 260 | 542 | **282** |
+| 844x390 warn | 28 | 273 | 549 | 276 |
+| 932x430 warn | 28 | 303 | 566 | 263 |
+| 1024x600 warn | 28 | 484 | 579 | 95 |
+| 1180x700 warn | 29.5 | 566 | 628 | 62 |
+| 1280x720 warn | 32 | 575 | 678 | 103 |
+| 1366x768 warn | 34.14 | 614 | 721 | 107 |
+| 1440x800 warn | 36 | 638 | 767 | **129** |
+| 1512x850 warn | 37.8 | 682 | 804 | 122 |
+| 1600x900 warn | 40 | 730 | 841 | 111 |
+| 1920x1080 warn | 40 | 910 | 910 | 0 |
+| 1920x1080, 15-box max load | 40 | 910 | 936 | 26 |
+| 1440x800 warn, drawer open | 36 | 261 | 767 | **506** |
+| 812x375 warn, drawer open | 28 | 105 | 542 | 437 |
+
+Facts:
+
+- **It is a HEIGHT bug, not a phone bug.** Clean at 1366x1024, 1680x1050, 1728x1117, 1792x1120, 1920x1200, 2560x1440. Rail clientHeight ≈ viewportHeight − 170, and the warn content saturates at 841px once width ≥ 1600 (both clamps cap: `--gap` at w≥1571.4, `--box-height` at w≥1600). Rule of thumb: **clean above ~1050px of viewport height at any width.**
+- **Portrait 375x812 is currently clean with real slack** — 244.5px idle, 149.1px warn. (`scrollHeight == clientHeight` proves *no overflow*, never *no slack*; `scrollHeight` is `max(content, clientHeight)`. Measure true content as `[...rail.children].pop().getBoundingClientRect().bottom - rail.getBoundingClientRect().top + rail.scrollTop`.)
+- **SYS is built last** (:829-843: SER, MIC, KEY, storage, filesystem badge), so it is always the first casualty. At 812x375/warn the fully-hidden boxes are `['1.0X','48','24','MIC','KEY','SSD','ext4']`; at 1440x800/warn `['KEY','SSD','ext4']`.
+- **With the drawer open the warnings themselves vanish.** `#experiment` is a child of `#bottom` (:669), i.e. inside the third `auto` row, so it eats the same `1fr` row. Cap is `min(46vh,460px)` (:421), `40vh` on phones (:584) — 368px at 1440x800, 150px at 812x375. At 812x375/warn+drawer the fully hidden list is `['LOG12','DROP 17','SYNC','2.0','1.0X','48','24','MIC','KEY','SSD','ext4']`. Both warning boxes gone.
+- **No scrollbar is visible.** There is no `::-webkit-scrollbar` and no `scrollbar-color` anywhere in the file; only `scrollbar-width: thin` at :194 and :424. On macOS/iOS/Android overlay scrollbars reserve no width and are transparent at rest. (Unverified — check first: the headless-Chrome `offsetWidth - clientWidth == 0` measurement has no discriminating power; a control div with `overflow-y:scroll; scrollbar-width:auto` also reports 0. Do not use it as a guard. macOS "Show scroll bars: Always" is a real counter-case.)
+
+### Current state at dev tip 981b6bf1
+
+**Not fixed. No drift.** The `:root` block and the `.rail` block are byte-identical to 4affc53e. The one `@media` block grew from 4 to 8 lines, gaining only `#experiment { max-height: 40vh; }` and `.xp-slider .label { flex: 0 0 6em; }`. New since the original write-up: the EXPERIMENT drawer (`#experiment`, :420-424 / :669) now removes up to 506px of rail viewport at 1440x800/warn — that case is in scope for W2 because it changes rail height without a window resize, which is exactly what a media-query fix cannot see.
+
+### What to change
+
+**Chosen mechanism: (b) — shrink the geometry tokens, driven by one measured ratio.** Rejected: whole-stage `transform: scale()`. Reasons:
+
+1. A naive `transform: scale()` on `#stage` **does not fix this at all**. Transforms do not change layout size, so the rail's `clientHeight` in CSS px is unchanged and `scrollHeight/clientHeight` is unchanged. To make (a) work you must give `#stage` a fixed logical canvas sized `viewport / s` and re-fit on every resize *and* every drawer toggle — a re-architecture of the one element `sizePreview()` measures via the ResizeObserver at :1760-1762, with a live double-scaling hazard for the preview.
+2. **The HDMI-parity argument for (a) is materially false.** `shrink_x = disp_width/1920` / `shrink_y = disp_height/1080` are computed at `src/module/simple_gui.py:1895-1896` but reach only the top row, the layout-dict positions, the HDR badge and the clip name (:1694-1780, :1935-2007). `draw_left_sections` (:1300) and `draw_right_sections` (:1465) use hard-coded `BOX_H, BOX_W = 40, 60`, `y = 97` and absolute gaps with **no shrink factor**. There is no scaled-rail behaviour to be faithful to. (template.html:566-568's claim that simple_gui "scales its whole 1920x1080 layout by a single ratio" is only half true; fix that comment while you are in there.)
+3. **Shrinking rail geometry is the HDMI GUI's own move.** `simple_gui.py:1315-1316` tightens `BOX_GAP` 14→10 and `SECTION_GAP` 66→26 when the buffer VU shares the column, and `draw_left_sections` `return y` (:1458, comment "caller uses this to avoid VU-meter collision") feeds :2018-2025, which shrinks the VU bar between 40 and 200px to give the grown column room. The HDMI answer to "the left column grew" is already "shrink something else", not "clip it".
+4. A whole-stage scale drags `#top-row` and `#bottom` down with it for no benefit — they are not the overflowing element — and at 812x375/warn would need s = 260/541.84 = **0.48**, taking the box glyph from 17.4px to 8.3px and the section label from 11.8px to 5.7px.
+
+**Legibility floor — binding, and the only floor table in this document. Write it into the CSS as `max()`, not into a comment. It governs both the height term and W1's width term.**
+
+| property | floor | basis, measured against the shipped `DIN2014-Bold.ttf` |
+|---|---|---|
+| `--box-height` | **23px** | `.box.small` = `calc(var(--box-height) * 0.48)` (:231) → **11.04px**, the smallest rendered glyph in the rail |
+| `--label-size` | **11px** | `.section-label` font (:207) → 11px |
+| `--box-size` | **31px** | at the 11.04px small glyph: `1.85` 20.93px, `ext4` 20.39px, `NTFS` 25.26px, `exFAT` **29.15px** — fits with ~1.85px margin. `DROP 17` is 41.79px and does **not** fit; it depends on W3's `.box.wide` auto-width having landed first |
+| `--gap` | **6px** | boxes must stay visually separate |
+
+Below 11px of rendered glyph, stop shrinking and fall back to scroll + fade.
+
+**Edit 1 — factor the tokens into base + fit.** In `:root` (:47-51) keep the five names exactly as they are (`tools/design_token_diff.py` reads only the first `:root` block) and add four `*-base` siblings:
+
+```css
+--gap-base:        clamp(8px, 1.4vw, 22px);
+--label-size-base: clamp(0.72rem, 1.45vw, 1.35rem);
+--box-size-base:   clamp(38px, 3.6vw, 60px);
+--box-height-base: clamp(28px, 2.5vw, 40px);
+```
+
+Then re-derive them **on `.rail` only** (custom properties resolve at the element where they are declared, so a `--fit` set on `.rail` cannot retroactively change a `:root`-declared `--gap` — the re-declaration is required).
+
+**These are additions to the existing `.rail` rule at `template.html:188-200`, not a replacement.** Only the `padding-top` line at `:199` is rewritten. Keep `display`, `flex-direction`, `gap`, `overflow-y`, `overflow-x`, `scrollbar-width` and both comments verbatim — dropping `flex-direction: column` turns each rail into a horizontal row, a direct violation of the binding ruling, and dropping `overflow-y: auto` is the regression named in *Constraints* below. The full resulting rule:
+
+```css
+.rail {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--gap) * 0.5);
+    overflow-y: auto;
+    overflow-x: hidden;
+    scrollbar-width: thin;
+    /* NEW: W1+W2 fit. --fit is written by fitRails() and is the smaller of the
+       height ratio (rail content vs stage row) and the width ratio (rail budget
+       vs viewport). The max() floors are the legibility floor; when one binds,
+       fitRails sets .clipped and the fade fallback shows. */
+    --gap:         max(6px,  calc(var(--gap-base)        * var(--fit, 1)));
+    --label-size:  max(11px, calc(var(--label-size-base) * var(--fit, 1)));
+    --box-size:    max(31px, calc(var(--box-size-base)   * var(--fit, 1)));
+    --box-height:  max(23px, calc(var(--box-height-base) * var(--fit, 1)));
+    /* was: padding-top: calc(var(--box-height) * 1.3) at :199 — keep the
+       existing draw_left_sections() comment above it */
+    padding-top:   calc(var(--box-height) * var(--rail-pad, 1.3));
+    overscroll-behavior: contain;   /* matches #experiment:423; the rails were missed */
+}
+.rail.fitted { --rail-pad: 0.4; }   /* reclaim the dead band once we are shrinking */
+```
+
+Scope is contained: `#stage { gap: var(--gap) }` (:180) and `#app`'s padding stay on the `:root` value here — W1's narrow-width block is what moves them, and only below 540px. Everything the rail's height is built from is inside this scope — `padding-top` (:199), `.section + .section { margin-top: calc(var(--gap)*0.7) }` (:204), `.section .boxes { gap: calc(var(--gap)*0.35) }` (:214), `.box { width/height/font-size }` (:217-228, glyph at :223), and `.section-label { font-size: var(--label-size) }` (:205-210). That last one is 11.9% of the warn content at 812px wide (4 sections × 16.18px) and is **not** derived from `--gap`/`--box-height` — a gaps-only shrink cannot touch it, which is why `--label-size` must be in the fit set.
+
+**Edit 2 — measure and write `--fit`.** `$` is `document.getElementById` (:726). `render()` (:1567) is the single call site for `renderLeftRail`/`renderRightRail` (:1574-1575) and is also called by the drawer toggle (:1752). Do the fit in a `requestAnimationFrame`, **not** inline in `render()` — `render()` runs at up to 12 Hz during a take (`simple_gui.py:192-193`, `target_fps = 12`), and reading `scrollHeight` straight after `rail.replaceChildren(...)` (:843) is a forced synchronous layout on a dirty tree.
+
+This is the canonical listing. W1's width term is in it, marked. Do not write a second one.
+
+```js
+// Each rail may take at most 8.5% of the viewport width (W1). At 375 that is
+// 31.9px against a 38px natural box -> 0.839, landing --box-size just above its
+// 31px floor. Inert above 447px of viewport width (447 * 0.085 == 38), so no
+// row of the fit/floor table below changes: its narrowest case is 812 wide.
+const RAIL_WIDTH_SHARE = 0.085;
+
+let fitPending = false;
+function fitRails() {
+    fitPending = false;
+    ['rail-left', 'rail-right'].forEach((id) => {
+        const el = $(id);
+        if (!el || !el.isConnected || !el.clientHeight) { return; }
+        el.classList.remove('fitted');
+        el.style.setProperty('--fit', '1');          // measure at natural size
+        const natural  = el.scrollHeight, avail = el.clientHeight;
+        const naturalW = el.getBoundingClientRect().width;
+        const fitH = Math.min(1, avail / natural);                                   // W2, height
+        const fitW = Math.min(1, (window.innerWidth * RAIL_WIDTH_SHARE) / naturalW); // W1, width
+        const fit  = Math.min(fitH, fitW);
+        if (fit < 1) { el.classList.add('fitted'); }
+        el.style.setProperty('--fit', fit.toFixed(4));
+        // the max() floors can stop the shrink short of avail — say so out loud
+        el.classList.toggle('clipped', el.scrollHeight - el.clientHeight > 1);
+    });
+}
+const scheduleFit = () => { if (!fitPending) { fitPending = true; requestAnimationFrame(fitRails); } };
+```
+
+Both ratios are read in the one `--fit: 1` pass, so the width term costs no extra reflow.
+
+Call `scheduleFit()` at the end of `render()` and observe **`#stage`**, not the rails, for geometry:
+
+```js
+if (window.ResizeObserver) { new ResizeObserver(scheduleFit).observe($('stage')); }
+```
+
+Observe `#stage` because writing `--fit` changes a rail's width, which would re-trigger a ResizeObserver on the rail itself; `#stage`'s border box is fixed by the grid and only its columns redistribute, so this cannot loop. `#stage`'s height *does* change when the drawer opens — which is the case a media query cannot catch.
+
+**Edit 3 — fallback fade, only when `.clipped`.** Use `mask-image` on `.rail` itself, not a `::after`: a pseudo-element inside a scroll container scrolls away with the content; a mask paints in the container's own box (verified in Chrome — `mask-origin` computes to `border-box` and the computed `maskImage` is byte-identical after `rail.scrollTop = rail.scrollHeight`). Ship `-webkit-mask-image` for Safari < 15.4. Do **not** use `animation-timeline: scroll()` — Chrome-only in the iOS-relevant window. Place after the `.rail` block (:200) and before `.rail:empty` (:201); keep the new rules property-disjoint from `display` so `.rail:empty`'s higher specificity never bites.
+
+```css
+.rail.clipped.more-below { -webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 26px), transparent);
+                                   mask-image: linear-gradient(to bottom, #000 calc(100% - 26px), transparent); }
+.rail.clipped.more-above { -webkit-mask-image: linear-gradient(to bottom, transparent, #000 14px);
+                                   mask-image: linear-gradient(to bottom, transparent, #000 14px); }
+.rail.clipped.more-above.more-below { -webkit-mask-image: linear-gradient(to bottom, transparent, #000 14px, #000 calc(100% - 26px), transparent);
+                                              mask-image: linear-gradient(to bottom, transparent, #000 14px, #000 calc(100% - 26px), transparent); }
+```
+
+Toggle `more-above`/`more-below` from a `scroll` listener (`{ passive: true }`) and from `fitRails`. Keep the mask off unless `.clipped` — a permanent mask forces compositing on a subtree repainted at 12 Hz.
+
+**What this closes.** `fit_needed = clientH / scrollH` (measured); `fit_floor = 23 / --box-height` (arithmetic — re-measure, do not trust):
+
+| viewport (warn) | fit needed | fit floor | outcome |
+|---|---|---|---|
+| 812x375 | 0.480 | 0.821 | floor binds → **fade fallback** |
+| 844x390 | 0.497 | 0.821 | floor binds → fade fallback |
+| 932x430 | 0.535 | 0.821 | floor binds → fade fallback |
+| 1024x600 | 0.836 | 0.821 | closed (marginal; `--rail-pad` reclaim gives headroom) |
+| 1180x700 | 0.901 | 0.780 | closed |
+| 1280x720 | 0.848 | 0.719 | closed |
+| 1366x768 | 0.851 | 0.674 | closed |
+| 1440x800 | 0.832 | 0.639 | closed |
+| 1512x850 | 0.848 | 0.608 | closed |
+| 1600x900 | 0.868 | 0.575 | closed |
+| 1920x1080, 15-box max | 0.972 | 0.575 | closed |
+| 1440x800 + drawer | 0.340 | 0.639 | floor binds → fade fallback |
+
+Every viewport in this table is ≥ 812 wide, so W1's width term is 1 in all of them and the column is unchanged by the merge. Every laptop and desktop case closes by shrinking. Phone-landscape warn and drawer-open do not: 13 boxes × 23px = 299px of irreducible box against a 260px viewport. That is arithmetic. Ship the fade fallback there.
+
+### How to prove it
+
+Harness: rebuild it first. See **Verification and gates → Rebuild the harness**. Do not measure the checked-in `index.html`.
+
+Probe: `const r = document.getElementById('rail-left'); [r.clientHeight, r.scrollHeight, r.scrollHeight - r.clientHeight, getComputedStyle(r).getPropertyValue('--fit')]`
+
+| case | baseline triple | passes when |
+|---|---|---|
+| 1440x800 `?state=warn` | `[638, 767, 129]` | third number **0**, `--fit` ≈ 0.83, computed `--box-height` ≥ 23px |
+| 1280x720 warn | `[575, 678, 103]` | third number 0 |
+| 1024x600 warn | `[484, 579, 95]` | third number 0 |
+| 1920x1080, 15-box max load | `[910, 936, 26]` | third number 0 |
+| 812x375 warn | `[260, 542, 282]` | `--box-height` == 23px exactly (floor binds) **and** `r.classList.contains('clipped') && r.classList.contains('more-below')` |
+| 812x375 warn + click `#btn-experiment`, wait 400ms | `[105, 542, 437]` | `clipped` + `more-below` still true (proves the fit re-ran on the drawer, not on a resize) |
+| 375x812 idle | content **426.52** vs clientH 671 | overflow stays 0. `--fit` ≈ **0.839** (W1's width term, not the height term) and `--box-height` ≈ 23.5px, still above the 23px floor |
+| 375x812 warn | content **518.91** vs clientH 668 | overflow stays 0 at `--fit` ≈ 0.839 — the content shrinks with the boxes, so shrinking cannot create overflow here |
+| **Operator ruling, every viewport above** | — | `getComputedStyle(document.getElementById('stage')).gridTemplateColumns` resolves to **three** tracks; `#rail-left`.x < `#preview-wrap`.x < `#rail-right`.x; `getComputedStyle(document.getElementById('rail-left')).flexDirection === 'column'`. Re-assert with `#btn-experiment` open. **A fail here voids the item regardless of the overflow numbers.** |
+
+Reachability, not just totals: `const rr = r.getBoundingClientRect(); [...r.querySelectorAll('.box')].filter(b => b.getBoundingClientRect().top - rr.top + r.scrollTop >= r.clientHeight).map(b => b.textContent)` — must return `[]` at 1440x800/warn (baseline `['KEY','SSD','ext4']`).
+
+Mask-not-a-pseudo-element test: set `r.scrollTop = r.scrollHeight`, then assert `getComputedStyle(r).maskImage` still resolves, `more-above === true`, `more-below === false`. A `::after` implementation fails this.
+
+Gate: `python3 tools/design_token_diff.py --strict` must exit 0 (it does today at 981b6bf1 — verified).
+
+Not provable from the desk: whether a finger can drag a ~31px strip that sits next to the tap-to-record `#preview-frame` (:622), and whether `mask-image` renders correctly on iOS Safari. Both need an iPhone against the rig.
+
+### Constraints and risks
+
+| item | detail |
+|---|---|
+| CI gate is inert here | `tools/design_token_diff.py:167-168` explicitly filters `("gap","value-size","label-size","box-size","box-height")` out of the colour check, and `--strict` exits 1 only on `not shared_ok` (:239-240), which compares the 14 rgb tuples in `src/module/design_tokens.py`. It is also one-directional — it never walks the CSS for strays, so **adding** `--gap-base` etc. cannot trip it. **There is no CI check that will catch a geometry regression.** Every claim above must be asserted by hand. |
+| `--*-base` names must stay prefix-compatible | The filter is `startswith(...)`, so `gap-base` / `box-size-base` / `box-height-base` / `label-size-base` all pass. `css_tokens` (:137-145) reads only the **first** `:root` block — put the new tokens there. |
+| Do not remove `overflow-y: auto` | `html/body` are `overflow: hidden` (:70). Without the rail's own scroller the `auto` grid column overruns `#stage`'s `1fr` row and the content is hard-clipped by the body with no scroll at all — strictly worse. The scroll must stay under the fit. |
+| HDMI parity | Shrinking rail geometry is not a divergence (see `simple_gui.py:1315-1316` and :1458 / :2018-2025). Cite `system-review/decisions/ADR-001-gui-harmonization.md:378-380` — "**Keep the region anchors per-surface.** The HDMI panel is a fixed-resolution instrument; the browser is not." — in the commit message so this does not read as a revert of B11.7 / F-297, whose rationale is at template.html:563-578. |
+| `overscroll-behavior: contain` | Behavioural change on iOS on the same element as the visual fix. Right call (matches :423) but land it as its own hunk so it can be reverted separately. |
+| W8 interaction — no risk | The claim that raising `#top-row`'s row-gap (`calc(var(--gap) * 0.5)`, :95) tips portrait into overflow is false. Injecting a change to `calc(var(--gap) * 1.2)` — more than double, 4px → 9.6px at 375 wide — costs portrait exactly 5px: idle headroom 244.48 → 239.48, warn 149.09 → 144.09. Tipping portrait/warn needs ~149px. |
+| W1 interaction — resolved, one mechanism | A height-only fit leaves `--fit` at 1 in portrait (244.5px of vertical slack), so the rails would never narrow there — which is the whole of W1. Both terms therefore write the **same** `--fit`: `Math.min(fitH, fitW)` in the Edit 2 listing above. There is no second variable, no second floor table, and no `.rail` declaration inside W1's media query. |
+| Repaint cost | `render()` runs at up to 12 Hz (`simple_gui.py:192-193`, `target_fps = 12`; deltas emitted at :1862, consumed at template.html:1630-1634). The rAF gate plus keeping the mask class-toggled are both load-bearing, not polish. |
+| Grep hazard | `src/module/app/templates/settings_editor.html` has an unrelated `.rail` nav-sidebar class (17 hits). Separate template, separate `<style>`, no cascade collision. Only `template.html` is in scope. |
+
+### Decision required from the operator
+
+None — mechanical. The mechanism, the sub-choice (b), and the 11px / 23px legibility floor are all settled above, and they are the same ones W1 uses.
+
+Two findings to file **separately**, not to fix here:
+
+1. **The HDMI GUI has the same bug and cannot scroll.** Walking `draw_left_sections` by hand for the warn load (y starts 97, label step `BOX_H + LABEL_SPACING` = 36, box step `BOX_H + BOX_GAP`): with `buffer_vu_meter` true (`settings.jsonc:251` default) y ends at 969 and fits; with it false y ends at 1141 and the ext4 box is drawn at 1087-1127, entirely off a 1080 canvas, with no scroll and no affordance. Worse, `draw_left_sections` is unscaled, so on a 1280x720 HDMI monitor the column still starts at y=97 with 40px boxes and runs off the bottom before SYS even with the VU meter on.
+2. **SYS-last ordering** (:829-843) is arguably the root cause on both surfaces — the storage filesystem badge, the thing `.rail`'s own comment (:183-187) says must never silently disappear, is the last thing drawn. Moving `warningBoxes()` (:794-803) out of CAM (:812) would protect DROP/SYNC, but the HDMI GUI draws them inside CAM too (`simple_gui.py:1374-1395`), so that is a divergence needing its own ADR-001 argument.
+
+## W3 — DROP badge fails contrast and crowds its count
+
+### What is wrong
+
+Two independent defects in the web GUI's DROP warning box. Both confirmed present at dev tip 981b6bf1.
+
+1. **Contrast.** `.box.drop` paints `rgb(120, 40, 180)` behind black text. WCAG 2.x ratio = **2.7612:1**. AA needs 4.5:1 for normal text and 3:1 for large bold text — this fails both, at every viewport.
+2. **Crowding.** `"DROP 17"` wraps to two lines inside the fixed box. Bare `"DROP"` (count 0) *overflows* the box and is clipped by `.rail { overflow-x: hidden; }`.
+
+Colour source, one place per surface:
+
+| What | File:line | Source text |
+|---|---|---|
+| Shared background token | `src/module/design_tokens.py:25` | `    "drop": (120, 40, 180),` |
+| Web copy of it | `src/module/app/templates/template.html:36` | `            --drop: rgb(120, 40, 180);` |
+| Only rule consuming it (background only, no `color`) | `template.html:234` | `.box.drop { background: var(--drop); }` |
+| Web text colour (NOT a token) | `template.html:34` | `            --box-text: #000;` |
+| Its sole consumer, specificity (0,1,0) | `template.html:221` | `            color: var(--box-text);` |
+| HDMI text colour, left rail | `src/module/simple_gui.py:1307` | `        TEXT_COLOR    = (0,   0,   0)` |
+| HDMI text colour, right rail | `src/module/simple_gui.py:1470` | `        TEXT_COLOR    = (0,   0,   0)` |
+
+`--drop` is the only failing box background. The five real `.box` backgrounds against black: `--box` 5.92, `--sync` 6.70, `--log-badge` 13.21, `--zoom-hi` 15.59, `--drop` **2.76**. (`--lock`, `--voltage`, `--res-switching` are foreground text colours on the black page, not box fills — `template.html:117`, `:357`, `:358`. `--sdr-badge`/`--hdr-badge`/`--wav-rec` are `.badge` fills whose text colour is an independent hardcoded `color: #000;` at `template.html:155`, unreachable from `--box-text`.)
+
+Crowding. Box pitch is `--box-size: clamp(38px, 3.6vw, 60px)` and `--box-height: clamp(28px, 2.5vw, 40px)` (`template.html:50-51`). `.box` font = `0.62 × --box-height`; `.box.small` = `0.48 ×` (`:231`). The label is built at `template.html:796-800`, and `.small` is gated on `label.length > 4` — `"DROP"` is exactly 4 characters, so bare DROP renders at the 0.62 factor.
+
+Measured against DIN2014-Bold advance widths (`DROP` 2.4550 em, `SYNC` 2.4080, `DROP 17` 3.7850, `DROP 173` 4.3250, `+0.5400` per extra digit):
+
+| Label | Class today | vw ≤1055 (38×28 box) | vw 1280 | vw 1920 |
+|---|---|---|---|---|
+| `DROP 17` | `drop small` | needs 50.87px → wraps, 26.88px tall in 28px | +12.06px | +12.67px |
+| `DROP` | `drop` (no small) | needs 42.62px → **overflows +4.62px, clipped** | +2.63px | +0.88px |
+| `SYNC` | `sync` (no small) | needs 41.80px → **overflows +3.80px, clipped** | +1.69px | fits from vw ≈1659 |
+
+The HDMI GUI does not have this defect: `_draw_status_box` auto-shrinks when the text exceeds the inner width (`simple_gui.py:1290-1293`). Measured with the repo's own font via Pillow, `DROP` is **64px** at bold 26 (left rail) and **60px** at bold 24 (right rail), both over the 56px threshold, so the redraw at bold 20 always fires. The web GUI is the surface that drifted.
+
+Sibling inconsistency: `boxes()` uses `part.length > 3` (`template.html:765`); `warningBoxes()` uses `label.length > 4` (`:799`). They disagree on any 4-character string.
+
+### Current state at dev tip 981b6bf1
+
+Nothing is fixed. `git diff --stat 4affc53e 981b6bf1 -- src/module/design_tokens.py` is empty; the token has not moved since e9299226. The template diff over the same range contains no line touching `--drop`, `--box-text`, `--box-size`, `--box-height`, `.box`, `warningBoxes` or `DROP`. `python3 tools/design_token_diff.py --repo . --strict` exits 0 today and prints `design_tokens.py entries: 14`.
+
+Corrections to numbers and scope claims commonly attached to this item, verified against the tree:
+
+- The right-rail call site is `template.html:853`, not 852. (`:852` is the `log_badge_cam1` line.) Left rail is `:812`.
+- `settings_editor.html` has a wholly separate palette and no `--drop`. "Both surfaces" = HDMI + live web GUI only.
+- `docs/simple-gui.md:27` does **not** describe the DROP colour — its "magenta" attaches to SYNC. Only `docs/troubleshooting.md:10`, `docs/sensors.md:5` and `docs/sensors.md:170` call DROP purple/magenta.
+
+### What to change
+
+Two routes for the contrast half. **Route B is recommended** and is written out below; Route A is the operator's alternative (see the last subsection).
+
+*Route B — white text on the existing purple (7.6054:1, clears AA and AAA).* There is no existing text-colour token to flip, so add a new key. Do not touch `--box-text` or `TEXT_COLOR`.
+
+1. `src/module/design_tokens.py`, inside `DESIGN_TOKENS` after line 25: `"drop_text": (255, 255, 255),`
+2. `src/module/app/templates/template.html`, **inside the first `:root` block, on any line 30–51** (line 52 is the closing `}` and the gate truncates there). Put it next to `--drop` at line 37. Literal comma-form `rgb()` only — `#fff`, `white` and `rgb(255 255 255)` all fail the gate:
+   `            --drop-text: rgb(255, 255, 255);`
+3. `template.html:234` — extend the existing rule. Specificity (0,2,0) beats `.box`'s (0,1,0) and it is already later in source order:
+   `.box.drop { background: var(--drop); color: var(--drop-text); }`
+4. `src/module/simple_gui.py` near line 21, beside `DROP_WARNING_COLOR = DESIGN_TOKENS["drop"]`: `DROP_TEXT_COLOR = DESIGN_TOKENS["drop_text"]`. Pass it instead of `TEXT_COLOR` in the two DROP draw calls only — the `TEXT_COLOR,` argument at `simple_gui.py:1381` (left rail) and `simple_gui.py:1526` (right rail). Leave `:1307` and `:1470` untouched.
+
+*Crowding half.* Add after `.box.small` (`template.html:231`):
+
+```css
+/* A warning box may carry a count ("DROP 17"). simple_gui's box is a fixed
+   60x40 and shrinks the font instead (simple_gui.py:1290-1293); the browser
+   has room. Grow on the inline axis only, from the same --box-size floor,
+   so every box that already fits keeps the rail's pitch. */
+.box.wide {
+    width: auto;
+    min-width: var(--box-size);
+    padding-inline: calc(var(--box-height) * 0.18);
+    white-space: nowrap;
+}
+```
+
+Replace `template.html:799`. Every label here is ≥4 characters, so `.small` becomes unconditional — which also fixes the bare-DROP clipping and matches the HDMI's own shrink:
+
+```js
+out.push(box(label, 'drop' + ' small' + (count > 0 ? ' wide' : '')));
+```
+
+The concatenated `' small'` is load-bearing. `_test/test_b97_web_gui_drop_count.py:43` is `self.assertIn("' small'", self.warning_boxes_body)` — an 8-character search ending in a quote. Writing `' small wide'` as one literal **fails that test** (verified by applying the edit and re-running the assertion). Either keep the `+ ' wide'` form above, or amend the test in the same commit.
+
+### How to prove it
+
+| Check | Command / measurement | Passing number |
+|---|---|---|
+| Token gate | `python3 tools/design_token_diff.py --repo . --strict; echo $?` | exit `0`; header reads `design_tokens.py entries: 15`; report gains the line `  --drop-text       (255, 255, 255)    == design_tokens.py` |
+| Token is inside the parsed block | `awk 'NR>=30 && NR<=51' src/module/app/templates/template.html \| grep -- --drop-text` | one hit |
+| Unit gates | `python3 -m pytest _test/ -q -p no:randomly` | 0 failures, specifically `test_b97_web_gui_drop_count.py` and `test_b95_sync_box_crossed_consistency.py` |
+| Contrast, measured | Paste the `ratio()` helper from **Verification and gates → WCAG contrast, in JS** (it parses the `rgb(...)` string; feeding `c.color` straight into an array destructure yields `NaN`), then: `const c = getComputedStyle(document.querySelector('.box.drop')); ratio(c.color, c.backgroundColor)` | **≥ 4.5**. Today returns 2.761. |
+| Crowding, at 1440×800, 812×375, 375×812 | `const b=document.querySelector('.box.drop'),r=b.getBoundingClientRect(); [r.width,r.height,b.scrollWidth,b.scrollHeight]` | `scrollWidth <= Math.ceil(r.width)` AND `scrollHeight <= Math.ceil(r.height)` |
+| Bare-DROP regression | same measurement with the mock count set to 0 | overflow goes from ~42.6px in a 38px box to 0 |
+| Rail jump | `document.getElementById('rail-left').getBoundingClientRect().width` and `#preview-wrap` likewise, with `drop_frame_latched` false then true | record the delta in the PR; predicted +23.0px per rail at 375px wide |
+
+Harness: rebuild it first. See **Verification and gates → Rebuild the harness**. The checked-in copy is **stale** in a way specific to this item — `index.html:605` still reads `box('DROP', 'drop')` (pre-`020910a3`, no count) and `:29` carries a `/* DROP_WARNING_COLOR */` comment the live template no longer has. Load `?state=warn`; `mock-io.js:68` already sets `drop_frame_latched: true, drop_frame_count: 17`.
+
+### Constraints and risks
+
+- **Never flip `--box-text` or `TEXT_COLOR`.** They are global. `--box-text` reaches five box background variants: default grey (white-on-`rgb(136,136,136)` = 3.54:1), `.box.log` (1.59:1), `.box.zoom-active` (1.35:1), `.box.sync` (3.14:1), `.box.drop`. Scope every change to `.box.drop` and the two DROP draw calls.
+- **The token gate proves nothing about this finding.** `tools/design_token_diff.py --strict` compares colour equality only (`:63-79`). It cannot see the applied text colour, the `.small` gating, or any contrast ratio; `--box-size`/`--box-height` are explicitly filtered out at `:167-168`. Green CI ≠ W3 fixed. CI job is `drift` in `.github/workflows/checks.yml:106-107`.
+- **HDMI-GUI parity.** The framebuffer box is a hard 60×40 (`simple_gui.py:1304`, `:1468`) and can never auto-width. `.box.wide` is a deliberate per-surface divergence. ADR-001 sanctions it — cite `system-review/decisions/ADR-001-gui-harmonization.md:378-380` ("Keep the region anchors per-surface…") in the PR or it reads as unreviewed drift.
+- **Widening the box resizes the live preview mid-record.** The rail is a content-sized `auto` grid track (`template.html:178`) whose max-content is currently `--box-size`. Measured: `.box.wide` makes it 60.95px, a **+23.0px** jump per rail; `warningBoxes()` feeds both rails (`:812` and `:853`), so a dual-sensor rig loses 45.9px = 12.2% of a 375px viewport. That reflow of the MJPEG `<img>` fires the instant DROP latches.
+- **Width is unbounded in the count** (+0.54 em per digit). Cap the rendered number — `"DROP 99+"` measures 4.3250 em, identical to three digits.
+- **Do not add any class to the SYNC box.** `_test/test_b95_sync_box_crossed_consistency.py:56-57` pins `if (V.frames_off_sync) { out.push(box('SYNC', 'sync')); }` byte-for-byte, and `.box.sync::after`'s diagonal strike (`template.html:237-244`) has a fixed 3px band tuned to a square-ish box.
+- **Cosmetic, expect it:** `DROP_TEXT_COLOR = DESIGN_TOKENS["drop_text"]` is a Subscript, so the tool's informational Python-constant scan skips it exactly as it already skips `DROP_WARNING_COLOR`. Also stale after this change but ungated: the `"The 14 shared tokens above…"` string at `tools/design_token_diff.py:236`, the VERDICT counts (16→17, 14→15), and `system-review/STATE.md:103` ("the 14 shared HDMI/web colours").
+- **Stale claim worth correcting while here:** `src/module/design_tokens.py:12-16` says `--box-text` has no equivalent on the Python side. `simple_gui.py:1307` and `:1470` both define `TEXT_COLOR = (0,0,0)`.
+
+### Decision required from the operator
+
+1. **Route A or Route B.** Route B (above) keeps the purple and turns the text white: 7.6054:1, docs stay true. Route A is the one-line token edit — lighten `--drop` to `rgb(165, 58, 245)` (4.5236:1 against black, near-fluorescent, blue channel nearly clipped) or desaturate to `rgb(150, 100, 205)` (5.0012:1). Route A changes a recognised on-camera alarm colour and contradicts `docs/troubleshooting.md:10`, `docs/sensors.md:5`, `docs/sensors.md:170`; `tools/docs_drift_check.py` does not check colour words, so nothing will catch it.
+2. **Accept the ~23px-per-rail preview shrink at latch time, or reserve the width permanently** via a `min-width` on `.rail` (never jumps, permanently narrower picture at every viewport).
+3. **Cap the drop count?** Realistic magnitude on a bad take is unknown — needs a Pi or real take logs (unverified — check first). Without a cap the rail width is unbounded.
+4. **SYNC overflows too** (+3.80px at the clamp floor, clipped at every viewport below ≈1659px — that is where `--box-size: 3.6vw` reaches SYNC's 59.72px, not the 1666.67px where `--box-size` hits its 60px cap). The real defect is "any 4-letter warning label rendered without `.small`". Fixing SYNC requires editing `_test/test_b95_sync_box_crossed_consistency.py` in the same commit. Fix it here, or file it separately?
+5. **Does white DROP text read on the physical HDMI panel** at real viewing distance and brightness? sRGB maths is a proxy; the panel has its own gamma. Needs eyes on cinepi.local. The geometry half of parity needs no device — it is derivable from the repo's own font file.
+
+## W4 — Locked reads as selected
+
+Nothing here is fixed at dev tip. All file paths are relative to the repo root; all line numbers are verified at `981b6bf1`.
+
+### What is wrong
+
+A locked FPS / SHUTTER / ISO draws as an inverted white pill in the web GUI top row, and a fully live, invisible `<select>` sits on top of it. The pill says "this parameter is frozen"; the control under it opens a picker, accepts a value, and posts a command.
+
+| Fact | Location | Source text |
+|---|---|---|
+| The only locked styling | `src/module/app/templates/template.html:119-125` | `/* draw_rounded_box(): a locked parameter is drawn inverted. */`<br>`.group.locked .value { background:#fff; color:#000; border-radius:5px; padding:0 0.22em; }` |
+| The overlay is live | `template.html:138-146` | `.group select { position:absolute; inset:-8px -6px; opacity:0; border:0; cursor:pointer; ... }` |
+| No lock guard on any top-row handler | `template.html:1734-1736` | `$('s-shutter').addEventListener('change', (e) => cmd('set shutter a ' + e.target.value));` |
+| Only 3 groups get `.locked` | `template.html:993-995` | `toggle('locked', Boolean(V.fps_lock / V.shutter_a_nom_lock / V.iso_lock))` |
+| HDMI GUI source of the pill | `src/module/simple_gui.py:1959-1961` | `self.draw_rounded_box(draw, value, position, font_size, 5, "black", "white", image)` — `radius = 5` at `simple_gui.py:2049` |
+
+Three verified consequences.
+
+1. **The toast never says "locked".** FPS and ISO setters return before any Redis write (`cinepi_controller.py:1024` `if self.fps_lock and not self.lock_override:`; `cinepi_controller.py:2006` `if not self.iso_lock:` wrapping the body). `cli_commands.py:225` then answers `True, f"requested {requested_value}, live value is {actual}"`, `api.py:78` renders `ok <message>`, and `template.html:707` toasts `set fps 30 → requested 30.0, live value is <n>`. `grep -rn "is locked" src/module/` returns only `template.html:1096, 1102, 1108` — EXPERIMENT-drawer `lockLabel` strings. The exact digits of `<n>` are a runtime fact (raw Redis string) — unverified, needs a device.
+2. **SHUTTER is not refused at all — the pill lies.** `template.html:1735` sends `set shutter a`, routed by `cli_commands.py:59` to `set_shutter_a`. That function (`cinepi_controller.py:2012-2076`) contains no read of `shutter_a_nom_lock` anywhere — only the threading lock `parameters_lock_obj` and sync-mode clamping. The guard lives in `set_shutter_a_nom` (`cinepi_controller.py:2082 if not self.shutter_a_nom_lock:`), which only the drawer calls (`set shutter a nom`, `cli_commands.py:64`). It writes `shutter_a` / `shutter_a_actual` unconditionally, and `SHUTTER_A_NOM` at `cinepi_controller.py:2049` when gated by `2046 if self.shutter_a_sync_mode == 0:`.
+3. **The browser is the outlier.** The analog pot routes through the guarded setter — `analog_controls.py:266 self._dispatch('shutter_a_nom', new_shutter_a)`. The web top row is the only operator surface that writes through a shutter lock.
+
+Two more verified gaps.
+
+- `#g-exp` never gets `.locked`. `simple_gui.py:1924-1930` `lock_mapping` includes `"exposure_time": "shutter_a_nom_lock"`, so the HDMI GUI inverts EXP under a shutter lock and the browser does not. `#g-exp` (`template.html:601`) is also the only top-row group without `.selectable` and without a `<select>`.
+- The same file already ships the opposite lock treatment for the drawer: `template.html:1494-1497` sets `entry.input.disabled = unusable`, `.disabled` class, and a named `title`; `template.html:476` `.xp-slider.disabled { opacity:0.4; pointer-events:none; }`. Two contradictory lock idioms on one page.
+
+### Current state at dev tip 981b6bf1
+
+- CSS did not drift. `.group.locked .value` at `119-125` is byte-identical to `4affc53e`.
+- The overlay GREW since the plan. `4affc53e` had `inset:0; width:100%; height:100%`; `981b6bf1` has `inset:-8px -6px` (commit `4b3d5093`, PR #160). `.group` has no border or padding, so the hit area is the group box + 16px height + 12px width, and it spans the LABEL as well as the value. Tapping the word "FPS" on a locked group opens the picker.
+- **Correction to the plan text:** the plan writes "FPS/SHUTTER/EI". There is no EI group. The third locked group is `#g-iso` (`template.html:604`, key `iso_lock`).
+- **Correction:** the plan's claim that "the reject toast already explains the refusal" is wrong. See point 1 above.
+- Cascade census: there are FOUR `.group.X .value` rules, not three — `.tinted` (116), `.switching` (117), `.locked` (120-125), `.clip` (349-354). `.clip` is later in source but sets **no colour property** (`font-size`, `overflow`, `text-overflow`, `max-width`), and `.group.clip` is used once, at `template.html:641` (bottom row), which never gets `.locked`. So `.group.locked .value` currently wins every colour tie. A new colour-setting `0-3-0 .group.X .value` rule is only dangerous if inserted **after line 125**; inserting before 120 is safe.
+
+### What to change
+
+Recommended: guard the change handlers, keep every pixel identical, name the reason. Zero visual change means zero parity risk against `simple_gui.py`. Replace `template.html:1734-1738`:
+
+```js
+// A locked parameter's setter drops the write and still answers 200
+// (cinepi_controller.set_fps / set_iso), so the only feedback today is
+// _confirm_or_ok's generic "requested X, live value is Y" — which never
+// says "locked". SHUTTER is worse: the top row sends `set shutter a`,
+// which never reads shutter_a_nom_lock, so the pill lies.
+const TOP_LOCKS = {
+    's-iso':     { key: 'iso_lock',           label: 'ISO is locked' },
+    's-shutter': { key: 'shutter_a_nom_lock', label: 'Shutter angle is locked' },
+    's-fps':     { key: 'fps_lock',           label: 'Frame rate is locked' },
+};
+function bindTopSelect(id, prefix) {
+    $(id).addEventListener('change', (e) => {
+        const guard = TOP_LOCKS[id];
+        if (guard && truthy(V[guard.key])) {
+            toast(guard.label);
+            renderSelectors();
+            return;
+        }
+        cmd(prefix + e.target.value);
+    });
+}
+bindTopSelect('s-iso',     'set iso ');
+bindTopSelect('s-shutter', 'set shutter a ');
+bindTopSelect('s-fps',     'set fps ');
+bindTopSelect('s-wb',      'set wb ');
+bindTopSelect('s-res',     'set resolution ');
+```
+
+- `truthy` (`:733`), `toast` (`:689`), `renderSelectors` (`:1040`) and `V` (`:717`) are all already in scope.
+- The three label strings live today only inside `XP_SLIDER_GROUPS` (`:1096`, `:1102`, `:1108`). Hoist them to one shared const that both the drawer and `TOP_LOCKS` read. Do not create a fourth copy — this repo has CI gates specifically because duplicated facts drift.
+- **`renderSelectors()` does not reliably restore SHUTTER.** `template.html:1042-1043` passes `steps.shutter_a.find((v) => String(v) === String(parseFloat(V.shutter_speed)))` as `current`; `find` returns `undefined` on no match, and `fillSelect` at `:748` is guarded by `if (current !== undefined && current !== null)`. `V.shutter_speed` is a formatted string (`f"{actual_angle_f:.1f}°"`, `simple_gui.py:750`). If the live angle is absent from the step table the rejected pick stays visible. Either set `e.target.value = String(<live value>)` explicitly in the guard branch, or fix the `find` fallback. iso/fps are unaffected.
+
+Optional companion, still zero visual change — add beside `template.html:993-995`:
+
+```js
+$('s-fps').title = V.fps_lock ? 'Frame rate is locked' : '';
+$('s-fps').setAttribute('aria-disabled', V.fps_lock ? 'true' : 'false');
+```
+
+Rejected alternatives, with the reasons:
+
+| Option | Why not |
+|---|---|
+| `.group.locked select { pointer-events:none; }` | Touch/mouse only. The `<select>` stays in the tab order and keyboard-operable, so Tab + ArrowDown still fires `change` and still POSTs. And it removes the only feedback the operator gets today — nothing else in `.group` has a click handler (the only nearby listener is `template.html:1740` on `#preview-frame`), so the tap becomes wholly inert. |
+| Lock glyph in the pill | Not renderable in both GUIs. `DIN2014-Bold.ttf` cmap: U+1F512 PADLOCK absent, U+25A0 / U+25CF / U+2219 absent; only U+00B7 and U+2022 survive. `simple_gui._get_font` (`:688-696`) loads the same TTF through PIL, so a padlock is `.notdef` there and falls back to colour emoji in the browser. |
+| Red ring via `box-shadow: 0 0 0 2px var(--lock)` | Viable but visual, so it needs a mirrored change in `draw_rounded_box` (`simple_gui.py:2041`). Operator call — see below. Use `box-shadow`, never `border`, so the top row does not reflow. |
+
+### How to prove it
+
+| Check | Command / expression | Proof value |
+|---|---|---|
+| Toast never says "locked" | `grep -rn "is locked" src/module/` | Exactly 3 hits, all `template.html:1096/1102/1108` |
+| Locked pill computed style | `getComputedStyle(document.querySelector('#g-fps .value'))` | `backgroundColor rgb(255,255,255)`, `color rgb(0,0,0)`, `borderRadius 5px` |
+| Hit-area overshoot | `const g=document.getElementById('g-fps').getBoundingClientRect(), s=document.querySelector('#g-fps select').getBoundingClientRect(); [s.height-g.height, s.width-g.width]` | `[16, 12]` today |
+| Pill padding sanity | `getComputedStyle(document.querySelector('#g-iso .value')).paddingLeft` at 1280px viewport | `5.7728px` (0.22 × 26.24px); `3.696px` at 375px (0.22 × 16.8px floor) |
+| FPS refusal path | `set fps lock 1`, then `curl -s -X POST -H 'Content-Type: text/plain' --data 'set fps 30' http://cinepi.local/api/v1/cmd` | HTTP 200, body `ok requested 30.0, live value is <old fps>` |
+| **SHUTTER write-through (needs a Pi)** | `set shutter a nom lock 1`; note `redis-cli get shutter_a`; `curl -s -X POST --data 'set shutter a 45' .../api/v1/cmd` | Bare `ok` AND `redis-cli get shutter_a` returns `45` ⇒ the lock is cosmetic. Unchanged ⇒ refuted. |
+| After the fix | pick a value on a locked group | Toast reads exactly `ISO is locked` / `Shutter angle is locked` / `Frame rate is locked`; no POST in DevTools Network; select shows the live value |
+| CI | `python3 tools/design_token_diff.py --repo . --strict` and `python3 tools/gui_field_extract.py --repo . --max-unresolved 0` | Both exit 0 |
+
+Harness caveat — **the measurement harness cannot show this case as it stands.** `development/web-ui-review/harness/mock-io.js:70-74` sets `iso_lock: true, fps_lock: true, shutter_a_sync: true` and **no** `shutter_a_nom_lock`, so `?state=warn` never showed a locked SHUTTER. Hand-add `shutter_a_nom_lock: true` to a mock state before measuring. Build and serve per **Verification and gates → Rebuild the harness** (`build.sh:16` defaults `REPO` to the shared clone, which is on another session's branch — always pass `$TREE`).
+
+### Constraints and risks
+
+- **Parity is a stated contract.** `template.html:8-11` says the browser and the on-camera monitor "read as one instrument", and the locked rule's own comment names `draw_rounded_box()`. There is no CI gate on it — only that comment. Any pixel change to `.group.locked .value` must be mirrored at `simple_gui.py:1961`. The recommended fix changes no pixels.
+- Inverse mode is already faithful: `body.inverse` (`template.html:58-62`) rebinds only `--label`, `--value`, `--sync-tint`, so the hardcoded `#fff`/`#000` survive, mirroring `simple_gui`'s hardcoded `"black"`/`"white"`.
+- Cascade: insert any new `.group.X .value` colour rule **before** line 120, never after 125.
+- **`design_token_diff.py` only checks Python → CSS.** `check_shared_tokens()` (`tools/design_token_diff.py:56-79`) iterates `DESIGN_TOKENS` and reports MISSING/DRIFTED; there is no reverse pass, and `:root` already declares 21 `--` names against 14 Python entries with CI green. A new CSS-only token would NOT fail the build. Reuse `var(--lock)` for style reasons, not CI reasons.
+- `--lock` / `DESIGN_TOKENS["lock"]` renders nowhere today. `parameters_lock` is assigned exactly once in the tree — `cinepi_controller.py:179 self.parameters_lock = False` — and is only read at `simple_gui.py:1134`. `all_lock` is a different, live attribute. So reusing `--lock` has zero collision, but no operator has ever seen it.
+- "Light pill with black text = ON" collision: `template.html:395 button.on { background: var(--log-badge); color:#000; }` with `--log-badge: rgb(205,205,205)`, used by the drawer's `ISO LOCK` / `SHUTTER LOCK` / `FPS LOCK` buttons (`:1551`). A lit lock button and a locked value pill are two light pills meaning different things. Any brighter locked treatment pushes further into that vocabulary.
+- **Do not close the backend hole in this PR.** Adding a `shutter_a_nom_lock` early return to `cinepi_controller.set_shutter_a` (`:2012`) also hits `set_fps`'s motion-blur snap (`cinepi_controller.py:987 self.set_shutter_a(closest_shutter_angle)`) and, critically, the ClearHDR self-heal, which calls it deliberately at `cinepi_multi.py:1045` and `:1049` with a docstring (`:1028-1033`) saying it must go through the real setter rather than a direct Redis write. A guard there would silently disable ClearHDR self-heal whenever SHUTTER LOCK is on. Controller-level change, Pi-gated, separate PR.
+- Interaction with W8: making a locked select inert (option b) would hand the ~4px of wrapped-row overlap to the row above, turning a static ambiguity into a state-dependent hit target. The recommended fix avoids this — the select stays live, only the write is guarded.
+- Docs: `docs/web-gui.md:86-89` documents the drawer's lock behaviour and says nothing about the top row. `grep -n "template" tools/docs_drift_check.py` returns nothing, so the docs gate will NOT catch this. Add the line by hand.
+- One media query exists in the whole stylesheet (`template.html:579-586`) and contains no `.group`, `.value`, `select` or lock rule. Nothing changes by viewport.
+
+### Decision required from the operator
+
+1. **Inert or explicit?** On a locked parameter, should the web GUI be silently inert (closest to the HDMI GUI, where a locked rotary simply does nothing) or explicitly refuse with a named reason (closest to what a touch instrument owes its operator)? The recommended fix assumes explicit. Both keep the pixels identical.
+2. **Should `#g-exp` get `.locked` under `shutter_a_nom_lock`,** matching `simple_gui.py:1928`? Cheap to close, but it puts a lock pill on a read-only field.
+3. **Is a visible per-parameter lock affordance wanted at all,** given the HDMI GUI has none? If yes, `simple_gui` must grow one too, and DIN2014 cannot draw a padlock — the cost is a font file or new `ImageDraw` primitives.
+4. **Should the SHUTTER backend hole be filed as its own finding?** It reclassifies W4: "polish, not correctness" holds for FPS and ISO only.
+
+## W5 — FULLSCREEN is dead on iPhone
+
+### What is wrong
+
+`src/module/app/templates/template.html:1764-1777` is the whole fullscreen implementation:
+
+```js
+    const fsBtn = $('btn-fullscreen');
+    function toggleFullScreen() {
+        const el = document.documentElement;
+        const active = document.fullscreenElement || document.webkitFullscreenElement;
+        if (!active) {
+            (el.requestFullscreen || el.webkitRequestFullscreen).call(el);
+        } else {
+            (document.exitFullscreen || document.webkitExitFullscreen).call(document);
+        }
+    }
+    fsBtn.addEventListener('click', toggleFullScreen);
+    document.addEventListener('fullscreenchange', () => {
+        fsBtn.textContent = document.fullscreenElement ? 'EXIT FULLSCREEN' : 'FULLSCREEN';
+    });
+```
+
+Three defects, all verified in source:
+
+| # | Defect | Evidence |
+|---|---|---|
+| D1 | `:1769` and `:1771` have no feature detect. When neither method exists, `(a \|\| b)` is `undefined` and `.call` throws a TypeError inside the click listener. | Apple's `jsc` prints `TypeError: undefined is not an object (evaluating '(el.requestFullscreen\|\|el.webkitRequestFullscreen).call')`; node/V8 prints `Cannot read properties of undefined (reading 'call')` |
+| D2 | Label never flips on prefixed-only WebKit. `:1775` subscribes to `'fullscreenchange'` only; `:1776` reads `document.fullscreenElement` only — while `:1767` *does* read `webkitFullscreenElement`. The file contradicts itself. | Safari desktop 5.1–16.3 fires only `webkitfullscreenchange` |
+| D3 | Both calls return a Promise; the return value is discarded at `:1769` and `:1771`. A rejection (untrusted gesture, permissions policy) is an unhandled rejection. | spec-mandated Promise return |
+
+Nothing catches D1. The only try/catch in the page is `:699-712` inside `cmd()`. The only `'error'` listener is `:1711`, on the MJPEG `<img>` elements. No `window.onerror`, no `unhandledrejection` handler. Strict mode is in force from `:678`, so the member access is a hard TypeError, not a no-op. `toast()` (`:689`) is never reached.
+
+`button:active { background: var(--label); color: #000; }` at `:394` inverts the button under the finger, so the dead control still gives press feedback and then does nothing.
+
+No fallback exists on this page. `grep -c -iE "<video|<canvas|<audio"` over the template returns **0**. The preview is two MJPEG `<img>` tags (`:621-629`). `HTMLVideoElement.webkitEnterFullscreen()` — the only fullscreen affordance iPhone Safari has ever exposed — has no element to be called on.
+
+Platform facts (MDN browser-compat-data, re-fetched and confirmed 2026-09-01):
+
+| Browser | `Element.requestFullscreen` | Note |
+|---|---|---|
+| Safari iOS — iPad | webkit-prefixed from 12, unprefixed from 16.4 | works; forced overlay button, swipe-down exits |
+| Safari iOS — iPhone | none, any version | BCD note verbatim: "Only available on iPad, not on iPhone." |
+| Safari desktop | webkit `requestFullscreen` 5.1, `fullscreenElement` 6, unprefixed 16.4 | this is why D2 is real |
+
+It is **iPhone**, not iOS. A UA or OS test would wrongly hide the button on iPad. caniuse still lists iOS Safari 12.0–26.6 as partial. Claims that Apple shipped iPhone element-fullscreen behind a flag in Safari 17.2 are **unverified — check first**; do not encode any version assumption either way.
+
+### Current state at dev tip 981b6bf1
+
+Not fixed. `git diff 4affc53e 981b6bf1 -- src/module/app/templates/template.html` renders `const fsBtn` / `function toggleFullScreen` / `const el = document.documentElement` as context lines. The block is byte-identical to the baseline the plan was written against. The only insertion in that region is the eight-line ResizeObserver block at `:1760-1762`.
+
+| Fact | State at 981b6bf1 |
+|---|---|
+| Markup `<button id="btn-fullscreen">FULLSCREEN</button>` | `:663`, last child of `#button-row` (`:659`), the only one of the four buttons with no `title=` |
+| `.hidden { display: none !important; }` | `:541`, specificity (0,1,0) |
+| `const show = (el, on) => el.classList.toggle('hidden', !on);` | `:732` |
+| `const truthy = (v) => ...` | `:733` |
+| `toast(msg)` | `:689` |
+| Repo-wide `btn-fullscreen` references | exactly **2**: `template.html:663` and `:1764`. (`:1776` is `fsBtn.textContent`, the variable, not the id; `PLAN.md:33` quotes `requestFullscreen`, not the id) |
+| `grep -c -i fullscreen src/module/simple_gui.py` | 0 |
+| `grep -i fullscreen` in `settings_editor.html` (4737 lines) | 0 — W5 is single-surface |
+| `docs/web-gui.md:29` | `- fullscreen toggle`, in the unconditional list opened at `:21` |
+
+### What to change
+
+Replace `src/module/app/templates/template.html:1764-1777` wholesale. Probe the methods once at wire-up, hide via the file's own `show()` helper, bind only if usable.
+
+```js
+    // iPhone Safari exposes no element-fullscreen API at all; iPad does
+    // (webkit-prefixed since iOS 12, unprefixed since 16.4). Probe the methods,
+    // never the UA, so iPad keeps the button and a future iPhone gains it. The
+    // preview is an MJPEG <img>, not a <video>, so there is no
+    // HTMLVideoElement.webkitEnterFullscreen() fallback here. Calling a missing
+    // method threw a TypeError inside the click listener that nothing caught --
+    // and button:active still flashed, so the control looked like it worked.
+    const fsBtn = $('btn-fullscreen');
+    const fsRoot = document.documentElement;
+    const fsRequest = fsRoot.requestFullscreen || fsRoot.webkitRequestFullscreen;
+    const fsExit = document.exitFullscreen || document.webkitExitFullscreen;
+    const fsActive = () => document.fullscreenElement || document.webkitFullscreenElement;
+
+    show(fsBtn, Boolean(fsRequest && fsExit));
+
+    if (fsRequest && fsExit) {
+        fsBtn.addEventListener('click', () => {
+            // Both return a promise that rejects on an untrusted gesture or a
+            // blocking permissions policy. webkitRequestFullscreen returns
+            // undefined, hence the guard.
+            const p = fsActive() ? fsExit.call(document) : fsRequest.call(fsRoot);
+            if (p && p.catch) { p.catch((err) => toast('fullscreen → ' + err.message)); }
+        });
+        // Safari and iPadOS below 16.4 fire only the prefixed event and set only
+        // document.webkitFullscreenElement, so one name and one property left
+        // the label permanently stuck on 'FULLSCREEN' there.
+        ['fullscreenchange', 'webkitfullscreenchange'].forEach((ev) => {
+            document.addEventListener(ev, () => {
+                fsBtn.textContent = fsActive() ? 'EXIT FULLSCREEN' : 'FULLSCREEN';
+            });
+        });
+    }
+```
+
+Rules for this edit:
+
+- Do **not** move the `show(fsBtn, ...)` into `render()`. One-shot at wire-up is correct and safe: `render()` runs at `:1779` and on every `gui_data_change`, calls `show()` on eleven other elements, and touches `btn-fullscreen` nowhere — the id appears only at `:663` and `:1764`.
+- Use `show()`, not `style.display`. `show()` is not always wrapped in `Boolean()` — `:895` passes `false`, `:919` passes `true`, `:925` and `:955` pass bare expressions, `:1453`/`:1550` pass `truthy(...)`. The idiom is `show(el, <anything truthy/falsy>)`. `Boolean(...)` here is fine, not mandatory.
+- Do **not** detect with `document.fullscreenEnabled`. It also goes false under a Permissions-Policy or in an iframe, which is a behaviour change. (It would not behave differently on iPhone — BCD gives it the identical iPad-only note.)
+- Do **not** UA-sniff or version-test. `if (window.ResizeObserver)` at `:1760` is the in-file precedent for a truthiness capability detect.
+- If the button is hidden rather than disabled, add a `title=` to `:663` for parity with its three siblings.
+- If `docs/web-gui.md:29` is qualified in the same PR, keep the wording free of backticked file paths — see gates below.
+
+### How to prove it
+
+| Step | Command / assertion | Proof |
+|---|---|---|
+| 1. Defect is real | `/System/Library/Frameworks/JavaScriptCore.framework/Versions/Current/Helpers/jsc -e "var el={}; try{(el.requestFullscreen\|\|el.webkitRequestFullscreen).call(el);}catch(e){print(e.name+': '+e.message);}"` | prints `TypeError: undefined is not an object (evaluating '(el.requestFullscreen||el.webkitRequestFullscreen).call')` — the exact string an iPhone console shows |
+| 2. Harness | Build and serve per **Verification and gates → Rebuild the harness**, then open `?state=idle` | page renders; a JS syntax error kills `render()` at `:1779` and yields a blank page |
+| 3. Probe is not over-eager | console: `JSON.stringify([!!document.documentElement.requestFullscreen, !!document.exitFullscreen])` | `[true,true]` on desktop — button stays visible where fullscreen works |
+| 4. Hide path | copy `harness/index.html`, edit `const fsRequest = ...` to `const fsRequest = null;`, load it, assert `document.getElementById('btn-fullscreen').classList.contains('hidden') === true` **and** `getComputedStyle(...).display === 'none'` | both true — proves `.hidden`'s `!important` (`:541`) wins |
+| 5. No throw, no listener | in that same copy install `window.addEventListener('error', e => console.log('UNCAUGHT', e.message))` and an `unhandledrejection` listener, then call `document.getElementById('btn-fullscreen').click()` programmatically (the button is `display:none`, hit-testing skips it — a real tap is impossible) | zero UNCAUGHT lines; post-fix the click dispatches to zero listeners |
+| 6. Contrast (regression baseline) | in the **unmodified pre-fix** harness, console: `delete Element.prototype.requestFullscreen; delete Element.prototype.webkitRequestFullscreen;` then `document.getElementById('btn-fullscreen').click()` | exactly one UNCAUGHT TypeError. There are no `fsRequest`/`fsExit` variables pre-fix — the lookup is inline at `:1769` — so property deletion is the only way to reproduce |
+| 7. Label | desktop browser: click FULLSCREEN, assert `textContent === 'EXIT FULLSCREEN'`; Esc, assert back to `'FULLSCREEN'`. Confirm by reading the source that both `'fullscreenchange'` and `'webkitfullscreenchange'` are registered | the prefixed path itself cannot be exercised on a current desktop browser |
+| 8. Gates | from repo root: `python3 tools/design_token_diff.py --repo . --strict`, `python3 tools/gui_field_extract.py --repo . --max-unresolved 0`, `python3 tools/docs_drift_check.py --repo . --strict` | all exit 0 (all three are 0 at 981b6bf1 today) |
+| 9. Device gate — desk CANNOT close this | load `http://cinepi.local:5000/` on a real **iPhone** over the hotspot: FULLSCREEN absent. On a real **iPad**: present, works, label flips | catches a UA-sniff regression and catches a future iOS that ships element fullscreen on iPhone |
+
+Layout is **not** a risk and needs no measurement pass. Row width was computed statically against the shipped `src/module/app/static/DIN2014-Bold.ttf` (97272 bytes, real TTF, magic `00010000`, not an LFS pointer), with `--gap: clamp(8px,1.4vw,22px)` (`:47`), `--value-size: clamp(1.05rem,2.05vw,1.9rem)` (`:48`), `button { font-size: calc(var(--value-size)*0.62); padding: 0.3em 0.7em; border: 2px }` (`:385`,`:388`,`:390`), `#button-row { gap: calc(var(--gap)*0.5) }` (`:377`), `#app` padding (`:82`):
+
+| viewport | gap px | font px | need, 4 btns | need, 3 btns | available | slack, 4 btns |
+|---|---|---|---|---|---|---|
+| 320 | 8.00 | 10.42 | 270.41 | 188.55 | 304.00 | +33.59 |
+| 375 | 8.00 | 10.42 | 270.41 | 188.55 | 359.00 | +88.59 |
+| 812 | 11.37 | 10.42 | 275.46 | 191.92 | 789.26 | +513.80 |
+| 1440 | 20.16 | 18.30 | 472.19 | 328.33 | 1399.68 | +927.49 |
+
+The row fits all four buttons on one line at every width down to 320 CSS px (narrowest shipping iPhone); wrap would only occur below ~286 px. Hiding one button cannot change `#button-row` height. CSS `gap` renders nothing around a `display:none` item. FULLSCREEN is *not* meaningfully the widest label — 5.6907 em vs EXPERIMENT's 5.6537 em, a 0.65% difference. If you recompute these numbers, note `--value-size` is **redefined** at `:434` inside the `#experiment` rule (`:420-436`); `#button-row` (`:659`) is a sibling of `#experiment` (`:669`) and uses the `:root` value.
+
+### Constraints and risks
+
+| Item | State |
+|---|---|
+| Cascade | The complete list of button selectors is `button` (`:382-393`), `button:active` (`:394`), `button.on` (`:395`), `button[disabled]` (`:396`), `.xp-row button` (`:519-523`). None sets `display`. `#button-row { display:flex }` (`:374`) applies to the container. `.hidden` is `!important` — the hide cannot lose. |
+| Media query | `@media (max-width:900px), (orientation:portrait)` (`:579`) sets `#button-row { justify-content: center }` (`:580`), specificity (1,0,0), same as `:373` but later in source so it wins. With three buttons the row still centres. No rule targets `#btn-fullscreen` at any breakpoint. |
+| HDMI-GUI parity | No divergence. `simple_gui.py` has zero `fullscreen` occurrences — it owns the DRM plane and is inherently full-screen. FULLSCREEN is web-only chrome, like EXPERIMENT. |
+| CI — token gate | `tools/design_token_diff.py:46` sets `TEMPLATE = "src/module/app/templates/template.html"`; `css_tokens()` does `src.find(":root")` and parses only the first `:root` block (`:29-52`). A JS edit ~1700 lines below cannot move it. |
+| CI — field gate | Not the only gate that reads the template. `.github/workflows/checks.yml:112` runs `tools/gui_field_extract.py --max-unresolved 0`, which opens the template at `:117`/`:133`/`:139` — `web_consumed()` does a whole-word search for every HDMI field name, `socket_events()` regexes `socket\.on\(['"]([a-z_]+)['"]`. The fullscreen block contains neither, so this edit is safe — but `web_consumed()` is *removal*-sensitive, so verify rather than assume on any future template deletion. |
+| CI — docs gate | Editing `docs/web-gui.md` is gated by `tools/docs_drift_check.py --strict` (`checks.yml:97`), which validates every backticked file citation (`CITE_RE` at `tools/docs_drift_check.py:126`) and every internal link. A qualifier containing a backticked path must name a file that exists. |
+| CI — nothing lints JS | `checks.yml` runs ruff (`src/` only), pytest, shellcheck, and the six contract-drift tools. `docs.yml` builds MkDocs. There is no HTML or JS linter and no browser test. A syntax error inside the IIFE (`:677-1780`) ships with green CI as a fully dead page. **Loading the harness after editing is mandatory, not optional.** |
+| Fullscreen is treated as protected state elsewhere | `src/module/app/__init__.py:51` suppresses the mid-take browser reload with the comment `# reload would kick the operator out of fullscreen mid-take.` Do not describe FULLSCREEN as inconsequential chrome. |
+| Adjacent bug, out of W5's brief | `template.html:1673` is `socket.on('reload_browser', () => window.location.reload());` and `app/__init__.py:58-65` fires that on a 2 s timer after every completed resolution switch while **not** recording. A full reload drops fullscreen. So on iPad and desktop — exactly where the button works — an idle resolution change kicks the operator out of fullscreen 2 s later. The guard at `:48-52` covers only the recording case. File as its own row; do not fix inside W5. |
+| Interaction with other W items | None. Single-surface (`settings_editor.html` has zero `fullscreen` hits). Note the style split: `template.html` is `const`/arrow, `settings_editor.html` is `var`/ES5 — match the file you edit. |
+
+### Decision required from the operator
+
+1. **Hide or disable.** The plan says hide. `button[disabled] { opacity: 0.45; cursor: default; }` already exists at `:396`, so `fsBtn.disabled = true; fsBtn.title = 'not supported by this browser';` is a one-line alternative that keeps the row balanced and explains itself. Layout is safe either way (table above).
+2. **Scope.** D1 (probe + hide) is W5's stated brief. D2 (label desync) and D3 (unhandled rejection) are real, verified, and in the same 14 lines. Fold them in, or land D1 only and file D2/D3 as new PLAN.md rows.
+3. **Docs.** Whether `docs/web-gui.md:29` gets a qualifier in the same PR, and with what wording — e.g. "fullscreen toggle (hidden on browsers with no element-fullscreen API, such as iPhone Safari)".
+4. **Is iPad a supported operator device?** If yes the button must survive there, and BCD flags a forced overlay button that cannot be disabled plus swipe-down-exits. Whether that is acceptable during a take is an operator call.
+5. **Which iPhone/iOS.** If the operator's phone runs an iOS that has shipped element fullscreen, the probe correctly keeps the button and the "dead on iPhone" headline is stale for that device — the unguarded `.call` at `:1769` is still a genuine defect on any engine lacking the API. Only the phone settles this.
+
+## W6 — Dead theme CSS in the settings editor
+
+**Do not execute `PLAN.md:34` literally.** It says "~150 lines of dead theme CSS … Delete the dead palettes". The real dead count is **42 lines**: 40 lines of dead `[data-theme]` palettes (66-105), plus the empty `.console` rule at 672, plus the shadowed `--line` at 47. The `:root` palette the row calls dead is live and load-bearing: it paints the raw-file drawer, every toast and the confirm modal, and it supplies the only declaration of `--focus`. Deleting it as written removes every keyboard focus indicator on the page and turns three surfaces transparent.
+
+All file references below are `src/module/app/templates/settings_editor.html` unless stated, at dev tip 981b6bf1, and every line number was re-read in the tree.
+
+### What is wrong
+
+Four palette blocks exist. Only two are dead.
+
+| Block | Lines | Status | Why |
+|---|---|---|---|
+| `:root{}` — light "paper" | 19-41 | **LIVE** | Inherited by everything outside `#app`; sole declaration of `--focus` (line 40) |
+| `@media (prefers-color-scheme: dark){ :root{} }` | 42-65 | **LIVE** | Same, when the operator's OS is dark; re-declares `--focus` at 63 |
+| `:root[data-theme="dark"]{}` | 66-85 | DEAD | Never matches |
+| `:root[data-theme="light"]{}` | 86-105 | DEAD | Never matches |
+
+Two independent facts make the "paper" palette live.
+
+1. **`--focus` is not shadowed.** `:root` declares 21 custom properties. `#app.skin-hud` (890-911) declares 20. The set difference is exactly `{--focus}`. Five rules pair `outline:none` with `box-shadow: var(--focus)`:
+
+```
+238:  .btn:focus-visible{ outline:none; box-shadow: var(--focus); }
+320:  .page-tabs button:focus-visible{ outline:none; box-shadow: var(--focus); }
+390:  .field-input:focus-visible, select.field-input:focus-visible{ outline:none; box-shadow: var(--focus); }
+409:  .toggle:focus-visible{ outline:none; box-shadow: var(--focus); }
+709:  .json-tabs button:focus-visible{ outline:none; box-shadow: var(--focus); }
+```
+
+Per CSS Custom Properties L1, `var()` inside a custom property is substituted where the property is **declared**. `--focus: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent)` therefore resolves against `:root`'s colours and inherits already-resolved into `#app`. Every focus ring on the page is currently paper-orange or amber, not HUD green.
+
+2. **Four nodes live outside `#app`.** A `<div>` balance over 980-2232 gives 305 opens / 305 closes with depth first reaching zero at **line 2232** — `#app` closes there. These are siblings, not descendants:
+
+| Element | Line | var()-dependent? |
+|---|---|---|
+| `.json-scrim#jsonScrim` | 2234 | No — literal `rgba(0,0,0,.3)` at 718 |
+| `.json-drawer#jsonDrawer` (+ head/tabs/body/foot/icon-btn, 689-725) | 2235-2249 | **Yes** |
+| `.toast#toast` (728-737) | 2251 | **Yes** |
+| `.modal-scrim#modalScrim` | 2253 | No — literal `rgba(0,0,0,.4)` at 740 |
+| `.modal#confirmModal` (+ `h3`/`p`/`.btn`s, 742-750) | 2254-2261 | **Yes** |
+
+There is no `#app.skin-hud .json-*`, `.toast` or `.modal` rule anywhere (all 42 `skin-hud` hits sit in 890-977 plus the markup at 980). So those three surfaces resolve against `:root` and flip with the operator's OS colour scheme on a page that is otherwise permanently black.
+
+Measured consequences today (recomputed WCAG 2.x, surface named):
+
+| Surface | Light OS | Dark OS | Inside `#app` |
+|---|---|---|---|
+| `#confirmModal` background | `#ffffff` | `#1a1713` | would be `#0c0b09` |
+| `#toast` bg / text | `#211d17` / `#f7f3ec` | `#f2ede4` / `#100e0c` (cream toast on black HUD) | — |
+| `.modal` / `.toast` border-radius | 5px | 5px | 0px |
+| `.json-tabs button` radius | 3px | 3px | 0px |
+| Focus ring outer, on `--panel` `#0c0b09` | `#a6631c` = 4.14:1 | `#dd9a45` = 8.23:1 | HUD `#90ee90` would be 13.88:1 |
+| Focus ring inner, on `--panel` | `#f7f3ec` = 17.79:1 | `#100e0c` = 1.02:1 (invisible) | — |
+
+Neither the media block nor the `data-theme` blocks redeclare `--radius`/`--radius-lg`, which is why the radii stay 3px/5px in both OS schemes.
+
+Genuinely dead, verified:
+
+| Item | Lines | Note |
+|---|---|---|
+| `:root[data-theme="dark"]` + `:root[data-theme="light"]` | 66-105 (40 lines) | `data-theme` appears only at 66, 86, 672 — zero hits in the 2475-line script region; `documentElement` count = 0 file-wide |
+| `:root[data-theme="light"] .console, .console{ }` | 672 | Empty body, emits nothing |
+| `--line: #33301f2b;` | 47 | Immediately overwritten by `--line: #363026;` at 48 |
+| `background: #0c0a08;` inside `.console` | 667 | Beaten everywhere by `#app.skin-hud .console{ background:#000; … }` (974); both `.console` nodes (1993, 2208) are inside `#app` |
+| Paper literals surviving inside the HUD | 667, 677-679 | `.console` `color:#d8cdb8`, `.tag-ok #8fce87`, `.tag-warn #e0ac5c`, `.prompt #7a7263`. Line 974 overrides only `background`, so these render. Not reachable by deleting `:root`, and no HUD substitute is defined anywhere. **Out of scope for W6** — file as a new PLAN.md row |
+
+### Current state at dev tip 981b6bf1
+
+- **No drift.** `git diff 4affc53e 981b6bf1 -- src/module/app/templates/settings_editor.html` = 61/37 across 30 hunks; grepping that diff for `--focus|:root|skin-hud|json-drawer|class="modal"|class="toast"` returns zero hits. The theme region is byte-identical to when the plan was written. Nothing here is already fixed.
+- **Every line number shifted +2** since 4affc53e: the first hunk is `@@ -1,4 +1,6 @@`, adding `<!DOCTYPE html>` and the viewport meta. Numbers in this section are correct at 981b6bf1. Older notes citing this file are off by two — do not "correct" a number in this section against them.
+- `grep -c 'prefers-color-scheme'` is **1** today, and that hit is line 42, the colour block itself. Line 878 is `prefers-reduced-motion` and does not match.
+- No `color-scheme:` declaration exists in the file. `services/cinemate-recovery/cinemate-recovery.py:702` has `:root { color-scheme: light dark; }` as precedent.
+
+### What to change
+
+**Option A — promote the HUD palette to `:root` (recommended).** Net effect: zero computed-style change for anything inside `#app`, and the drawer/toast/modal/focus-ring stop flipping with the OS.
+
+1. In the surviving `:root{}` (19-41), replace the 20 palette values on lines **20-39** with the `#app.skin-hud` values verbatim from **891-910**. Keep `--focus` on line 40 unchanged — it re-resolves automatically to `0 0 0 2px #050403, 0 0 0 4px #90ee90`. Add `color-scheme: dark;` to the same block.
+2. Delete lines **42-65** — the whole `@media (prefers-color-scheme: dark)` block. Now redundant.
+3. Delete lines **66-105** — both `:root[data-theme=…]` blocks. Line 106 is blank, 107 is `*{ box-sizing: border-box; }`; the cut is clean.
+4. Delete line **672**.
+5. Delete the `#app.skin-hud{ … }` variable block, lines **890-911**, only. **Keep 912-977 unchanged** — the bare `#app.skin-hud,` selector at 912 starts the DIN font override and every rule below is component behaviour, several hardcoding literals that are not tokens.
+6. Drop the now-dead `background: #0c0a08` on line **667**. Leave the three paper *text* literals on 667 and 677-679 alone — no HUD substitute exists for them and inventing one is not cleanup. They are already recorded above as a separate finding.
+7. Update `PLAN.md:34` per *Ledger edits*.
+
+**Option B — move the nodes instead** (smaller diff, no palette edit): move lines 2234-2261 to just before the `</div>` at 2232 so they become children of `#app`. Verified safe today: all four are `position:fixed`, and `.app` (134-144, plus 146 which sets only `grid-template-*`) has no `transform`, `filter`, `perspective`, `contain` or `will-change` — `grep -n 'will-change\|contain:\|perspective\|backdrop-filter'` over the file returns nothing, so the viewport stays their containing block. Fragile: adding any of those to `.app` later silently reparents four fixed elements with no test covering it. Option A has no such tripwire.
+
+**Option C — reconnect a real toggle** (the plan's fallback): only if a daylight/outdoor light mode is actually wanted. Requires a control, persistence, setting `data-theme` on `documentElement`, **and** moving the HUD palette off `#app.skin-hud` onto `:root[data-theme="hud"]` so the toggle reaches the out-of-`#app` surfaces. A toggle that only flips `#app` reproduces today's bug.
+
+**Never:** delete lines 19-41 or 42-65 without re-homing `--focus` first.
+
+### How to prove it
+
+Static. No hardware needed.
+
+| Check | Command | Proof |
+|---|---|---|
+| `data-theme` gone | `grep -n 'data-theme' src/module/app/templates/settings_editor.html` | no output |
+| media block gone (option A) | `grep -c 'prefers-color-scheme' src/module/app/templates/settings_editor.html` | `0` (was `1`) |
+| `--focus` survives | `grep -c -- '--focus' src/module/app/templates/settings_editor.html` | `6` (1 declaration + 5 consumers; was 7) |
+| Token parity inside `#app` | extract every `--name:` from the new `:root` and diff against the old `#app.skin-hud` block from `git show 981b6bf1` | identical 20 names/values, plus `--focus` and `color-scheme` |
+
+CI gates that must stay green — run all four, not just the first:
+
+```
+python3 tools/design_token_diff.py --repo . --strict          # checks.yml:107
+python3 tools/gui_field_extract.py --repo . --max-unresolved 0 # checks.yml:112
+python3 tools/link_frequency_drift_check.py --repo . --strict  # checks.yml:115
+python3 -m pytest _test/ -q
+```
+
+`design_token_diff.py` never reads this file (`TEMPLATE = "src/module/app/templates/template.html"`, line 46; it takes only `src.find(":root")`, 139-142) — a failure there means something unrelated broke. `gui_field_extract.py:160` and `link_frequency_drift_check.py:30` **do** parse `settings_editor.html`, but as regex/JS parsers, so a CSS-only edit is safe; run them anyway. Three tests read the file (`_test/test_action_catalogues_agree.py:29`, `_test/test_log_encode_normalization.py:47`, `_test/test_b95_config_defaults_consistency.py:62`); none assert on CSS, so **no test can catch a CSS regression here** — the greps above are the only guard.
+
+Browser confirmation at `http://cinepi.local:5000/settings-editor`, optional but cheap. Before the edit, with the OS in light mode: `getComputedStyle(document.getElementById('confirmModal')).backgroundColor` returns `rgb(255, 255, 255)`; in dark mode `rgb(26, 23, 19)`. After: `rgb(12, 11, 9)` in both. Regression guards, after: tab to a `.btn` and assert `getComputedStyle(btn).boxShadow !== 'none'`; open the drawer and assert `getComputedStyle(document.getElementById('jsonDrawer')).backgroundColor !== 'rgba(0, 0, 0, 0)'`; same for `#confirmModal` and `#toast`.
+
+### Constraints and risks
+
+| Risk | Detail |
+|---|---|
+| **Dropping `--focus`** | Highest. `box-shadow` becomes invalid-at-computed-value-time → initial `none`; the same rules set `outline:none`, so the page loses every keyboard focus indicator. WCAG 2.4.7 regression, silent, invisible to the suite. |
+| **Deleting `:root` 19-41 or 42-65 wholesale** | `.json-drawer`, `.toast`, `.modal` lose background/border/color/radius — transparent slabs. The toast has 30+ `showToast()` call sites and is the primary feedback channel. |
+| **Off-by-one at 47/48** | Adjacent, near-identical `--line` lines. Deleting 48 instead of 47 leaves an 8-digit hex (`#33301f2b`, alpha 0x2b) → 83%-transparent borders outside `#app` in dark OS. |
+| **Off-by-one at 672** | Line 672 also carries a bare `.console` selector. It is an empty rule, so deleting the whole line is a no-op — but deleting the real `.console{…}` at 666-671 instead breaks both consoles (1993, 2208). |
+| **Option A is a visual change** | Drawer, toast and confirm modal go from paper/warm-dark to HUD black, square corners, DIN instead of serif (the font override at 912-921 is scoped to `#app.skin-hud` descendants). Do not ship this under a "remove dead CSS" commit message. |
+| **HDMI-GUI parity** | This file's HUD palette is a hand-written second copy of `simple_gui.py`'s colours (`#90ee90` lightgreen, `#ffdd00` zoom_hi, `#ff33ff` sync, `#ff4136` lock) that `design_tokens.py` does **not** cover — only `template.html` is under the pipeline. Editing 890-911 touches that untracked duplication. Bringing it under the pipeline would require extending `design_token_diff.py`'s parser (first `:root` of `template.html` only) — out of scope for W6. |
+| **iframe** | `<iframe id="liveEmbedFrame" src="/">` at 2226 embeds `template.html`. Its palette is independent and unaffected. Any "the whole page is now one palette" claim in a commit message is false for that region. |
+| **W-item interaction** | Two, both in this document. W7 edits `.topbar` (174-186) and restructures 987-1006. W10 inserts `.clip-progress` CSS after `:793` and reads `#app.skin-hud` (890-911) as its contrast basis. Sequence W6 first — *Order of work*, row 6. |
+
+### Decision required from the operator
+
+**Yes — one call, before any code is written: A, B or C.**
+
+- The 42-line deletion (66-105 = 40, plus 672, plus 47) is mechanical and belongs in whichever option ships.
+- Whether the raw-file drawer, the toast and the confirm modal should turn HUD-black is a design decision, not a cleanup. Nothing in the repo settles it: `system-review/decisions/ADR-001-gui-harmonization.md` never mentions light/dark/theme/skin/paper (grep count 0), and there is no `docs/settings-editor.md`.
+- If a daylight/outdoor light mode is wanted, nothing should be deleted from the palettes and option C is the answer — the opposite of what the plan proposes.
+- Context for the decision: PLAN.md:34's own evidence cell says the light-scheme test "rendered dark" mid-session. That is consistent with this finding — `#app` is the one region genuinely immune. The plan recorded the symptom and drew the opposite conclusion.
+
+## W7 — Save can scroll out of reach
+
+All work is in one file: `src/module/app/templates/settings_editor.html` (the settings-editor page served at `/settings-editor`). Line numbers below are dev tip `981b6bf1` and were re-read against the tree.
+
+### What is wrong
+
+`.topbar` is a nowrap flex row that hides its own scrollbar. `#saveBtn` is its last child, so on a narrow viewport Save sits past the right edge with no scrollbar, no fade, no chevron.
+
+| Fact | Location | Source text |
+|---|---|---|
+| Topbar scrolls inside itself, scrollbar suppressed | 174-186 | `min-width: 0; overflow-x: auto; scrollbar-width: none;` and `.topbar::-webkit-scrollbar{ display:none; }` |
+| Save is the last of 10 children | 1005 | `<button class="btn btn-primary" id="saveBtn" disabled>Save changes</button>` |
+| Unsaved chip carries `hidden` | 996 | `<span class="pill" id="dirtyPill" hidden>…` |
+| `.pill` sets `display:flex` — author rule beats UA `[hidden]{display:none}` | 220 | `display:flex; align-items:center; gap:6px;` |
+| `.btn` sets `display:inline-flex; flex:0 0 auto` — same defeat, and buttons never shrink | 232-233 | `display:inline-flex; align-items:center; gap:7px;` / `flex: 0 0 auto; white-space: nowrap;` |
+| Hamburger breakpoint shows the menu button only; it does not move Save | 197 | `@media (max-width: 860px){ .hamburger{ display:flex; } }` |
+| `#saveBtn` click is the ONLY code path that PUTs either file | 3770 | `document.getElementById('saveBtn').addEventListener('click', …` |
+| "Save & reboot Pi" does not save | 2204 label; handler 4716-4724 | handler calls only `runBootSequence` (4629), which is `setTimeout` line-painting + `showToast`, zero `fetch` |
+
+Measured in headless Chrome 149 against this exact template (fonts are base64 data URIs at lines 6-7, so headless metrics equal real metrics):
+
+| Viewport | Save right edge | On screen? |
+|---|---|---|
+| 320 / 360 / 375 / 393 / 430 | 784.91 | no — 409.91 px past the edge at 375 |
+| 784 | 784.91 | no |
+| 785 | 784.91 | yes (crossover) |
+| 860 | 842 | yes |
+| 861 / 900 / 960 / 973 | 973.91 | no — desktop dead band |
+| 974+ | 973.91 | yes (crossover) |
+
+Two clip bands, not one. Crossing 861 → 860 *rescues* Save, because the 860px query drops the 232px `.brand` column (136 → 146) while the hamburger costs only 29+14=43px: net +189px. Child widths at 375px: hamburger 29.00, `.search` 60.00, `.topbar-spacer` 0.00, `#dirtyPill` 97.63, `#openJson` 132.77, `#revertBtn` 68.69, `#downloadBtn` 86.83, `#uploadBtn` 70.88, `#saveBtn` 109.13, gaps 14, padding 18 each side → `scrollWidth` 803.
+
+Save is reachable but undiscoverable: `topbar.scrollLeft = 99999` lands at 428 and Save's right edge becomes 356.91. `offsetHeight 56 − clientHeight 55` is the 1px border-bottom (178), not a scrollbar. The bar is `position: sticky`, so it never moves out of the way.
+
+Second, independent bug found in the same pass — the `hidden` attribute is inert wherever an author rule sets `display`. Verified by measurement, not inference:
+
+| Element | Line | `hasAttribute('hidden')` | computed `display` | measured size |
+|---|---|---|---|---|
+| `#dirtyPill` | 996 | true | `flex` | 97.63 px wide, renders "0 UNSAVED" permanently |
+| `#saveBtn` `#openJson` `#revertBtn` `#downloadBtn` `#uploadBtn` on the RAW/Live tabs | 997-1005 (`#openJson`'s `<button>` opens at 997; `:999` is its inner `<span id="openJsonLabel">`) | true | `flex` | 109.13 / 132.77 / 68.69 / 86.83 / 70.88 — `syncTopbarForPage()` (4570-4582) is dead for all five |
+| `#welcomeImgClear` (`.icon-action`, 797-800) | 1107 | true | `flex` | 30.00 × 30.00 — "Remove image" always visible; the toggles at 3295/3305 do nothing |
+| `#cfg-cam0-link-card` / `#cfg-cam1-link-card` (`.card`, 338-345) | 2127 / 2137 | true | `grid` | 834.00 × 88.88 each on the config tab — `card.hidden = !cfgSupportsLinkFreq(sensor)` at 3169 is dead |
+
+`[hidden]` DOES work on `#uploadInput`, the four `[data-page-lede]` `.lede` paragraphs, and both `.cfg-link-warn` spans — those have no author `display`.
+
+No keyboard escape hatch: `grep -c 'metaKey\|ctrlKey'` = **0**. No unsaved-changes guard: `grep -c 'beforeunload'` = **0**. The drawer footer (2246-2248) offers only Copy.
+
+### Current state at dev tip 981b6bf1
+
+- W7 is **still true and unfixed**. `.topbar` (174-186), the child order (987-1006), `#dirtyPill` (996) and `#saveBtn` (1005) are byte-identical to what the C8 plan reviewed.
+- The one relevant drift since the plan: PR #160 added `<!DOCTYPE html>` (line 1) and `<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">` (line 3). Before that, a 375px phone rendered at a 980px layout viewport where Save's right edge (973.91) cleared by 6.09px — visible, drawn ~41.7 physical px wide. #160 was correct, but it turned W7 from "tiny but present" to "409.91px off screen".
+- `dev-track/C8-web-ui-review/PLAN.md:25` still reads "Nothing below is started. W1 is a decision, not a patch" — stale on both halves. Correcting it is assigned in *Ledger edits*, not here.
+- Contrast is fine — this is purely reachability. `#app.skin-hud` (890-899) is the palette in force: Save enabled `#04210c` on `#90ee90` = 12.07:1; disabled 3.82:1; chip idle 5.70:1; chip dirty 5.94:1.
+
+### What to change
+
+Do **A** and **B** together. B alone leaves four dead-`hidden` defects; A alone is insufficient — with A only, `scrollWidth` drops 803 → 691 and Save needs a 674px viewport, still off screen on every phone.
+
+**A. Make `hidden` work.** Add one rule near the `.pill`/`.btn` block. Use the four-selector form — the narrower `#dirtyPill[hidden], .btn[hidden]` covers only 6 of the 8 broken sites and ships a half-fix:
+
+```css
+#dirtyPill[hidden], .btn[hidden], .icon-action[hidden], .card[hidden]{ display:none !important; }
+```
+
+The global `[hidden]{display:none !important}` is more correct but has a 25-site blast radius (10 markup `hidden` attributes, 15 `.hidden =` assignments). If you take the global form, enumerate first with `grep -o '<[^>]* hidden[ >]'` and `grep -n '\.hidden = '` and check every page tab by hand.
+
+**B. Pin Save and the chip outside the scroller.** Restructure 987-1006 — wrap the middle band, leave hamburger, chip and Save as direct `.topbar` children:
+
+```html
+<header class="topbar">
+  <button class="hamburger" id="hamburger" …>…</button>
+  <div class="topbar-scroll">
+    <label class="search">…</label>
+    <div class="topbar-spacer"></div>
+    <button class="btn btn-ghost" id="openJson" …>…</button>
+    <button class="btn btn-ghost" id="revertBtn" …>Revert</button>
+    <button class="btn btn-ghost" id="downloadBtn" …>Download</button>
+    <button class="btn btn-ghost" id="uploadBtn" …>Upload</button>
+  </div>
+  <input type="file" id="uploadInput" accept=".json,.jsonc,.txt" hidden>
+  <span class="pill" id="dirtyPill" hidden>…</span>
+  <button class="btn btn-primary" id="saveBtn" disabled>Save changes</button>
+</header>
+```
+
+Keep `.topbar-spacer` INSIDE the scroller — it is what right-aligns the ghost buttons at wide widths. `#uploadInput` genuinely computes `display:none`, so its position is free.
+
+CSS, replacing 174-186 (move `overflow-x` off `.topbar` onto the new child; delete the retargeted `.topbar::-webkit-scrollbar` rule at 186):
+
+```css
+.topbar{
+  grid-area: topbar;
+  display:flex; align-items:center; gap:14px;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--line);
+  background: var(--panel);
+  position: sticky; top:0; z-index: 20;
+  /* Only the middle band scrolls. #dirtyPill and #saveBtn are pinned outside
+     .topbar-scroll so the one action that matters cannot scroll out of reach;
+     min-width:0 still stops the PAGE scrolling sideways. */
+  min-width: 0;
+}
+.topbar-scroll{
+  flex: 1 1 auto; min-width: 0;
+  display:flex; align-items:center; gap:14px;
+  overflow-x: auto; scrollbar-width: none;
+}
+.topbar-scroll::-webkit-scrollbar{ display:none; }
+#dirtyPill, #saveBtn{ flex: 0 0 auto; }
+```
+
+No JS changes are required — there is still exactly one `#saveBtn`, so `updateDirtyPill()` (3223-3232) and `syncTopbarForPage()` (4570-4582) keep working untouched.
+
+Optional, independent, cheap: a document-level Cmd/Ctrl+S that calls `saveBtn.click()` only when `!saveBtn.disabled`, and `preventDefault()` only when it actually handles the event. Also consider a `beforeunload` guard gated on `dirtyEls.size || configDirty` — 3 lines, and today there is nothing stopping a user losing every edit.
+
+A sticky bottom save bar was considered and rejected: it needs a new element, `env(safe-area-inset-bottom)` padding, a `.main` bottom-padding change, per-page show/hide, and either moves `#saveBtn` (breaking desktop balance) or duplicates it (two elements whose `disabled`/`hidden` must stay in sync). Fix B is one wrapper div and ~6 CSS lines.
+
+### How to prove it
+
+The template has exactly ONE Jinja expression — `var API_TOKEN = {{ api_token | tojson }};` at line 2270. Substitute that one string and the file needs no Flask server.
+
+**Do not use `chrome-headless-shell`.** It is not on PATH on this machine, and `--window-size` is silently ignored under headless with `--dump-dom` here (you get a 500×725 viewport), which would invalidate every px number below. Use the `preview_*` tools against the `settings-editor-harness` config (port 8792) — note it is hard-wired to `development/worktrees/settings-editor-fixes` and must be re-pointed at `$TREE` — and set each viewport with `preview_resize`, asserting `window.innerWidth` before measuring. See **Verification and gates → Driving it with the preview_\* tools**.
+
+| Check | Baseline (must reproduce first) | Pass condition after A+B |
+|---|---|---|
+| Topbar width @375 | `.topbar` `scrollWidth` = 803, `#saveBtn` right = 784.91 | — |
+| Primary gate: Save on screen | fails at 320/360/375/393/430 | `saveBtn.getBoundingClientRect().right <= innerWidth && .left >= 0` at all five; prototype measured **302 / 342 / 357 / 375 / 412** |
+| Desktop dead band | right = 973.91 at 861/900/960/973 | right = **882** at 900px; re-check 861, 870, 973 |
+| `hidden` works | `#dirtyPill` `hasAttribute('hidden')===true` with `display:'flex'`, width 97.63 | `display:'none'`, width 0 |
+| RAW-tab leak | click `[data-page-tab="raw"]`; all five controls `display:flex`, `scrollWidth` still 803 | all five `display:'none'`; `scrollWidth` ≈ 330 |
+| Config-tab leak | click `[data-page-tab="config"]`; both link cards 834.00 × 88.88 while `hidden` | both `display:'none'`, width 0 |
+| No sideways page scroll | — | `documentElement.scrollWidth == innerWidth` at 360/375/393/430/861/900/973/1024/1440 |
+| 320px caveat | `documentElement.scrollWidth` = **352** vs innerWidth 320 **already, before any change** | must stay 352 — "not worse", not "fixed" |
+| Inner scroller still scrolls | — | `.topbar-scroll.scrollLeft = 99999` lands positive (prototype: scrollWidth 489 vs clientWidth 173 @375) and `#saveBtn`'s rect does not move |
+| Wide-width layout | `.search` = **314.05px** @1440 | `.search` ≈ **370px** @1440 — this GROWS by design. Fix A frees 97.63+14 = 111.63px inside the scroller, and `.search{flex:1 1 120px}` (200) + `.topbar-spacer{flex:1 1 auto}` (212) split it. Do **not** gate on 314 — that rejects a correct implementation. |
+| Token gate | `python3 tools/design_token_diff.py --strict` exits 0 today | still 0. It reads only `src/module/simple_gui.py` (45) and `template.html` (46) — a failure means you edited the wrong file. |
+
+Device check no harness substitutes for: load `http://cinepi.local/settings-editor` on a real phone in portrait, change one field, confirm the chip appears (it must NOT read "0 unsaved" when clean) and Save is visible with no horizontal scrolling.
+
+### Constraints and risks
+
+| Risk | Detail |
+|---|---|
+| The original bug the `overflow-x` rule fixed | The comment at 181-183 records that `overflow-x:auto` exists to stop the PAGE scrolling sideways. `min-width:0` must stay on `.topbar` AND be set on `.topbar-scroll`. This is the single most likely way to get the fix wrong. |
+| `overflow-y` side effect | `.topbar` today computes `overflow-y: auto` (spec-derived from `overflow-x: auto` + `visible`). Removing `overflow-x` restores true `visible`. Desirable for a sticky header, but any descendant relying on the 56px row clipping vertically will now escape it. |
+| Tight middle band | Pinned Save (109.13) + hamburger (34) leaves ~118px of scroller at 320px and ~173px at 375px, against `.search{min-width:60px}` (200). Raising the search min-width later can push Save off again. |
+| Visible behaviour changes beyond "Save is reachable" — put all four in the PR body | (1) the permanent "0 UNSAVED" chip starts disappearing; (2) file controls vanish on RAW/Live; (3) the "Remove image" button and the two CSI-2 link cards stop rendering when they should be hidden; (4) an accidental escape hatch closes — today `updateDirtyPill` (3231) leaves Save *enabled* on RAW/Live when settings are dirty, and because `hidden` is ignored it is still clickable and its handler falls through to the settings PUT. After Fix A it correctly disappears. |
+| a11y win worth noting | Because `hidden` only ever acted through the UA rule, those five "hidden" controls stay focusable and exposed to AT on RAW/Live today. Fixing the cascade fixes tab order for free. |
+| Chip reorders | Fix B moves `#dirtyPill` from 4th child (left of the ghost cluster) to the right of all four ghost buttons, adjacent to Save. Arguably an improvement, but it is a visible desktop change — state it, don't ship it silently. |
+| HDMI-GUI parity | Does **not** bind. ADR-001 (`system-review/decisions/ADR-001-gui-harmonization.md`) governs `simple_gui.py` ↔ `template.html`; `settings_editor.html` has no HDMI counterpart. Say so in the PR so a reviewer does not reject on parity grounds. |
+| No CI guard | `tools/design_token_diff.py` cannot see this file. There is no automated guard on `settings_editor.html` layout — verification is by measurement, not CI. Still run `.github/workflows/checks.yml`. |
+| Cmd/Ctrl+S | Shadows the browser's Save-Page shortcut on every tab. Gate on `!saveBtn.disabled`; `preventDefault()` only when handled. Helps desktop only, not phones. |
+| Ordering vs other W items | If W6 (dead `:root` palettes overridden by `#app.skin-hud`) lands in the same pass, sequence W6 first — anyone measuring colours here hits the `#app.skin-hud` trap at 890. |
+
+### Decision required from the operator
+
+1. **Pin the chip too, or only Save?** Recommended: pin both. The chip is the only signal that unsaved work exists, and it costs 97.63px of scroller. Pinning it also relocates it (see risks).
+2. **Short label under ~400px?** At 320-375px the scroller has only 118-173px left. Swapping "Save changes" → "Save" below a breakpoint buys back ~50px. Unverified px saving — measure if adopted.
+3. **Scroll affordance on `.topbar-scroll`?** Edge fade or chevron, versus accepting silent truncation now that the critical action is outside it.
+4. **`#cfgRebootBtn` (2204, "Save &amp; reboot Pi")** — should it save? It currently only animates. It is the button a user hits precisely when they cannot find the real Save. Either wire it to the config PUT or relabel it "Reboot Pi". Out of scope for W7 as a code change, but the decision belongs with this finding.
+5. **Add Cmd/Ctrl+S and a `beforeunload` guard in this pass?** Both are independent of the layout fix and cheap.
+6. **Scope floor:** if sub-360px viewports are out of scope, the scroller gets noticeably more room and item 2 becomes unnecessary. If the editor is laptop-first rather than phone-first, the 861-973px dead band is the more common failure.
+
+## W8 — Wrapped-portrait select overlap (accepted trade-off)
+
+Not fixed at dev tip. Reproduces exactly. Scope is one CSS line plus a comment rewrite.
+
+All geometry below is headless Chrome, devicePixelRatio 1, real DIN2014 faces, viewport forced by a same-origin iframe. Nothing here is device-verified on iOS/WebKit — see "Decision required".
+
+### What is wrong
+
+The live web GUI top row wraps to two lines on every phone-portrait width. Rows sit 4px apart. Each `<select>` hit area bleeds 8px past its group box vertically. The lower row's select therefore wins a 4.000px strip of the upper row's groups: a tap on the bottom of FPS opens the RESOLUTION picker.
+
+| Fact | file:line | Source text / measured value |
+|---|---|---|
+| Enlarged hit area, no width/height | `src/module/app/templates/template.html:138-146` | `.group select { position: absolute; inset: -8px -6px; opacity: 0; border: 0; cursor: pointer; -webkit-appearance: none; appearance: none; }` |
+| Trade-off comment (one word wrong, both numbers right) | `template.html:127-137` | `…the only cost is ambiguity where the top row wraps on a portrait phone: rows sit 4px apart there, so a lower row's select reaches ~4px into the row above…` |
+| Row gap, the only rule setting it | `template.html:90-96` | `#top-row { display: flex; flex-wrap: wrap; justify-content: space-between; align-items: baseline; gap: calc(var(--gap) * 0.5) var(--gap); }` |
+| `--gap` floors at 8px | `template.html:47` | `--gap: clamp(8px, 1.4vw, 22px);` — 1.4vw reaches 8px only at 571.43px, above every wrap threshold, so the wrapped row gap is **always** 4px |
+| Only `@media` in the file; touches neither rule | `template.html:579-586` | `#button-row`, `.vu-track`, `#experiment`, `.xp-slider .label` |
+| `#app` top padding clips row-0 selects | `template.html:82` | `padding: calc(var(--gap) * 0.6) var(--gap);` → 4.797px, so 3.203px of every row-0 select sits above the layout viewport |
+
+Measured at 375×812, `?state=idle`:
+
+| Quantity | Value |
+|---|---|
+| `getComputedStyle('#top-row').rowGap` | `4px` |
+| `.group` boxes, row 0 (g-fps/g-shutter/g-exp/g-iso/g-wb) | y[4.797, 22.797], h 18.000 |
+| `.group` box, row 1 (g-res) | y[26.797, 44.797], h 18.000 |
+| `s-res` top | 18.797 → intrusion = 22.797 − 18.797 = **4.000px** |
+| `elementFromPoint(95.2, 18.8)` / `(95.2, 16.8)` | `select#s-res` / `select#s-shutter` |
+| `?state=warn`, `elementFromPoint(44.8, 18.8)` / `(44.8, 16.8)` | `select#s-wb` / `select#s-fps` |
+
+Why the lower row wins: all five selects are `position:absolute; z-index:auto` and `.group` is `position:relative; z-index:auto` (no stacking context), so hit order is DOM order and the later element wins. Confirmed empirically, not only by spec.
+
+Cost: in the collision columns the upper group's reachable tap band drops from 34px to 18.797px — roughly the pre-#160 18px, i.e. PR #160's own gain is cancelled for those groups. (The purely geometric uncontested band is 22.000px; 18.797px is what a finger can reach, because `#app`'s 4.797px top padding puts the rest off-viewport.)
+
+Wrap thresholds, bisected: two rows at ≤548px (idle/rec/dual) and ≤563px (warn, whose locked pills are wider). One row at ≥549 / ≥564. The row never splits into three lines down to 320px. So every phone portrait width wraps, no phone landscape width does, and the fix below can only ever add one gap.
+
+Collision count (groups geometrically overlapped by a row-1 select): 5 at 320 and 360, 3 at 375 and 393, 2 at 412/430/480/540. At 375 idle those three are g-fps, g-shutter, g-exp; only the first two own a `<select>`, so only two lose a tap band.
+
+**Two distinct quantities, do not merge them.** The *group intrusion* is **4.000px** — how far a row-1 select reaches into a row-0 group *box* (22.797 − 18.797). The *select-to-select overlap* is **12.00px** — how far the two 34px hit areas overlap *each other*: 8px of bleed below row 0 plus 8px above row 1, less the 4px row gap. Row-0 select bottom 30.797, row-1 select top 18.797. The battery reports it as `oy` on four pairs. A 16px row gap closes both (8 + 8 = 16). The template comment's "4px" is the first quantity and is correct.
+
+Four claims measurement disproves. Do not repeat them:
+
+| Claim | Truth |
+|---|---|
+| "the overlap is MUTUAL — row 0 also reaches 4px into row 1" | Geometrically true, operationally void. Every column where a row-0 select bleeds down is also covered by a row-1 select, which wins by DOM order. Probes at 375×812 idle: `elementFromPoint(30, 28)`, `(30, 30.5)`, `(30, 20)` all return `s-res`, never `s-fps`. The defect is one-directional. Say "the lower row's select wins a 4px strip of the row above". |
+| "a tap on those descender pixels" is literally accurate | No. Baseline y = 18.117 (4.797 + 0.320 half-leading + 13.000 ascent). Deepest ink of any selectable value = 18.268. The band starts at 18.797, i.e. 0.529px below the deepest descender. The band is line-box leading and contains zero glyph ink. |
+| Selects are "56×34" | Height is uniformly 34; widths are not uniform and none is 56. At 375×812 idle: 55.219, 110.469, 54.219, 85.469, 186.438 — over groups of 43.219 / 98.469 / 42.219 / 73.469 / 174.438, all 18.000 tall. "44×18 → 56×34" is rounded prose copied from `dev-track/C8-web-ui-review/PLAN.md:17`, not a measurement. |
+| g-exp's `1/52` has ink in the stolen band | False at 375 (the width everything else is measured at). `v-exp` spans x[195.313, 230.656]; `s-res` ends at x=188.438. The stolen columns of g-exp are x[170.344, 188.438] — the `EXP` label. True only at 320 and 360. |
+
+### Current state at dev tip 981b6bf1
+
+- **Not fixed, not drifted.** `template.html:138-146` and `:127-137` are byte-identical to what PR #160 landed in `4b3d5093`. `git log 4affc53e..981b6bf1 -- src/module/app/templates/template.html` returns exactly `d6c1a0c3`, `4b3d5093`, `1675ca66`, `a5a86358`, `94f80e54`; none touches the select rule or `#top-row`'s gap (`a5a86358` mentions `#top-row` only in prose at `template.html:410`).
+- Pre-#160 rule, from source at `4affc53e:src/module/app/templates/template.html:129-133`: `position: absolute; inset: 0; width: 100%; height: 100%;`. #160 deleted the two longhands.
+- `.group select` matches exactly five elements (`s-fps`, `s-shutter`, `s-iso`, `s-wb`, `s-res`, markup at `template.html:595/599/606/610/615`). The EXPERIMENT drawer's runtime selects are under `.xp-select` / `.xp-group`, never `.group`. Bottom-row groups (`template.html:635-637`) have no selects.
+- **A claimed W2 regression is false — do not carry it.** It is sometimes said that the left rail worsened from 444/282 to 542/260 at 812×375 because of the EXPERIMENT drawer commits. That is an idle-vs-warn state mismatch. Measured at both `4affc53e` and `981b6bf1`: idle = 446/282, warn = 542/260, byte-identical across commits. `#experiment` carries `class="hidden"` (`template.html:669`) with `.hidden { display: none !important; }` (`template.html:541`) and sits outside `#stage`. No regression.
+- The shared clone `/Users/patrikeriksson/Documents/cinemate/cinemate` is **not** on dev — it was on `claude/cinemate-docs-review-h4pxp6` at `6663e84e` when this was written. Work in `$TREE`, per *Before you touch anything*.
+
+### What to change
+
+**One line.** Raise `#top-row`'s row gap to twice the select's vertical bleed. At 16px the two hit areas meet edge-to-edge with zero overlap.
+
+Edit `src/module/app/templates/template.html:90-96`:
+
+```css
+#top-row {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: baseline;
+    /* Row gap must be at least twice .group select's 8px vertical bleed,
+       or the two wrapped rows' invisible hit areas meet in the middle and
+       the lower row's picker wins the upper row's bottom 4px. Inert
+       whenever the row does not wrap, so it costs nothing at any width the
+       HDMI GUI has a counterpart for. */
+    gap: max(16px, calc(var(--gap) * 0.5)) var(--gap);
+}
+```
+
+`max()` is always 16px today (`--gap` caps at 22px, so `calc(--gap * 0.5)` caps at 11px); it documents the coupling and survives a future `--gap` raise.
+
+**Also rewrite the comment at `template.html:127-137`.** Keep the px-not-em rationale. The two numbers in it are right; the phrase "a tap on those descender pixels" is wrong — the band is line-box leading and contains zero glyph ink (proved below). Correct statement: where the top row wraps, the lower row's select wins a 4px strip of the row above, cancelling this rule's own tap-target gain for the two affected groups; `#top-row`'s row gap is what prevents it, so the two rules are coupled.
+
+**Do NOT ship the "cap the vertical extension" option.** Both formulations measured, both bad:
+
+| Formulation | Measured result |
+|---|---|
+| `inset: calc(-1 * min(8px, var(--gap) * 0.25)) -6px` | `--gap` is small at every real width, so the bleed resolves to 2px/side. Select height collapses to **22.000px at 375×812 and 23.656px at 812×375** — it defeats #160 in landscape too, where nothing wraps. This expression appears nowhere in PLAN.md; `PLAN.md:36` states no formula. Treat it as the trap, not the instruction. |
+| `inset: -4px -6px` | Intrusion exactly 0, `#top-row` stays 40px — but the select drops 34 → 26px at **every** width, paying back part of #160 everywhere. |
+| Either, gated on a breakpoint | Rejected because it makes a hit-target detail state-dependent for a 4px gain, and the breakpoint would have to be ≥564 to cover warn's 549–563 wrap band. **Not** because width media queries are banned in this file — `:579` already is one, and W1 adds a second. B11.7/F-297 removed the portrait *restack* (see the comment at `:563-578`), not width queries. |
+
+**iOS 14.0–14.4: out of scope, but `PLAN.md:38-40`'s stated reason is measurably wrong on both halves.** Correcting that prose is part of W8's comment work. **Write no CSS for it.**
+
+> Explicitly **not** doing: the `inset` shorthand's lack of a fallback for iOS 14.0–14.4 (that window is the only engine that renders this page but drops `inset`; the degradation is a worse tap target, not a broken page).
+
+MDN browser-compat-data: `css.properties.inset` → safari `14.1`, safari_ios `mirror`; `css.properties.row-gap` flex_context → safari `14.1`, safari_ios `mirror`. Both land in the same release, so that engine drops `inset` **and** flexbox gap together — simulated, `#top-row` goes 40 → 36px, the wrapped rows touch at 0px, `g-fps` 43.219 → 37.625px. W8's 4px premise does not exist there. And the degradation is worse than "a worse tap target": with `inset` dropped, the selects fall to their static position at intrinsic size — 15×15, 34×15, 30×15, 39×15, 68×15, `coversGroup=false` for all five. The picker no longer covers the text it controls.
+
+### How to prove it
+
+Harness: rebuild it first. See **Verification and gates → Rebuild the harness**. Do not measure the checked-in `index.html`.
+
+Measure inside a fixed-width same-origin iframe or via `preview_resize`, and assert `window.innerWidth`. Chrome clamps `--window-size` to a 500px minimum on macOS, and because `--gap`/`--value-size`/`--label-size` all sit on their clamp floors below ~571px, every y-coordinate is identical at 375 and 500 — a bad run looks right and only the collision count differs.
+
+| Step | Assertion that counts as proof |
+|---|---|
+| Reproduce | `?state=idle` @375×812: `rowGap === '4px'`; `g-fps` {y 4.797, h 18.000}; `g-res` {y 26.797, h 18.000}; `s-res.top === 18.797`. Intrusion 4.000. |
+| Prove the lower row wins | `elementFromPoint(95.2, 18.8).id === 's-res'` and `(95.2, 16.8).id === 's-shutter'`. `?state=warn` @x=44.8: 18.8 → `s-wb`, 16.8 → `s-fps`. That 2px flip is the whole finding. |
+| Confirm the fix | With the change: `rowGap === '16px'`; `#top-row` height 40 → 52; every select still exactly 34.000 tall; `s-fps.bottom === 30.797 === s-res.top` (zero overlap); `elementFromPoint(95.2, 21.8) === 's-shutter'` (idle) and `(44.8, 21.8) === 's-fps'` (warn). |
+| Confirm it is free in landscape | @812×375 `?state=warn`, before/after must be identical: `#top-row` height 18/18, `#rail-left` scrollHeight/clientHeight 542/260 in both, `#stage` height 259.922 in both. |
+| Confirm it is free in portrait | @375×812 `?state=warn`: `#rail-left` 668/668 → 656/656 (scrollHeight === clientHeight both ways, so nothing new is hidden). idle 671/671 → 659/659. The 12px comes out of `#stage`, which has slack. |
+| Re-bisect the wrap threshold if fonts, `--value-size` or the value strings change | Binary-search iframe width, cluster `.group` rects by `rect.top`. Expect 1 row from 549 (idle/rec/dual) and 564 (warn). |
+| Contract gates | From the repo root, all three must exit 0: `python3 tools/design_token_diff.py --repo . --strict`; `python3 tools/gui_field_extract.py --repo . --max-unresolved 0`; `python3 tools/docs_drift_check.py --repo . --strict`. |
+| Device gate (harness cannot do this) | On a real iPhone/Android in portrait, top row wrapped: tap the bottom edge of FPS and SHUTTER and record which picker opens, before and after. |
+
+### Constraints and risks
+
+- **Contract gates cannot see this change, unconditionally.** `tools/design_token_diff.py` `css_tokens()` reads only the first `:root` block — `start = src.find(":root")` / `block = src[start:src.find("}", start)]` at `tools/design_token_diff.py:140-143`. No declaration on `#top-row` or `.group select` is parsed by that tool at any value. (The name filter at `:167-168` excluding `gap`/`value-size`/`label-size`/`box-size`/`box-height` is a second, weaker line of defence; the value-shape filter at `:164-165` is a third. Cite the `:root`-only scan, not the name filter.)
+- **HDMI-GUI parity is not at risk from the row-gap change.** `src/module/simple_gui.py:1734-1736` — `_top_row_layout` justifies six groups between `TOP_ROW_LEFT_X` and `RES_RIGHT_ANCHOR` on a fixed canvas with no wrapped state. `row-gap` is inert when a flex container does not wrap. But any change that alters `#top-row`'s height in the non-wrapping case **would** break parity, so the 812×375 and desktop-width height assertions above are mandatory.
+- **Residual cost, confined.** +12px of `#top-row` at viewports that wrap **and** are short — resized desktop windows and Android split-screen landscape; no phone is both. Extra hidden left-rail content, `?state=warn`: 548×400 244→256, 540×360 284→296, 500×320 343→355, 480×300 363→375 (~+4%). Zero at 812×375 and zero at 375×812.
+- **Interaction with W1.** W1 is settled, not open: the rails stay left and right at every viewport and the layout shrinks to fit, so W8 does not disappear with it. Sequence W8 *after* W1 all the same — W1 changes the portrait geometry this row gap sits in, so measure the wrap once W1's shrink has landed.
+- **`#top-row`'s wrap is outside the operator ruling.** The ruling scopes to `#stage`'s three columns and `.rail`'s direction. `#top-row` carries `flex-wrap: wrap` and wraps at every phone-portrait width; that is pre-existing, accepted behaviour, and W8's fix (+12px of row gap) entrenches it rather than removing it. Say so in the commit body so it does not read as a reflow shipped against the ruling.
+- **Interaction with W2.** W8 costs zero glyph legibility; W2 hides the storage filesystem badge outright at 812×375. If only one lands this cycle, land W2. Do not let W8's +12px in the wrapped-and-short case be confused with W2's existing overflow.
+- **WebKit unverified — check first.** All numbers are Chrome headless. WebKit's flex baseline alignment could yield a group height other than 18.000, which would move the 4.000px figure. The DOM-order tiebreak for two `z-index:auto` positioned siblings is per spec and should hold, but is unverified there.
+- `PLAN.md:17` and `PLAN.md:38-40` both need correcting — see *Ledger edits*.
+
+### Decision required from the operator
+
+1. **Comment-only fallback.** If the row-gap change is not wanted, does the operator still want `template.html:127-137` corrected? As written it misnames the band ("descender pixels" — the band has zero glyph ink), which is exactly how a recorded trade-off gets rediscovered as a bug. Default: yes, correct it either way.
+
+## W9 — Clip download, server half (NEW, not in the plan)
+
+Not a W1–W8 item. `dev-track/C8-web-ui-review/PLAN.md` contains no finding about the RAW pane, downloads, takes or clips. The operator's report is the claim. Nothing here is already fixed at dev tip.
+
+### What is wrong
+
+One download route exists in the whole tree. It builds a complete zip on disk before any byte reaches the client.
+
+| Fact | Location | Verified source |
+|---|---|---|
+| Download route builds the zip, then sends it | `src/module/app/settings_editor.py:486-502` | `zip_path = raw_files.build_take_zip(path)` at :492, `@after_this_request` at :494, `send_file(...)` at :502 |
+| Temp file has no `dir=` → lands in `tempfile.gettempdir()` = `/tmp` on the Pi rootfs | `src/module/app/raw_files.py:175` | `fd, tmp_path = tempfile.mkstemp(prefix="settings-editor-", suffix=".zip")` |
+| Whole take is walked and copied uncompressed before the response starts | `raw_files.py:179-183` | `zipfile.ZipFile(tmp, mode="w", compression=zipfile.ZIP_STORED)` over `sorted(path.rglob("*"))` |
+| `%00` in `<name>` → HTTP 500, not 404 | `raw_files.py:145` | `except OSError:` — `Path.resolve()` raises `ValueError: lstat: embedded null character in path` and escapes it |
+| No recording interlock on DELETE | `settings_editor.py:480-483` | `ok, message = raw_files.delete_take(name)` — nothing else |
+| No recording interlock on bulk delete either | `settings_editor.py:505-518` | loops `raw_files.delete_take(name)` over an arbitrary `names` list |
+| Format route DOES have the interlock — copy this | `settings_editor.py:545-549` | `if rec == "1": return jsonify({...}), 409` |
+| Single download is a top-level navigation, so an error page replaces the settings editor | `templates/settings_editor.html:4043-4048` | `window.location = '/settings-editor/api/raw/takes/' + encodeURIComponent(name) + '/download';` |
+| Bulk download fires `window.location` every 800 ms | `settings_editor.html:4084-4096` | `setTimeout(function(){ window.location = ... }, i * 800)` |
+| Server is threaded Werkzeug dev server | `src/main.py:953` | `kwargs={'host': '0.0.0.0', 'port': 5000, 'allow_unsafe_werkzeug': True}` — no eventlet/gevent in requirements, so engineio resolves `async_mode='threading'` and flask_socketio calls `app.run(..., threaded=True)` |
+
+Reproduced measurements:
+
+- ENOSPC leaks the partial zip permanently. Monkeypatching `zipfile.ZipFile.write` to raise `OSError(28)` on the 3rd call left an orphaned `settings-editor-*.zip` in `gettempdir()`. The cleanup hook is registered at :494, after the build at :492, so a build failure never registers it.
+- The cleanup order is the opposite of what it looks like. Instrumented run: `send_file called → temp exists True`, `body iteration STARTS → temp exists False`. Flask runs `after_request` in `finalize_request` **before** the WSGI server consumes the iterable; the transfer works only because werkzeug holds an open fd. Consequence: a client that aborts mid-transfer does **not** leak. The leak is exactly the exception path.
+- Traversal is genuinely closed. `..`, `../secret`, `TAKE/../../secret`, `.`, `""`, `%2e%2e`, `..%2Fsecret.txt`, `%252e%252e`, and a symlinked take dir all return `None`.
+- Size arithmetic: `docs/clear-hdr.md:20` — "Each 3840×2200 16-bit DNG is ≈ 16.9 MB". 240 frames (10 s @ 24 fps) ≈ 4.06 GB; 1440 frames (60 s) ≈ 24.3 GB of temp file on the rootfs.
+- ZIP_STORED overhead is `30 + n` (local header) + `46 + n` (central dir) per file + 22 (EOCD), n = len(arcname). With a real CineMate arcname (n=38) that is **152 B/file**, measured exactly. Negligible against 16.9 MB, but do not quote a smaller figure.
+- `resolve_take` returns the first matching root only. With the same take name on `/media/RAW` and `/media/RAW1`, `list_takes()` returns two rows (each tagged `storage`) but both rows' buttons hit the RAW copy — the template keys on `data-name` alone.
+- `_is_take_dir` (`raw_files.py:51-55`) matches any dir with one `.dng`, so the take being recorded right now is listed, zippable and deletable.
+
+Unverified — check first: the claim that the bulk `window.location` race means only the LAST take arrives. The code and the server-side "no headers until the zip is built" premise are both confirmed; the browser-navigation consequence was never driven in a browser. Treat as leading hypothesis.
+
+### Current state at dev tip 981b6bf1
+
+- `src/module/app/raw_files.py` is byte-identical to the plan's base commit 4affc53e (`git diff --stat 4affc53e..HEAD` empty).
+- `settings_editor.py` changed 4/4 lines between those commits, all label strings inside `ACTION_METHODS`. Every RAW route line number above holds.
+- The template changed 61/37 lines, but no diff hunk touches `raw/takes`, `bulkDownload`, `data-download` or `build_take_zip`.
+- Nothing in this item is fixed.
+- The `/api/v1` token gate at `api.py:83-92` is a **no-op on a stock install**: `web_api_settings.py:13` and `settings.jsonc:23` both ship `"token": ""`, and `api.py:87-88` is `if not token: return None`. Do not frame the settings_editor blueprint as "less protected" — by default neither is authenticated. (Note `api.py:85` is `current_app.config['SETTINGS']`, a bare subscript.)
+
+### What to change
+
+1. `raw_files.resolve_take` — widen the except and add a storage filter. Signature: `def resolve_take(name: str, *, storage: str | None = None) -> Path | None:` (the bare `*` is required if keyword-only is intended; `from __future__ import annotations` is already at `raw_files.py:16` so `str | None` is fine on the Pi's 3.11). Change `except OSError:` at :145 to `except (OSError, ValueError):`. Add `if storage and root.name != storage: continue` inside the root loop. Both existing callers (`settings_editor.py:488`, `raw_files.py:153`) pass one positional arg and are unaffected.
+
+   Thread `?storage=` through the two **single-take** routes that already have it available client-side (rows carry `t.storage`, `settings_editor.html:3979`): `GET .../download` (`settings_editor.py:486-502`) and `DELETE /api/raw/takes/<name>` (`:480-483`). `POST /api/raw/bulk` (`:505-518`) takes a bare `names` list and stays name-only — **the duplicate-name ambiguity therefore remains open on bulk delete, which is a data-loss path.** Do not close it by inventing a wire format. File it as a candidate PLAN.md row, and say in the report that "Delete selected" is first-match-wins across `/media/RAW` and `/media/RAW1` until it is closed.
+
+**Items 2 and 3 are conditional.** They exist solely to feed `showDirectoryPicker`. **Write them only if the operator answers W10 decision 1 "yes".** W10's own evidence says the picker cannot work on the real origin, so the likely answer is no — in which case skip straight to item 4, which is the whole of W9.
+
+2. *(gated)* NEW `GET /settings-editor/api/raw/takes/<name>/files?storage=RAW1` — the manifest the folder picker needs. Body: `{"ok": true, "take": ..., "storage": ..., "file_count": N, "total_bytes": B, "recording": bool, "files": [{"name": "f000001.dng", "size_bytes": ..., "mtime": ...}]}`. `sorted()`, `is_file()` only, names relative to the take dir. 404 → `{"ok": false, "message": "Take 'X' not found"}`.
+
+3. *(gated)* NEW `GET /settings-editor/api/raw/takes/<name>/files/<path:filename>` — `return send_from_directory(path, filename, conditional=True, max_age=0)`. Use `send_from_directory`, not `send_file`: werkzeug's `safe_join` is the traversal guard. Measured on a real server: good name → 200 with `Content-Length`, `Accept-Ranges: bytes`, stable `ETag`; `Range: bytes=0-99` → **206** with `Content-Range`; `../../etc/passwd` and `..%2F..%2Fetc%2Fpasswd` → 404 both. It returns `Content-Disposition: inline`, not `attachment` — fine for the fetch path, pin it explicitly if the endpoint ever becomes user-clickable. **Its 404 is werkzeug's HTML page, not JSON, unlike every other route in this blueprint.** That is accepted: nothing but `fetch` reads it, and adding a blueprint `errorhandler(404)` would change the body of the existing JSON routes too. State it in the commit body.
+
+4. CHANGED `GET .../download` — stream the zip, no temp file. The existing docstring rejects streaming ("a hand-rolled streaming encoder risks silently corrupt downloads"); that objection does not apply, because stdlib `zipfile` handles a non-seekable sink itself. Verified end to end: `zf._seekable == False`, `testzip()` returns `None`, `namelist()` correct, bodies byte-exact, macOS `unzip -t` "No errors detected".
+
+```python
+class _StreamSink(io.RawIOBase):
+    def __init__(self): self._buf = bytearray()
+    def writable(self): return True
+    def write(self, b): self._buf += b; return len(b)
+    def drain(self):
+        chunk = bytes(self._buf); self._buf.clear(); return chunk
+
+def stream_take_zip(path: Path):
+    sink = _StreamSink()
+    with zipfile.ZipFile(sink, "w", compression=zipfile.ZIP_STORED, allowZip64=True) as zf:
+        for f in sorted(path.rglob("*")):
+            if not f.is_file():
+                continue
+            zi = zipfile.ZipInfo.from_file(f, arcname=f"{path.name}/{f.relative_to(path)}")
+            zi.compress_type = zipfile.ZIP_STORED
+            with zf.open(zi, "w") as dest, open(f, "rb") as src:
+                while (chunk := src.read(1 << 20)):
+                    dest.write(chunk)
+                    if (out := sink.drain()):
+                        yield out
+            if (out := sink.drain()):
+                yield out
+    if (out := sink.drain()):
+        yield out
+```
+Route side: `Response(stream_with_context(raw_files.stream_take_zip(path)), mimetype="application/zip", headers={"Content-Disposition": f'attachment; filename="{name}.zip"'})`. Chunked transfer is confirmed working on this exact server (real `curl` against a threaded werkzeug: `Transfer-Encoding: chunked`, no `Content-Length`, `unzip -t` clean). No reverse proxy exists anywhere in the repo to buffer it.
+
+5. Imports in `raw_files.py:18-22` — **add `import io`** (needed by `_StreamSink(io.RawIOBase)`; the current imports are `logging, shutil, tempfile, zipfile, pathlib, psutil`, with no `io`) and **delete `import tempfile` at `:20`**. `tempfile` is used only inside `build_take_zip`, `ruff.toml` selects `F401`, and CI runs `ruff check src/`. Reproduced: leaving it gives `F401 tempfile imported but unused --> raw_files.py:20:8`. `zipfile` at `:21` stays (used by `stream_take_zip`).
+
+6. Delete `build_take_zip()`. Its only caller is `settings_editor.py:492`, plus the comment at `settings_editor.html:4085-4088` that cites its docstring — update that comment in the same change or it becomes a lie.
+
+   Imports in `settings_editor.py:19-27` — currently `Blueprint, after_this_request, current_app, jsonify, render_template, request, send_file`. Add `Response` and `stream_with_context` (and `send_from_directory` only if items 2/3 are in). Remove `after_this_request` and `send_file` once `/download` no longer uses them, or `F401` fails CI.
+
+7. Recording interlock. Add `raw_files.active_take_names(redis_controller) -> set[str]` reading `last_dng_cam0` / `last_dng_cam1` and taking `Path(v).parent.name`, skipping `""` and the literal `"None"`. Those keys hold a full DNG path (`docs/redis-keys.md:80`; written at `cinepi_multi.py:323`, key name built at :293) and are reset to `"None"` on start_all/stop_all, not on record stop — so AND the result with `is_recording == "1"`. `app.config['REDIS_CONTROLLER']` already exists (`app/__init__.py:69`).
+
+   Three response shapes, written out so they are not invented:
+
+   - `DELETE /api/raw/takes/<name>` on an active take — copy the format route's precedent verbatim (`settings_editor.py:549`):
+     `return jsonify({"ok": False, "message": "Refusing to delete while recording"}), 409`
+   - `POST /api/raw/bulk` — **whole-request 409**, not a per-name refusal. The route today returns `{"ok": all_ok, "results": {name: {...}}}`; a partial delete that silently skipped the recording take is worse than a refusal the operator can see. Check the whole `names` list first:
+     `return jsonify({"ok": False, "message": "Refusing to delete while recording", "recording": sorted(active & set(names))}), 409`
+   - `/download` and the manifest stay **allowed**. `/download` returns a zip stream with no JSON envelope, so it cannot carry `recording: true` — only the manifest reports it, as a body field. Do not add a header for it.
+
+8. Concurrency cap. Module-level `threading.BoundedSemaphore(2)`, acquired **non-blocking in the route**. The release point is the part that is easy to get wrong:
+
+   - `@after_this_request` and request teardown both run at `finalize_request`, **before** the WSGI server consumes the response iterable (proved in *What is wrong*). Releasing there is a no-op for the case the cap exists to protect.
+   - Release inside the generator, wrapped in `try/finally`, so a client abort — which raises `GeneratorExit` into the generator — still frees the permit. Without the `finally`, two aborts leak both permits and every subsequent download 429s forever.
+
+   ```python
+   def _guarded(gen, sem):
+       try:
+           yield from gen
+       finally:
+           sem.release()
+   ```
+
+   Acquire in the route with `sem.acquire(blocking=False)`; on failure return 429 `{"ok": false, "message": "A download is already in progress"}` with `Retry-After: 5`. **Client concurrency must be ≤ 2 to match**, or 4 parallel per-file fetches produce 429s on correct traffic — pick the two numbers together with W10 and say which you picked. Load-bearing, not polish: `threaded=True` puts no ceiling on concurrent full-bandwidth reads off the media volume, which is the storage contention already known to cause frame drops and ALSA xruns.
+
+### How to prove it
+
+| Check | Command | Passing number |
+|---|---|---|
+| `%00` no longer 500s | `client.get('/settings-editor/api/raw/takes/%00abc/download')` | **404** JSON (today: 500 HTML, measured) |
+| No temp file during download | snapshot `glob(gettempdir()+'/settings-editor-*.zip')` before/after a full GET | set difference **empty** |
+| ENOSPC no longer leaks | monkeypatch `ZipFile.write` → `OSError(28)` on 3rd call, run the route | **0** leaked files (today: 1, measured) |
+| Streamed zip is valid | `data=b''.join(stream_take_zip(t))` | `ZipFile(BytesIO(data)).testzip() is None`, `namelist()` exact, bodies byte-equal |
+| Wire format on the real server | `curl -sD- -o /dev/null http://cinepi.local:5000/settings-editor/api/raw/takes/<TAKE>/download` | `Transfer-Encoding: chunked`, `Content-Type: application/zip`, **no** `Content-Length`, TTFB **< 1 s** (today: minutes) |
+| Range on per-file route *(gated on items 2/3)* | `curl -sD- -r 0-99 -o /dev/null .../files/f000001.dng` | **206** + `Content-Range: bytes 0-99/<size>` |
+| Traversal still closed *(gated on items 2/3)* | `curl -s -o /dev/null -w '%{http_code}' .../files/../../etc/passwd` and `..%2F..%2Fetc%2Fpasswd` | **404** both |
+| Recording interlock | start a take, `curl -X DELETE .../api/raw/takes/<ACTIVE>`; then the same via `POST /api/raw/bulk` | **409** both; a different take still 200; the bulk 409 is whole-request and deletes nothing |
+| Concurrency cap | 3 concurrent curls | 3rd → **429** + `Retry-After: 5` |
+| Cap releases on abort | start 2 downloads, `Ctrl-C` both mid-transfer, then start a 3rd | 3rd returns **200**. A 429 here means the `finally` is missing and the permits leaked |
+| Desktop round-trip | unzip a real multi-GB take with `unzip -t`, macOS Archive Utility, Windows Explorer | DNG count == the take dir's own file count; a sample DNG opens in a raw converter |
+| Folder-picker path *(gated on items 2/3)* | Chromium `showDirectoryPicker()` → per-file `getFileHandle(create:true)` + `createWritable()` + the pump in W10 change 6 | `du -sb` of the saved folder **==** manifest `total_bytes` |
+| CI | `python3 -m pytest _test/ -q -p no:randomly` and `ruff check src/` | both green off-hardware |
+
+**New tests are required, not optional.** This item adds a streaming generator, a recording interlock and a semaphore, and nothing in the existing suite covers any of it. The fixture to copy is `_test/test_settings_editor_format.py:45` — `make_app(redis_values=None, with_executor=True)` builds a bare Flask app with `settings_editor_bp` registered and a fake redis in `app.config['REDIS_CONTROLLER']`. Two sibling files (`test_settings_editor_backup.py`, `test_web_api_blueprint.py`) establish the convention for this blueprint. Add, in one new `_test/test_raw_files_download.py`:
+
+| Test | Asserts |
+|---|---|
+| `%00` in the name | 404 with a JSON body, not 500 |
+| `stream_take_zip` round-trip | `ZipFile(BytesIO(b''.join(...))).testzip() is None`, `namelist()` exact, bodies byte-equal |
+| Recording interlock, DELETE | 409, take still on disk |
+| Recording interlock, bulk | whole-request 409, **nothing** deleted |
+| Semaphore | 3rd concurrent acquire → 429 + `Retry-After`; and a permit released after a generator is closed early (`gen.close()`) |
+| Traversal on the per-file route *(only if items 2/3 shipped)* | 404 for `../../etc/passwd` and `..%2F..%2Fetc%2Fpasswd` |
+| Manifest shape *(only if items 2/3 shipped)* | keys present, `file_count` matches the fixture, 404 body is JSON |
+
+Pi baseline to capture BEFORE changing anything: `findmnt /tmp`, `df -h / /tmp`, `ls -la /tmp/settings-editor-*.zip`. Anything in that last listing is already-leaked evidence (an in-flight transfer's temp file is already unlinked and therefore invisible, so a hit there is a past failure, not a live download).
+
+### Constraints and risks
+
+- CI jobs that exist at 981b6bf1: `lint` (`ruff check src/`), `test` (`pytest _test/ -q -p no:randomly`), `shell`, `drift` (six named tools: docs_drift_check, findings_disposition_check, design_token_diff, gui_field_extract, link_frequency_drift_check, redis_key_diff). **There is no requirements-drift job** — the stale comment in `requirements.txt` claiming one is wrong; `checks.yml` explicitly does not `pip install -r requirements.txt`. Keeping imports stdlib-only (`io`) is still correct, just not for that reason.
+- `tools/docs_drift_check.py --strict` will not fire: no file under `docs/` cites `raw_files.py` or `settings_editor.py` with a line number. Renumbering these modules is safe.
+- **No docs change is required for W9.** `docs/changelog.md:49` already advertises "browse, download or format the RAW drive from the RAW files pane", which stays true; the two new endpoints (if items 2/3 ship) are internal to the pane and there is no `docs/settings-editor.md` to add them to — creating one is out of scope. If bulk download's *behaviour* changes, that is W10's docs obligation, not W9's.
+- HDMI-GUI parity does not apply — the RAW pane has no `simple_gui` counterpart, and no design tokens change.
+- Archive format changes: streamed entries always carry data descriptors (`flag_bits=0x8`, measured). ZIP64 is **conditional**, not automatic — a small test fixture stays `extract_version=20`; ZIP64 records appear only once sizes/offsets exceed 32-bit limits. Do not go looking for ZIP64 in a 400 KB fixture. The desktop round-trip gate still stands for real multi-GB takes.
+- Losing `Content-Length` on /download is a real browser-UX regression: no size, no ETA, no resume. Today's response does carry it (measured). The per-file path gets progress from the manifest instead.
+- Werkzeug sends `Connection: close` on every response (hardcoded), so a 1400-DNG per-file save costs 1400 TCP handshakes. Client concurrency must be **≤ 2** to match the server semaphore, or specify 429 + `Retry-After` backoff in W10. Pick both numbers in one decision.
+- `_test/test_settings_editor_format.py` imports `raw_files` and patches `raw_files.storage_summary`. Keeping `storage` keyword-with-default preserves it.
+- Listing cost is 3 directory walks per Refresh, not 1: `_is_take_dir` globs (`raw_files.py:53`), `_take_info` iterdirs + stats each entry (`:63-65`), and `storage_summary` walks every take dir again (`:127`) — and `refreshRawPane()` hits both endpoints. Six call sites: `settings_editor.html:3954, 3957, 4056, 4069, 4080, 4101`. No polling timer exists. Out of scope for W9 but do not make it worse.
+
+### Decision required from the operator
+
+1. What is actually observed — a browser error page replacing the settings editor, a hang with no download entry, a 0-byte file, or (with "Download selected") only one take arriving? Each maps to a different mechanism above, and none of them was observed on the operator's device. Nothing in this item has been exercised against real storage, a real take, or a real browser.
+2. `findmnt /tmp` + `df -h /` on the Pi: rootfs ENOSPC (likely) vs tmpfs RAM exhaustion tripping the 80% auto-stop.
+3. Browser/OS: `showDirectoryPicker()` is Chromium-desktop only. Is "use Chrome on a laptop" acceptable, or is a fallback needed?
+4. Hotspot AP or LAN? That is the throughput ceiling and sets per-file concurrency.
+5. Hide the actively-recording take from `list_takes()`, badge it, or leave it? Server reports `recording: true` either way.
+6. Add an `X-Cinemate-Token` gate to the settings_editor blueprint? Note it would be inert by default, same as `/api/v1`.
+7. Multi-take streaming zip now? The original objection ("briefly doubles disk usage") disappears with streaming.
+
+## W10 — Clip download + destination folder, client half (NEW, not in the plan)
+
+Nothing here is already fixed at dev tip. This item is **not** in `dev-track/C8-web-ui-review/PLAN.md` — that findings table is W1–W8 (`PLAN.md:29-36`) and `grep -niE "download|raw pane|raw files" PLAN.md` returns nothing. All work lands in `/Users/patrikeriksson/Documents/cinemate/cinemate` (the read-only pinned tree used for these line numbers is a different checkout). Confirm your branch is based on dev tip `981b6bf1` before trusting any line number below — the local clone was on `claude/cinemate-docs-review-h4pxp6` @ `6663e84e` when this was written.
+
+**Read this first: the folder picker cannot work on the real origin.** `window.showDirectoryPicker` is `[SecureContext]`-gated.
+
+| Fact | Evidence |
+|---|---|
+| The server has no TLS | `src/main.py:953` runs `socketio.run` with `{'host': '0.0.0.0', 'port': 5000, 'allow_unsafe_werkzeug': True}` — no `ssl_context` |
+| Nothing terminates TLS in front of it | no nginx/Caddy/certbot in `cinemate-install.sh` or `services/` |
+| Operators reach it over plain HTTP | `http://10.42.0.1:5000` (`docs/web-api.md:17`), `http://cinepi.local:5000` (`docs/web-gui.md:10`) — neither is a potentially-trustworthy origin |
+| "Just enable TLS" is not available | `docs/building-control-units.md:45` and `:112` both hardcode `const char* CAM = "http://10.42.0.1:5000";` |
+| **Unverified — check first** | That `window.showDirectoryPicker === undefined` and `isSecureContext === false` there. This is spec reasoning, not a browser observation. Prove it before writing a single line of picker code |
+
+### What is wrong
+
+| # | File:line | Verified source | Defect |
+|---|---|---|---|
+| 1 | `settings_editor.html:4046` | `window.location = '/settings-editor/api/raw/takes/' + encodeURIComponent(name) + '/download';` | Per-row download is a top-level navigation, not a download-attributed anchor. |
+| 2 | `settings_editor.html:4090-4093` | `names.forEach(function(name, i){ setTimeout(function(){ window.location = ... }, i * 800); });` | Bulk fires N navigations 800 ms apart. Not a naked loop — the stagger exists and is still far too short. |
+| 3 | `settings_editor.py:492` then `:502` | `zip_path = raw_files.build_take_zip(path)` … `return send_file(zip_path, as_attachment=True, download_name=f"{name}.zip")` | The entire zip is built before any header is emitted. TTFB = full zip build time, so the 800 ms stagger cannot serialise anything. |
+| 4 | `raw_files.py:175-183` | `tempfile.mkstemp(prefix="settings-editor-", suffix=".zip")` … `zipfile.ZIP_STORED` … `zf.write(f, arcname=f"{path.name}/{f.relative_to(path)}")` | Every byte of the take is copied to the system `/tmp` first. Arcnames already prefix `<take>/`. |
+| 5 | `settings_editor.py:489-490` | `return jsonify({"ok": False, "message": f"Take '{name}' not found"}), 404` | Not an attachment, so `window.location` **commits** the navigation and replaces the editor with raw JSON. |
+| 6 | `settings_editor.html:2280`, `:3227`, `grep -c beforeunload` = 0 | `var dirtyEls = new Set();` / `var n = dirtyEls.size;` | A committed navigation silently discards every unsaved `settings.jsonc`/`config.txt` edit. No unload guard exists. |
+| 7 | `settings_editor.html:2226` | `<iframe id="liveEmbedFrame" class="live-embed-frame" src="/" …>` | The same navigation tears down the live GUI iframe — socket.io connection and MJPEG preview both drop. |
+| 8 | `settings_editor.py:505-511` | `if action != "delete" or not isinstance(names, list): return jsonify(...), 400` | There is no bulk-download endpoint. A one-request combined zip does not exist server-side. |
+| 9 | — | — | No progress UI, no cancel, no error surface on either path. A minutes-long silent TTFB reads as a dead button. |
+
+Not wrong, despite what the symptom suggests: the filename **is** set (`download_name=f"{name}.zip"`, `:502`) and `Content-Length` is present, so a percentage progress bar is feasible. A 500 renders Flask's generic "Internal Server Error" page, **not** a traceback — debug is never enabled (`SocketIO(app)` at `src/module/app/__init__.py:15`, no `debug` kwarg at `src/main.py:953`).
+
+Corroborating prior art already in-repo: `system-review/deliverables/FORMAT-DRIVE-PLAN.md:66-68` — "The server is threaded werkzeug … and take-zip downloads already block requests this long. No background thread, no job queue." (that doc says `main.py` line 937; the call is now at 953). `system-review/FINDINGS.md:219` (F-295) already moved the bulk buttons below the list; the fix comment survives at `settings_editor.html:2059-2060`.
+
+### Current state at dev tip 981b6bf1
+
+- Blueprint prefix is `/settings-editor` (`settings_editor.py:43-46`, registered unconditionally at `src/module/app/__init__.py:82`), so every URL above is correct as written.
+- `requirements.txt` lists only `flask` (:16) and `flask_socketio` (:17) — no eventlet/gevent, `SocketIO(app)` passes no `async_mode`. Werkzeug runs threaded. N selections really do mean N concurrent full-take copies into `/tmp`.
+- `services/cinemate-autostart/cinemate-autostart.service` sets no `PrivateTmp=` and no `TMPDIR=`, so `mkstemp` uses the real system `/tmp`. **Unverified — check first:** whether `/tmp` is tmpfs on this image (`findmnt /tmp`). If it is, `build_take_zip` writes a whole take into RAM and that is a more urgent bug than anything in this section.
+- `refreshRawPane()` (`:4021-4024`) is **not** polled — `grep -c setInterval` = 0. Its only callers are `:3954`, `:3957`, `:4056`, `:4069`, `:4080`, `:4101`.
+- JS idiom: `grep -cE 'async function|await |=> *\{'` = 0, `grep -c "new Promise\|Promise\."` = 0, zero `const`, and every `let` hit is the English word inside a CSS comment. **ES5 syntax; ES6+ runtime APIs (`fetch`, `Set`) are already in use.** New code must be `var` + `function` + `.then`, but may use `Promise`/`AbortController`/`getReader()`.
+- `python3 tools/design_token_diff.py --strict` exits 0. It reads only `SIMPLE_GUI = "src/module/simple_gui.py"` (`:45`) and `TEMPLATE = "src/module/app/templates/template.html"` (`:46`) — settings_editor.html is never read, so this gate cannot trip on your edits.
+- `docs/changelog.md:49` advertises "browse, download or format the RAW drive from the RAW files pane". `docs/web-gui.md` mentions downloads **nowhere** — editing it is optional new documentation, not correcting an existing lie.
+
+### What to change
+
+**1. Replace `window.location` with an `<a download>` click.** The file already has the idiom at `:3824-3831` (`downloadText`: `a.href = url; a.download = filename;`). An anchor download is handed to the download manager, not the navigable, so a 404/500 can no longer replace the document. This alone removes defects 1, 5, 6, 7 and the mutual cancellation in 2.
+
+```js
+  var CAN_PICK_FOLDER = !!(window.isSecureContext && window.showDirectoryPicker);
+  function takeDownloadUrl(name){
+    return '/settings-editor/api/raw/takes/' + encodeURIComponent(name) + '/download';
+  }
+  // only used by the picker path (change 6); needs W9 item 3
+  function takeFileUrl(name, file){
+    return takeDownloadUrl(name).replace(/\/download$/, '/files/') + encodeURIComponent(file);
+  }
+  function downloadViaAnchor(url, filename){
+    var a = document.createElement('a');
+    a.href = url; a.download = filename; a.rel = 'noopener';
+    document.body.appendChild(a); a.click(); a.remove();
+  }
+```
+
+**2. Pre-flight against `/api/raw/takes`** (`settings_editor.py:475-477`, returns `raw_files.list_takes()`) before firing. It is cheap and catches the one predictable failure — take deleted or drive unmounted — without paying for a zip build. **Do not call `refreshRawPane()` from inside a download queue**: it rebuilds every row via `list.innerHTML = ''` (`:3974`) and rewires listeners (`:4004`), destroying the row holding the progress bar. Set a `refreshSuppressed` flag while a download is active, or refresh only after the queue drains.
+
+**3. Per-row progress UI, reusing `.capacity-track` / `.capacity-fill`** (`:761-762`, live on the storage meter at `:3911`). Row markup ends at `:3996` with `        '</div>';` — **that line must first become `'</div>' +`** or appending is a syntax error. Then append:
+
+```js
+        '<div class="clip-progress">' +
+          '<div class="capacity-track"><div class="capacity-fill" data-progress-fill style="width:0%"></div></div>' +
+          '<span class="clip-progress-text" data-progress-text>Starting…</span>' +
+          '<button class="icon-action" data-cancel-download title="Cancel" aria-label="Cancel download">' + CANCEL_ICON + '</button>' +
+        '</div>';
+```
+
+Declare `CANCEL_ICON` beside the two that already exist — `DOWNLOAD_ICON` (`:3872`) and `DELETE_ICON` (`:3873`) — in the same idiom (`<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">` plus two crossing `<path>`s). Do not author a new icon language; the pane has exactly one.
+
+Use `.icon-action` (`:797-800`, 30×30, `flex: none`) rather than `.btn.btn-ghost` (`:225-231`, ~33px tall) — it matches the row's existing control language beside an 8px track. CSS, inserted after `.clip-actions` at `:793`:
+
+```css
+  .clip-progress{ grid-column: 1 / -1; display:none; align-items:center; gap:10px; margin-top:9px; }
+  .cliprow.is-downloading .clip-progress{ display:flex; }
+  .clip-progress .capacity-track{ flex:1; }
+  .clip-progress-text{ font-size:12px; color: var(--muted); font-variant-numeric: tabular-nums; white-space:nowrap; }
+```
+
+`grid-column: 1 / -1` spans both `grid-template-columns: 22px 1fr auto auto` (`:783`) and the ≤640px `20px 1fr` (`:811`), so the media query at `:810-813` needs no change and defines no conflicting rule. Specificity `.cliprow.is-downloading .clip-progress` (0,3,0) beats `.clip-progress` (0,1,0).
+
+**4. Row lookup: do not hand-roll CSS escaping.** Take names come from directory names on removable media. Iterate `.cliprow` and compare `getAttribute('data-name')`, or use `CSS.escape`.
+
+**5. Bulk path.** Operator decision 2; **default (b)** if unanswered.
+- (a) Serialise anchor downloads behind one `showConfirm` that warns the browser may prompt to allow multiple downloads.
+- (b) Disable "Download selected" for >1 with an explanatory tooltip until a server-side combined-zip endpoint exists. Simpler and honest.
+
+**6. Picker path — write it only if the operator answers decision 1 "yes".** It depends on W9 items 2 and 3, which are themselves gated on the same answer. Capability-gated at every call site.
+
+Constraints it must satisfy, all of which the prose version left to invention:
+
+- ES5 syntax (`var` + `function` + `.then`; no `async`/`await`/arrow — `grep -cE 'async function|await |=> *\{'` must stay `0`).
+- `createWritable()` **truncates on open**. Cancelling without an explicit cleanup leaves a truncated file, not a removed one. The cleanup contract is `writable.abort()` **then** `dirHandle.removeEntry(name)`.
+- Strictly one take in flight. `showConfirm` (`:4206`) is callback-based — `function showConfirm(message, onYes, onCancel, opts)` with a single global pending slot (`pendingConfirmYes`/`pendingConfirmCancel`, `:4205`) that `:4213-4214` overwrites **without invoking either previous callback**. A second confirm therefore drops the first pair silently. Refuse to open an overwrite prompt while `confirmModal` has class `open`.
+- Client concurrency ≤ 2, to match W9's server semaphore.
+
+```js
+  var pickerAbort = null;                 // AbortController for the take in flight
+  function savePickedTake(dirRoot, take, files, onProgress){
+    var total = files.reduce(function(a, f){ return a + f.size_bytes; }, 0), done = 0;
+    pickerAbort = new AbortController();
+    return dirRoot.getDirectoryHandle(take, { create: true }).then(function(dir){
+      return files.reduce(function(chain, f){
+        return chain.then(function(){
+          var writable;
+          return dir.getFileHandle(f.name, { create: true })
+            .then(function(fh){ return fh.createWritable(); })
+            .then(function(w){
+              writable = w;
+              return fetch(takeFileUrl(take, f.name), { signal: pickerAbort.signal });
+            })
+            .then(function(res){
+              if (!res.ok) { throw new Error('HTTP ' + res.status + ' on ' + f.name); }
+              var reader = res.body.getReader();
+              function pump(){
+                return reader.read().then(function(r){
+                  if (r.done) { return writable.close(); }
+                  done += r.value.length;
+                  onProgress(done / total);
+                  return writable.write(r.value).then(pump);
+                });
+              }
+              return pump();
+            })
+            .catch(function(err){
+              // truncate-on-open means a half-written file must be removed,
+              // not just closed.
+              var cleanup = writable ? writable.abort() : Promise.resolve();
+              return cleanup
+                .then(function(){ return dir.removeEntry(f.name); })
+                .catch(function(){ /* best effort */ })
+                .then(function(){ throw err; });
+            });
+        });
+      }, Promise.resolve());
+    });
+  }
+```
+
+Error taxonomy — map each to a toast, do not let any reach the console unhandled:
+
+| `err.name` | Cause | Toast |
+|---|---|---|
+| `AbortError` | operator hit Cancel, **or** dismissed the picker dialog | "Download cancelled" — not an error |
+| `NotAllowedError` | permission denied on the directory handle | "Permission denied for that folder" |
+| `SecurityError` | call reached a non-secure context (a `CAN_PICK_FOLDER` gate is missing) | "Folder picker unavailable here" + fall back to the anchor path |
+| `QuotaExceededError` | destination disk full | "Not enough space in that folder" |
+| anything else | — | the message verbatim, prefixed "download failed — " |
+
+**7. Honest destination hint** under `#clipListFooter` (`:2057`): when `CAN_PICK_FOLDER` is false, tell the operator the page is served over plain HTTP so it cannot open a folder picker, and to enable "Ask where to save each file" in the browser.
+
+**Do not** adopt a blob-buffered fetch (fetch → Blob → object URL) as the default. It buffers the whole take in memory and will OOM the tab on a multi-GB take on iOS Safari or low-memory Android.
+
+### How to prove it
+
+| Check | Command / expression | Proof value |
+|---|---|---|
+| Secure-context verdict (decides the feature) | On the hotspot, `http://10.42.0.1:5000/settings-editor` console: `JSON.stringify({secure: window.isSecureContext, picker: typeof window.showDirectoryPicker, origin: location.origin})` | `{"secure":false,"picker":"undefined","origin":"http://10.42.0.1:5000"}` → picker-as-primary is dead. Repeat on `cinepi.local:5000`. |
+| Picker reachable at all | `ssh -L 5000:localhost:5000 pi@cinepi.local`, then same snippet on `http://localhost:5000` | `{"secure":true,"picker":"function"}`. If not true here, delete the picker branch entirely. |
+| Stagger is hopeless | `time curl -s -o /dev/null -D - "http://localhost:5000/settings-editor/api/raw/takes/<TAKE>/download" -w '%{time_starttransfer}s TTFB / %{size_download} bytes\n'` | Any `time_starttransfer` > 1.0 s proves `i * 800` at `:4093` cannot serialise. Record the real number — no estimate exists. |
+| Mutual cancellation (dev tip) | Select 3 takes → "Download selected" → DevTools Network | 3 `/download` requests, first two "(canceled)", 1 file on disk not 3. |
+| SPA destruction (dev tip) | Dirty the form, then console: `window.location = '/settings-editor/api/raw/takes/definitely-not-a-take/download'` | Page replaced by the 404 JSON; dirty pill gone; iframe torn down. |
+| Anchor fix | Same URL via an `<a download>` element | Page does **not** navigate, dirty pill survives. **Unverified — record what happens to the response**: Chrome may save a tiny file *or* show a failed-download entry. Note which; if it fails silently, the pre-flight in change 2 is mandatory, not optional. |
+| Headers present | `curl -sI ".../download" \| grep -iE 'content-disposition\|content-length'` | `attachment; filename=<TAKE>.zip` + numeric length. **This HEAD builds the whole zip** — small take only, watch `df -h /`. |
+| Disk doubling | `watch -n1 'df -h / /media/RAW'` during one large download | Free space on `/` drops by the take's full size and recovers. Repeat with 3 selected to size the concurrent risk. |
+| Progress geometry *(change 3, gated on decision 1)* | `getComputedStyle(document.querySelector('.cliprow.is-downloading .clip-progress')).display` | `'flex'`; `'none'` on a non-downloading row. |
+| Track height *(gated)* | `document.querySelector('.clip-progress .capacity-track').getBoundingClientRect().height` | `8`. **Do not use `getComputedStyle().height`** — `*{box-sizing:border-box}` at `:107` plus the 1px border makes it report `6px`, and the assertion would fail on a correct implementation. |
+| Full-row span *(gated)* | Compare `.clip-progress` rect width to `.cliprow` rect width − 32 (padding `13px 16px`, `:784`) at 1280px and 375px | Match within 1px at both breakpoints. |
+| Cancel *(picker path only)* | Abort mid-transfer on the tunnel | Network shows "(canceled)", **and the destination folder no longer contains the file at all** — `dir.removeEntry(name)` ran. A truncated or zero-length file left behind means the cleanup path is missing; `createWritable()` truncates on open, so "zero-length" is the failure, not the pass. |
+| Contrast (HUD skin is unconditional — `#app.skin-hud` at `:890-911`, applied at `:980`) | `.clip-progress-text` = `#8a8a8a` on `.cliplist` `--panel #0c0b09` (`:781`); fill `#90ee90` on track `--panel-2 #131210` | 5.70:1 (passes AA 4.5:1) and 13.2:1 (passes SC 1.4.11 3:1). Both recomputed and confirmed. |
+| Gate | `python3 tools/design_token_diff.py --strict` | Exit 0 (baseline verified at dev tip). |
+| Idiom | `grep -cE 'async function\|await \|=> *\{' src/module/app/templates/settings_editor.html` | Still `0`. |
+
+### Constraints and risks
+
+- **Unguarded picker call = a newly dead button.** On the real origin the property does not exist, so `window.showDirectoryPicker(...)` throws `TypeError`. Every call site must sit behind `CAN_PICK_FOLDER`.
+- **Chrome gates downloads 2..N** behind an "Automatic downloads" permission chip. On a phone or kiosk the chip may be invisible, so serialised anchors can silently produce exactly one file — today's symptom with a different cause.
+- **N concurrent anchor downloads = N concurrent `build_take_zip()` calls**, each copying a full take to `/tmp` on the rootfs SD card. This can fill `/` and take the Pi down. Serialise or replace with a server-side stream.
+- **Do not refactor `send_file` to X-Sendfile.** The `@after_this_request` unlink (`settings_editor.py:494-500`) runs at `finalize_request`, before the body streams; it only works because `send_file` already holds an open fd and POSIX keeps the inode alive.
+- **Grid hazard:** a child of `.cliprow` without an explicit `grid-column` is auto-placed into the next cell and shifts the layout — the exact bug the CSS comment at `:523` warns about. `.clip-progress` must carry `grid-column: 1 / -1`.
+- **HDMI-GUI parity: none required.** This pane has no simple_gui counterpart, and the design-token gate does not read this template.
+- **Interactions:** W6 (HUD skin is the only live palette) sets the contrast basis used above. Any W item that touches `renderClipList` or `.cliprow` grid columns collides with change 3 — land them in one pass.
+- **Docs:** if bulk download is disabled or changed, update `docs/changelog.md:49`. `docs/web-gui.md` needs an addition only if you want the RAW pane documented at all.
+- Security note, not a regression: this is an unauthenticated pane on an open hotspot. `raw_files.resolve_take` (`:134-149`) blocks traversal, but any joined client can already enumerate and pull every take.
+
+### Decision required from the operator
+
+1. **Is the picker branch worth writing?** This gates the largest block of new code in the batch: change 6 here, change 3's progress UI, **and W9 items 2 and 3**. If the answer to "how do you reach the editor" is "hotspot only, from an iPad", the whole branch is dead code — ship only the anchor path (a ~5-line change), skip both new endpoints, and accept that **there is then no progress UI and no destination folder at all**: an `<a download>` hands off to the browser's download manager, which owns the progress bar, and the browser's "Ask where to save each file" setting is the entire destination story. The blob-buffered alternative that could report progress is forbidden below. Default if unanswered: **skip the picker.**
+2. **Bulk download: keep (serialised, with warning) or disable for >1** until a server-side combined-zip endpoint exists?
+3. *(only if decision 1 is "yes")* **Layout on the picker path:** `<chosen>/<take>/<take>.zip` (nested) or flat `<chosen>/<take>.zip`? The zip's arcnames already prefix `<take>/` (`raw_files.py:182`), so nesting double-wraps on extract.
+4. **A combined-zip endpoint now?** The streaming server half is already in scope as W9. A *multi-take* combined zip is not, and it is what would make bulk download one request instead of N. W9 decision 7 is the same question from the server side — answer them together.
+5. **Has a single-take download ever succeeded on real hardware?** A stopwatch on one click distinguishes "broken" from "multi-minute silent TTFB read as a dead button" and changes which fix is urgent.
+
+## Order of work
+
+**Ask these in one message before writing code.** Every decision below gates code, not commentary. If a
+decision is unanswered when you reach it, take the Default, proceed, and record the assumption in the
+report as `applied (on default, operator confirmation open)`.
+
+| W | Decision | Default if unanswered |
+|---|---|---|
+| W3 | Route A (lighten `--drop`) or Route B (white text) | **B** |
+| W4 | Silently inert, or explicit refusal with a named reason | **Explicit** |
+| W5 | Hide or disable the button; D1 only, or D1+D2+D3 | **Hide; all three** |
+| W6 | A (promote HUD palette), B (move the nodes) or C (real toggle) | **None — hard block.** A, B and C ship visibly different products. Do not guess |
+| W7 | Pin the chip too, or only Save; ship Cmd/Ctrl+S and `beforeunload`? | **Pin both; skip both extras** |
+| W9 | Concurrency cap value; hide the actively-recording take? | **2; leave it listed, report `recording: true`** |
+| W10 | Write the picker branch at all (also gates W9 items 2/3); bulk = serialise or disable >1 | **Skip the picker; disable >1** |
+
+**W6 is the only hard block.** Everything else has a default — start on it and flag the assumption.
+
+W1, W2 and W8 need no answer at all: their mechanisms are settled in their own sections, and W8's
+residual question is answered by the Out of scope list below.
+
+| Order | Item(s) | Branch / PR | Why here |
+|---|---|---|---|
+| 1 | **W5** | PR A | `template.html` JS only, 14 lines, touches nothing any other item touches. Land it first to prove the harness loop works |
+| 2 | **W3** | PR B | Changes the DROP box's **width**, which moves the rail width, which is W1's and W2's input. Must land before the geometry work or you measure a moving target |
+| 3 | **W4** | PR B (2nd commit) | Same file, same parity question as W3, no geometry. Ride the same PR only if the operator answers W3 and W4 the same way; otherwise its own PR |
+| 4 | **W1 + W2** | PR C, **one PR** | They are one implementation, not two. W2's `--fit` scalar *is* W1's shrink; W1 contributes only the width term to the `Math.min` and two non-`.rail` declarations. A media query alone cannot close W2's drawer-open case (`#stage`'s height changes with no window resize) and a height-only fit cannot close W1's portrait case (portrait has 244.5px of vertical slack, so the height ratio is 1). Splitting them produces two conflicting `.rail` overrides — equal specificity, source order decides |
+| 5 | **W8** | PR C (3rd commit) | One line (`#top-row { row-gap: … }`) in the same file and the same portrait layout W1 just changed. Measure it *after* W1's shrink lands. Note W1 re-derives `--gap` on `.rail` only, so `#top-row`'s `calc(var(--gap) * 0.5)` still reads the `:root` value — but re-measure rather than assume |
+| 6 | **W6 → W7** | PR D, **one PR, in this order** | Same file (`settings_editor.html`), overlapping regions. W6 first: until you know `#app.skin-hud:890` is what renders, every colour you measure in that file is wrong — that trap is what misled the original review |
+| 7 | **W9 + W10** | PR E, **one PR** | Two halves of one feature. A streaming-zip client against a temp-file server (or vice versa) is untestable and half-shipped |
+
+Independent of everything: **W5**. Shares a file but not a region: W3/W4/W8 with W1/W2 (all
+`template.html`). Shares a file *and* a region: **W1/W2** (rail geometry), **W6/W7** (settings-editor
+topbar and palette). Inseparable: **W9/W10**.
+
+After PR C lands, re-run W3's proof (`getClientRects().length` on `.box.drop`, box width vs rail
+content width). W1 shrinks `--box-size`/`--box-height` at narrow widths, so W3's auto-width has to be
+re-confirmed under the new floors.
+
+**Merge hazard.** `origin/feature/no-camera-start` is unmerged and adds `"no_cam"` to `DESIGN_TOKENS`,
+`--no-cam` to `:root`, and `.box.no-cam { background: var(--no-cam); }` on the line **immediately above**
+`.box.drop`. If it lands on `dev` before PR B, W3 collides in the same diff hunk — and the NO CAM badge
+repeats W3's defect (black on `rgb(220,30,30)` = 4.248:1, also below AA). Do **not** probe with
+`git log origin/dev | grep -i no-camera` — a squashed or retitled merge need not carry that string and
+the check silently returns nothing. Probe the code instead, on the fetched tip:
+
+```bash
+git -C "$TREE" grep -n no_cam origin/dev -- src/module/design_tokens.py
+git -C "$TREE" grep -n 'box\.no-cam' origin/dev -- src/module/app/templates/template.html
+```
+
+If either hits, scope W3's fix to the warning-badge family rather than one selector.
+
+## Verification and gates
+
+### Rebuild the harness — every time, before every measurement
+
+`development/web-ui-review/harness/index.html` in the shared workspace is **stale** and does not
+announce it: it is a build of `c02f8e67` (2026-08-17), 965 lines against dev's 1783, predating both
+PR #160 and the entire EXPERIMENT drawer. Its mtime is not a reliable signal — something rewrote it on
+2026-09-01 without a clean `build.sh` run. Never measure the checked-in copy.
+
+`build.sh` **does** honour `$1` as the source tree, but it **always** writes its output to
+`$HERE/index.html` — `HERE` is derived from `BASH_SOURCE`, and the write is `> "$HERE/index.html"` at
+`build.sh:28`. Running it in place therefore overwrites the checked-in artifact. Its `REPO` default
+(`build.sh:16`) is the shared clone, which is on another session's branch. So copy it out **and** pass
+an explicit path:
+
+```bash
+SCRATCH=<your scratchpad>/harness-dev
+TREE=<the worktree from "Before you touch anything">
+HARNESS=/Users/patrikeriksson/Documents/cinemate/development/web-ui-review/harness
+
+mkdir -p "$SCRATCH"
+cp "$HARNESS"/{build.sh,mock-io.js,preview.svg} "$SCRATCH/"
+bash "$SCRATCH/build.sh" "$TREE"          # also copies the two DIN2014 faces
+
+# Proof the build is current: sed is line-for-line, so the counts MUST match.
+wc -l < "$SCRATCH/index.html"
+git -C "$TREE" show HEAD:src/module/app/templates/template.html | wc -l
+# 1783 == 1783 before any edit. The two must always match each other; the
+# absolute number grows as you add CSS. If you see 965 you are looking at the
+# stale copy.
+```
+
+Serve it **in the background** — a foreground `http.server` blocks the Bash tool until timeout and
+`sleep` is blocked, so you could never curl it. There is no `launch.json` entry for 8811, so this is
+the one server that does not go through `preview_start`:
+
+```bash
+# run_in_background: true
+/Users/patrikeriksson/.pyenv/versions/3.12.8/bin/python -m http.server 8811 \
+    --bind 127.0.0.1 --directory "$SCRATCH"
+```
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' 'http://127.0.0.1:8811/index.html?state=warn'   # 200
+```
+
+`build.sh` exits 1 if any `{{` survives, so a silent half-substitution is not possible.
+
+**This is the only harness recipe in this document.** W2, W3, W4, W5 and W8 all point here. Do not run
+`build.sh` from its own directory and do not serve port 8794 from the shared workspace.
+
+The mock exposes exactly one query parameter, `state`, with four values (`mock-io.js:86`); an unknown
+value falls back to `idle` silently. **Measure W2/W3/W4/W8 in `?state=warn`** — it is the only state
+that renders the DROP/SYNC/LOG boxes and a `.group.locked`.
+
+### Driving the RAW pane locally (W9 / W10)
+
+`raw_files.MEDIA_ROOT` is a module-level `Path("/media")` (`raw_files.py:28`), so nothing in the RAW
+pane renders on a Mac until you re-point it. Build a fixture tree in the scratchpad — a few take
+directories each holding one or more `.dng` files, since `_is_take_dir` (`raw_files.py:51-55`) matches
+any dir with one `.dng` — then monkeypatch `raw_files.MEDIA_ROOT` at it and register the blueprint on a
+bare Flask app, copying `make_app()` from `_test/test_settings_editor_format.py:45`.
+
+| Desk-closable with the fixture | Still needs `cinepi.local` |
+|---|---|
+| `%00` → 404 JSON; traversal 404s; manifest shape | `findmnt /tmp`, `df -h /`, real ENOSPC |
+| `stream_take_zip` round-trip, `testzip()`, byte-equality | TTFB on a real multi-GB take |
+| Recording interlock 409 on DELETE and bulk (fake redis) | Hotspot throughput, real take size |
+| Semaphore 429 and release-after-abort | Whether a single-take download has ever succeeded |
+| Every W10 client proof: `.clip-progress` display, track height 8, full-row span at 1280 and 375, contrast | The secure-context verdict on the operator's own device |
+
+### Driving it with the preview_* tools
+
+**A `.claude/launch.json` exists** — at `/Users/patrikeriksson/Documents/cinemate/.claude/launch.json`,
+one level *above* the repo (the repo's own `cinemate/.claude/` is an empty directory). `preview_start`
+resolves it from a cwd inside the repo. It holds 19 configurations; none sets `"autoPort": true`, so
+`preview_start` refuses rather than reassigning when a port is already held by another session.
+
+Two traps: `webgui-review-harness` (port 8794) points at the **stale** shared workspace directory, and
+in the verification session it reported success and then vanished between calls. Do not rely on it.
+
+The recipe that worked:
+
+1. `preview_start` any stable config purely to obtain a `serverId` — `settings-editor-preview` (8791)
+   worked. If its port is already held by another session, any of the other 18 configs does just as
+   well; the page is navigated away from in the next step, so which one it is does not matter.
+2. `preview_eval` → `location.replace('http://127.0.0.1:8811/index.html?state=warn')`.
+3. Assert you are actually there before measuring — a `chrome-error://` page silently reports
+   `innerWidth` 980:
+   ```js
+   ({ href: location.href, mode: document.compatMode })   // want 'CSS1Compat'
+   ```
+4. `preview_resize` with explicit `width`/`height`, then **`location.reload()`**, then wait for render.
+   `sizePreview()` runs off a `ResizeObserver` (`template.html:1760-1762`) and the mock fires
+   `initial_values` at t+30ms; measuring too early returns a stale preview rect (observed: 708×638 where
+   the truth was 460×258). Gate on `document.querySelector('.box.drop') !== null`.
+5. `preview_inspect` is the cheapest way to prove one colour (computed styles + bounding box in one
+   call). `preview_screenshot` is illustration only — **never** evidence for a ratio or a font size.
+6. `preview_resize` also takes `colorScheme: "light" | "dark"`. It is a no-op for `template.html`
+   (every `@media` in it is width- or orientation-keyed, both before and after W1) and is exactly what
+   W6 needs on `settings_editor.html`.
+
+### WCAG contrast, in JS
+
+```js
+// WCAG 2.x contrast ratio from two getComputedStyle colour strings.
+// Caveat: getComputedStyle returns rgba() when alpha < 1; this takes the first
+// three numbers, which is only correct for opaque colours. Composite first otherwise.
+function ratio(fg, bg) {
+  const lin = c => (c /= 255, c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+  const L = s => { const [r, g, b] = s.match(/[\d.]+/g).map(Number);
+                   return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b); };
+  const a = L(fg), b = L(bg);
+  return +(((Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05)).toFixed(3));
+}
+// Self-check: ratio('rgb(0,0,0)', 'rgb(120,40,180)') === 2.761
+//             ratio('rgb(255,255,255)', 'rgb(120,40,180)') === 7.605
+```
+
+### The per-viewport battery
+
+Run this at **1440×800**, **812×375** and **375×812**, in `?state=warn`, reloading after each resize.
+Paste it whole into `preview_eval`.
+
+It is self-contained — `ratio()` is inlined, and nothing depends on `$` (which is IIFE-scoped at
+`template.html:726` and unreachable from the console).
+
+```js
+(() => {
+  const ratio = (fg, bg) => {
+    const lin = c => (c /= 255, c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+    const L = s => { const [r, g, b] = s.match(/[\d.]+/g).map(Number);
+                     return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b); };
+    const a = L(fg), b = L(bg);
+    return +(((Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05)).toFixed(3));
+  };
+  const R = e => { const q = e.getBoundingClientRect();
+    return [+q.width.toFixed(2), +q.height.toFixed(2), +q.left.toFixed(2), +q.top.toFixed(2)]; };
+  const rail  = document.querySelectorAll('.rail')[0];
+  const drop  = document.querySelector('.box.drop');
+  const dcs   = getComputedStyle(drop);
+  const rng   = document.createRange(); rng.selectNodeContents(drop);
+  const frame = document.getElementById('preview-frame');
+  const stage = document.getElementById('stage');
+  const fr = frame.getBoundingClientRect(), sr = stage.getBoundingClientRect();
+  const ids   = [...document.querySelectorAll('.group select')].map(s => s.id);
+  const rects = ids.map(id => ({ id, r: document.getElementById(id).getBoundingClientRect() }));
+  const overlaps = [];
+  for (let i = 0; i < rects.length; i++) for (let j = i + 1; j < rects.length; j++) {
+    const a = rects[i].r, b = rects[j].r;
+    const ox = Math.min(a.right, b.right) - Math.max(a.left, b.left);
+    const oy = Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top);
+    if (ox > 0 && oy > 0) overlaps.push([rects[i].id, rects[j].id, +ox.toFixed(2), +oy.toFixed(2)]);
+  }
+  return {
+    vp: [innerWidth, innerHeight],
+    // Operator ruling (binding): rails stay left and right; the layout shrinks, never restacks.
+    stageCols:   getComputedStyle(stage).gridTemplateColumns,
+    railOrder:   ['rail-left', 'preview-wrap', 'rail-right']
+                   .map(id => +document.getElementById(id).getBoundingClientRect().x.toFixed(2)),
+    railFlexDir: getComputedStyle(document.getElementById('rail-left')).flexDirection,
+    // W3
+    dropRatio:     ratio(dcs.color, dcs.backgroundColor),
+    dropIfWhite:   ratio('rgb(255,255,255)', dcs.backgroundColor),
+    dropBox:       R(drop), dropFont: dcs.fontSize,
+    dropLineBoxes: rng.getClientRects().length,          // > 1 means the count wrapped
+    // W2
+    railClippedPx: rail.scrollHeight - rail.clientHeight,
+    railGutterPx:  rail.offsetWidth  - rail.clientWidth, // 0 here; non-zero only with classic scrollbars
+    boxOverhangPx: +(drop.getBoundingClientRect().width - rail.clientWidth).toFixed(2),
+    // W1
+    frame: R(frame), stage: R(stage),
+    deadAbove:    +(fr.top - sr.top).toFixed(2),
+    deadBelow:    +(sr.bottom - fr.bottom).toFixed(2),
+    frameAreaPct: +((fr.width * fr.height) / (innerWidth * innerHeight) * 100).toFixed(2),
+    // W8 + the PR #160 floors
+    selRects:    rects.map(x => [x.id, +x.r.width.toFixed(2), +x.r.height.toFixed(2)]),
+    selOverlaps: overlaps,
+    clipFont: getComputedStyle(document.getElementById('v-clip')).fontSize,   // must stay 10px
+    wavFont:  getComputedStyle(document.getElementById('v-wav')).fontSize,    // must stay 8px
+    // W4
+    lockedSelPointerEvents: getComputedStyle(document.querySelector('.group.locked select')).pointerEvents
+  };
+})()
+```
+
+Baseline at dev tip, `?state=warn`:
+
+| | 1440×800 | 812×375 | 375×812 |
+|---|---|---|---|
+| `stageCols` | three tracks | three tracks | three tracks |
+| `railOrder` | strictly ascending | strictly ascending | strictly ascending |
+| `railFlexDir` | `column` | `column` | `column` |
+| `dropRatio` | 2.761 | 2.761 | 2.761 |
+| `dropIfWhite` | 7.605 | 7.605 | 7.605 |
+| `dropLineBoxes` | 2 | 2 | 2 |
+| `railClippedPx` | 129 | 281 (104 clientHeight with the drawer open → 436) | 0 |
+| `frameAreaPct` | 62.86 | 39.0 | **14.98** |
+| `deadAbove` / `deadBelow` | 0.02 / 0.02 | 0.43 / 0.44 | 253.66 / 253.66 |
+| `selOverlaps` | none | none | 4 pairs, `oy` = 12.00 each |
+| `clipFont` / `wavFont` | 10px / 8px | 10px / 8px | 10px / 8px |
+| `lockedSelPointerEvents` | `auto` | `auto` | `auto` |
+
+For the settings editor (W6/W7) use the same loop against `settings-editor-harness` (port 8792) — but
+note it is hard-wired to `development/worktrees/settings-editor-fixes`, which currently has the `dev`
+*branch* checked out. Re-point it at `$TREE` or you are measuring someone else's tree.
+
+### CI gates — every one, with its exact local command
+
+Run all **eleven** from the worktree root before each commit. Nothing in the suite asserts a px value or
+a contrast ratio (`grep -lnE 'px\b' _test/*.py` returns nothing), so the harness measurement is the only
+check on any CSS change here.
+
+| Gate | Command | Pass looks like |
+|---|---|---|
+| ruff | `ruff check src/` | `All checks passed!` (scope is `src/` only; `_test/` and `tools/` are unlinted) |
+| pytest | `python3 -m pytest _test/ -q -p no:randomly` | `688 passed, 368 subtests passed` at dev tip — the count **rises** once W9's `_test/test_raw_files_download.py` lands; zero failures is the gate, not the number. `-p no:randomly` is **mandatory** — two tests stub `flask_socketio` into `sys.modules` and never clean up |
+| shellcheck | `find . -name '*.sh' -not -path './.git/*' -print0 \| xargs -0 shellcheck -f gcc` | no output. Verified installed today at `/opt/homebrew/bin/shellcheck` |
+| shellcheck (generated) | `python3 tools/check_generated_scripts.py` | exit 0 |
+| drift 1/6 | `python3 tools/docs_drift_check.py --repo . --strict` | exit 0 |
+| drift 2/6 | `python3 tools/findings_disposition_check.py --repo .` | `228 findings, all dispositioned` |
+| drift 3/6 | `python3 tools/design_token_diff.py --repo . --strict` | `0 drifted`, and `--box-text  #000` still under NOT COMPARABLE |
+| drift 4/6 | `python3 tools/gui_field_extract.py --repo . --max-unresolved 0` | `offered but ABSENT on the controller: 0` |
+| drift 5/6 | `python3 tools/link_frequency_drift_check.py --repo . --strict` | `12 frequencies … none restated in the template. OK` |
+| drift 6/6 | `python3 tools/redis_key_diff.py --max-unreferenced 12 --cinepi-raw /Users/patrikeriksson/Documents/cinemate/cinepi-raw` | exit 0. **Without `--cinepi-raw` it exits 2 from a worktree** — it looks for `../cinepi-raw`, which only exists next to the main clone |
+| mkdocs | `/Users/patrikeriksson/.pyenv/versions/3.12.8/bin/python -m mkdocs build --strict --site-dir <scratch>/mkdocs-out` | exit 0. Use the pyenv interpreter; the material plugin stack is not installed under the system python. CI itself runs `--clean` without `--strict`; `--strict` is the stricter local convention |
+
+**There is no `make test`, `make lint` or `make check`.** The Makefile is a systemd-service installer
+(`Makefile:22`); `make` prints help and `make install` runs `sudo systemctl` on the developer's Mac. Do
+not invoke it.
+
+Tests that read the templates as **text**, and will fire if you move a substring they match: four on
+`template.html` (`test_b95_sync_box_crossed_consistency`, `test_b97_web_gui_drop_count:25`,
+`test_b97_web_gui_labels_from_populate_values:22`, `test_web_gui_resolution_auto_refresh:41`), three on
+`settings_editor.html` (`test_action_catalogues_agree:29`, `test_b95_config_defaults_consistency:62`,
+`test_log_encode_normalization:47`). If W6/W7 touch the settings editor's JavaScript action catalogue,
+`test_action_catalogues_agree` is the one that fires — that list exists in three copies and the test
+enforces agreement.
+
+## What the desk cannot close
+
+Nothing in this list can be closed from a laptop. **Report each as "code change written, hardware gate
+open" — never as done.**
+
+| Needs | Which items | What specifically |
+|---|---|---|
+| **A physical iPhone on the hotspot** | W5 | Whether `requestFullscreen` is actually absent on the operator's iOS version; whether the probe hides the button correctly; the label-desync path on prefixed-only WebKit |
+| | W8 | Whether a real finger triggers the 4px group intrusion at all. All overlap geometry is `elementFromPoint` in headless Chrome; iOS applies touch-centroid adjustment and fuzzy tap targeting |
+| | W1, W2 | Whether a vertical drag starting on the rail — ~32px wide after the shrink, down from 38 — scrolls the rail, or is eaten by the page / the adjacent tap-to-record handler. Also whether `mask-image` renders the fade correctly on iOS Safari |
+| | W7 | Whether the pinned Save is reachable one-handed at 320–375px |
+| **A real Pi (`cinepi.local`)** | W3 | Whether white DROP text reads on the physical HDMI panel at real viewing distance and brightness — sRGB maths is a proxy, the panel has its own gamma. Also the realistic magnitude of `drop_frame_count` on a bad take, which sets whether the rail width needs a cap |
+| | W4 | Whether the SHUTTER write-through actually moves the redis value while locked |
+| | W9 | `findmnt /tmp` and `df -h /` — rootfs ENOSPC versus a tmpfs `/tmp` exhausting RAM and tripping the 80% auto-stop. Also `ls /tmp/settings-editor-*.zip` for leaked temp files |
+| | W10 | Real take size, hotspot AP throughput, and whether a single-take download has *ever* succeeded (a stopwatch on one click distinguishes "broken" from "multi-minute silent TTFB") |
+| **The HDMI panel itself** | W3, W4 | Any parity change to `simple_gui.py` changes what the camera's own screen looks like. `TEXT_COLOR` also draws the crossed-SYNC strike line (`simple_gui.py:1298`), so an HDMI-side text-colour change recolours more than the badge |
+
+Both browser harnesses are headless Chrome at `devicePixelRatio` 1. No test, no gate and no tool in the
+repo exercises a browser.
+
+## Out of scope
+
+- **The `inset` shorthand fallback for iOS 14.0–14.4.** PLAN.md's exclusion stands. Its *reasoning* is
+  measurably wrong on both halves — that engine drops `inset` and flexbox `gap` together, so W8's 4px
+  premise does not exist there, and the degradation is a select that no longer covers its group, not
+  merely a worse tap target. Correcting `PLAN.md:38-40`'s prose is W8's work. **Write no CSS for it**,
+  and do not add `min-width`/`min-height` to `.group select`.
+- **Any change to `cinepi-raw`.** Every item here is template, CSS, JS, plus at most one Python token
+  dict and the two settings-editor modules. If a fix appears to need the C++ side, stop and report.
+- **Any rebuild.** Nothing in this work requires recompiling `cinepi-raw`, reflashing, or touching the
+  driver, libcamera or the installer.
+- **Reinstating the portrait restack.** The operator ruled on 2026-09-01 that the rails stay left and
+  right at every viewport and the layout shrinks rather than reflows. B11.7 / `d8bfbbd1` stands and
+  PLAN.md's option 3 is rejected. See W1. Do not add an orientation-keyed media query; W1's one new
+  block is width-keyed on purpose, and it contains no `.rail` declaration.
+- **Handbook edits.** `cinemate-handbook` has two known-stale pages
+  (`conventions/checks-and-ci.md` says four drift scripts where six run;
+  `working/changing-the-gui.md` says colours are "defined twice"). Both are real, both are a separate
+  repo with its own push-approval rule, and neither belongs in this PR.
+- **A docs page for the settings editor.** It has no entry in `mkdocs.yml`'s nav today. Adding one is
+  scope creep.
+
+## Reporting
+
+Hand back one report. No summary `.md` files in the repo — the report is your final message.
+
+One exception, and it is a decision, not a default: C0, C2, C3 and C4 each keep their kickoff prompt
+in-repo as `SONNET-PROMPT.md`, and `dev-track/C8-web-ui-review/` holds only `PLAN.md`. **Do not file
+this document as `dev-track/C8-web-ui-review/SONNET-PROMPT.md` unless the operator asks for it.** Note
+the inconsistency in the report and let them call it.
+
+**Per item, one row.** Status is exactly one of: `applied` · `already-fixed-at-tip` ·
+`blocked-on-decision` · `blocked-on-hardware` · `skipped`. Never silently drop an item.
+
+| W | Status | Files touched | Before → after | Gate |
+|---|---|---|---|---|
+| W3 | applied | `template.html`, `design_tokens.py` | DROP contrast 2.761 → 7.605; `dropLineBoxes` 2 → 1 at all three viewports | token diff exit 0, `--box-text` still NOT COMPARABLE |
+
+Then, in prose:
+
+1. **The operator ruling, asserted.** For every item that touched `template.html` CSS, paste
+   `stageCols`, `railOrder` and `railFlexDir` at all three viewports, and again with the EXPERIMENT
+   drawer open. `railOrder` must be strictly ascending and `railFlexDir` must be `column` in every one.
+   A run that does not show this is not a pass, whatever the other numbers say.
+2. **Measured numbers, before and after, at all three viewports** for every item that changed geometry
+   or colour. Raw `preview_eval` output is acceptable and preferred over description. State the harness
+   build's line count so the reader knows it was current.
+3. **Every gate you ran, with its result** — the eleven commands in the table above. Say explicitly if
+   you skipped one and why.
+4. **Every deliberate HDMI/web divergence**, one sentence each, matching what you wrote in the code
+   comment and the commit body.
+5. **Every decision you took on its Default** rather than an operator answer, and the ledger-branch
+   deviation, one line each.
+6. **Everything left open**: which operator decisions are unanswered, which hardware gates are open, and
+   for each, exactly what question or measurement would close it. Include the two findings W9 leaves
+   open by design: bulk delete's duplicate-name ambiguity, and the paper text literals at
+   `settings_editor.html:667, 677-679`.
+7. **Anything you found that is not in this document.** New defects go in the report as candidate
+   PLAN.md rows, not into the diff.
+8. **Anything marked "unverified — check first" that you checked** — run
+   `grep -n "unverified — check first"` over this document and answer every hit. Say what you found, and
+   say so plainly if it did not reproduce.

--- a/docs/settings-json.md
+++ b/docs/settings-json.md
@@ -83,6 +83,22 @@ Wireless control API for microcontrollers (ESP32/Pico/M5Stack etc.) over the hot
 `max_sse_clients` – concurrent `/events` connections.<br>
 `broadcast` – the UDP status line: `enabled`, `port`, `hz` (rate), and `keys` (which Redis keys appear in the broadcast).
 
+### https
+
+Serves the web UI on port 5000 over TLS instead of plain HTTP. **Off by default, and not simply "more secure".**
+
+A camera is reached at `cinepi.local` or, on the hotspot, at `10.42.0.1`. No certificate authority will issue for an mDNS name or a private address, so this always means a **self-signed** certificate and a full-page browser warning on first visit — every visit in a private window, and repeatedly on iOS.
+
+Turn it on when you need a *secure browser context*. The RAW files pane's **Download into a folder…** button uses the File System Access API, which browsers only expose on a secure origin (and which only Chromium-based desktop browsers implement at all — Safari and Firefox offer it on neither http nor https).
+
+One consequence is handled for you. cinepi-raw's MJPEG preview on port 8000 speaks only plain HTTP and cannot be upgraded, and a secure page is forbidden from loading an insecure subresource — so on HTTPS the live preview would go black. CineMate detects that the page was served over TLS and routes the preview through a same-origin proxy at `/preview/<cam>/stream` instead. A plain-HTTP camera is unaffected and keeps talking straight to port 8000, so it pays nothing for this.
+
+`enabled` – `false` by default. When `true` and no usable certificate exists, one is minted at startup.<br>
+`cert_file` / `key_file` – where the pair lives. Relative paths resolve against the repo root; both are git-ignored. The key is written `0600`.<br>
+`valid_days` – lifetime of a freshly minted certificate (default 3650). An expired one is re-issued automatically on the next start.
+
+If a certificate cannot be produced — `openssl` missing, or the path unwritable — CineMate logs the reason and serves plain HTTP anyway. A camera that answers insecurely is better than one that does not answer at all.
+
 ### storage
 
 `auto_preroll` – controls the short automatic warm-up recording that prepares mounted media before the first real take. Set it to `true` to run the warm-up on startup and when RAW storage mounts. Set it to `false` to skip only the automatic startup and mount-triggered pre-rolls. Manual `storage preroll` CLI runs remain available either way. See [Storage pre-roll](storage-preroll.md).

--- a/docs/settings-json.md
+++ b/docs/settings-json.md
@@ -89,7 +89,7 @@ Serves the web UI on port 5000 over TLS instead of plain HTTP. **Off by default,
 
 A camera is reached at `cinepi.local` or, on the hotspot, at `10.42.0.1`. No certificate authority will issue for an mDNS name or a private address, so this always means a **self-signed** certificate and a full-page browser warning on first visit — every visit in a private window, and repeatedly on iOS.
 
-Turn it on when you need a *secure browser context*. The RAW files pane's **Download into a folder…** button uses the File System Access API, which browsers only expose on a secure origin (and which only Chromium-based desktop browsers implement at all — Safari and Firefox offer it on neither http nor https).
+Turn it on when you need a *secure browser context*. The RAW files pane's own **Download**/**Download selected** controls pick this up automatically: on a secure origin, in a browser that implements the File System Access API (Chromium-based desktops only — Safari and Firefox offer it on neither http nor https), they ask where to save instead of handing the file to the browser's own download manager. Anywhere else, the same buttons fall back to a normal download with no change in behaviour.
 
 One consequence is handled for you. cinepi-raw's MJPEG preview on port 8000 speaks only plain HTTP and cannot be upgraded, and a secure page is forbidden from loading an insecure subresource — so on HTTPS the live preview would go black. CineMate detects that the page was served over TLS and routes the preview through a same-origin proxy at `/preview/<cam>/stream` instead. A plain-HTTP camera is unaffected and keeps talking straight to port 8000, so it pays nothing for this.
 

--- a/docs/web-gui.md
+++ b/docs/web-gui.md
@@ -9,6 +9,10 @@ than trusting a number here, since it moves as fields get added to either side.
 
 - the control UI listens on port `5000`, with the URL `http://cinepi.local:5000/`.
 - the clean MJPEG preview stream is available on port `8000` with the URL `http://cinepi.local:8000/stream`.
+  A bare `http://cinepi.local:8000/` serves the same stream once cinepi-raw is rebuilt from `fix/mjpeg-clean-preview`; before that it returns 404, as does the `/stream` URL itself until the first frame is published.
+- with [`system.https`](settings-json.md#https) enabled the UI is served over TLS, and the preview is
+  routed through a same-origin proxy at `/preview/<cam>/stream` — a secure page may not load port
+  8000 directly, since cinepi-raw serves it over plain HTTP.
 
 Every control action posts a CLI command line to [`/api/v1/cmd`](web-api.md) — the same dispatcher
 the CLI and serial paths use, so the browser cannot drift from them. GPIO, the analog pots, the

--- a/settings.jsonc
+++ b/settings.jsonc
@@ -15,6 +15,23 @@
       // its web UI on wlan0/eth0 if that interface already has an IP.
       "enabled": true
     },
+    "https": {
+      // Serve the web UI over TLS instead of plain HTTP. Off by default, and
+      // not simply "more secure": cinepi.local and the hotspot's 10.42.0.1
+      // can never hold a publicly-trusted certificate, so this always means a
+      // self-signed one and a browser interstitial on first visit.
+      //
+      // Turn it on when you need a secure browser context -- the RAW pane's
+      // "download into a folder" uses the File System Access API, which
+      // browsers only expose on a secure origin.
+      //
+      // The certificate is minted on first start if missing, and re-issued
+      // when it expires. Relative paths resolve against the repo root.
+      "enabled": false,
+      "cert_file": "resources/certs/cinemate.crt",
+      "key_file": "resources/certs/cinemate.key",
+      "valid_days": 3650
+    },
     "web_api": {
       // Wireless control API (ESP32/Pico/M5Stack etc. over the hotspot).
       "enabled": true,

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -50,6 +50,17 @@
             }
           }
         },
+        "https": {
+          "description": "TLS for the web UI on port 5000. Off by default -- cinepi.local and the hotspot address can never hold a publicly-trusted certificate, so this always means a self-signed one and a browser interstitial. Needed for the RAW pane's folder download, which requires a secure browser context.",
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean", "default": false },
+            "cert_file": { "type": "string", "default": "resources/certs/cinemate.crt" },
+            "key_file": { "type": "string", "default": "resources/certs/cinemate.key" },
+            "valid_days": { "type": "integer", "minimum": 1, "default": 3650 }
+          },
+          "additionalProperties": false
+        },
         "web_api": {
           "type": "object",
           "description": "HTTP/UDP control API over the Wi-Fi hotspot (docs/web-api.md). A missing or partial block behaves as the defaults shown here.",

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,7 @@ from module.config_loader import (
     SettingsLoadError,
     auto_storage_preroll_enabled,
     clearhdr_startup_values,
+    rec_tone_config,
     load_settings,
     DEFAULT_SETTINGS_PATH,
 )
@@ -623,18 +624,19 @@ def initialize_system(settings, pi_model="unknown"):
     usb_monitor = USBMonitor(ssd_monitor, settings=settings, redis_controller=redis_controller)
 
     gpio_cfg = settings["hardware_outputs"]
-    rec_tone_pins = gpio_cfg.get("rec_tone_pin")
+    rec_tone_cfg = rec_tone_config(gpio_cfg)
+    rec_tone_pins = rec_tone_cfg["pin"]
     if rec_tone_pins in (None, []):
-        # Backward compatibility: if no explicit rec_tone_pin is configured,
+        # Backward compatibility: if no explicit rec_tone pin is configured,
         # fall back to pwm_pin for REC sync tone output.
         rec_tone_pins = gpio_cfg.get("pwm_pin")
 
     gpio_output = GPIOOutput(
         rec_out_pins=gpio_cfg["rec_out_pin"],
         rec_tone_pins=rec_tone_pins,
-        rec_tone_frequency_hz=gpio_cfg.get("rec_tone_frequency_hz", 1000),
-        rec_tone_duty_cycle=gpio_cfg.get("rec_tone_duty_cycle", 50),
-        rec_tone_relay_drop_frames=gpio_cfg.get("rec_tone_relay_drop_frames", False),
+        rec_tone_frequency_hz=rec_tone_cfg["frequency_hz"],
+        rec_tone_duty_cycle=rec_tone_cfg["duty_cycle"],
+        rec_tone_relay_drop_frames=rec_tone_cfg["relay_drop_frames"],
         pi_model=pi_model,
     )
     dmesg_monitor = DmesgMonitor()
@@ -774,7 +776,7 @@ def run_application(args, log_queue):
     )
 
     gpio_cfg = settings.get("hardware_outputs", {})
-    rec_tone_pins = gpio_cfg.get("rec_tone_pin")
+    rec_tone_pins = rec_tone_config(gpio_cfg)["pin"]
     if rec_tone_pins in (None, []):
         rec_tone_pins = gpio_cfg.get("pwm_pin")
 

--- a/src/main.py
+++ b/src/main.py
@@ -19,6 +19,7 @@ from module.config_loader import (
     load_settings,
     DEFAULT_SETTINGS_PATH,
 )
+from module.https_settings import ssl_context_for
 from module.logger import configure_logging, log_directory
 from module.redis_controller import RedisController, ParameterKey
 from module.ssd_monitor import SSDMonitor
@@ -952,7 +953,17 @@ def run_application(args, log_queue):
             redis_controller, cinepi_controller, simple_gui, sensor_detect,
             command_executor, settings,
         )
-        stream = threading.Thread(target=socketio.run, args=(app,), kwargs={'host': '0.0.0.0', 'port': 5000, 'allow_unsafe_werkzeug': True})
+        run_kwargs = {'host': '0.0.0.0', 'port': 5000, 'allow_unsafe_werkzeug': True}
+        # Flask-SocketIO's threading async mode forwards **kwargs to
+        # app.run(), which hands ssl_context to Werkzeug. None of that is
+        # reached unless system.https.enabled is true, and ssl_context_for()
+        # returns None (rather than raising) if a certificate cannot be
+        # issued -- a camera answering on plain HTTP beats one not answering.
+        ssl_context = ssl_context_for(settings)
+        if ssl_context:
+            run_kwargs['ssl_context'] = (str(ssl_context[0]), str(ssl_context[1]))
+            logging.info("Web UI on https://<host>:5000 (self-signed certificate)")
+        stream = threading.Thread(target=socketio.run, args=(app,), kwargs=run_kwargs)
         stream.start()
         logging.info("Stream module loaded")
     else:

--- a/src/module/app/main/routes.py
+++ b/src/module/app/main/routes.py
@@ -1,6 +1,20 @@
-from flask import Blueprint, current_app, render_template, request
+import logging
+import urllib.error
+import urllib.request
+
+from flask import (
+    Blueprint,
+    Response,
+    current_app,
+    render_template,
+    request,
+    stream_with_context,
+    url_for,
+)
 
 from module.web_api_settings import web_api_settings
+
+logger = logging.getLogger(__name__)
 
 main_routes = Blueprint('main', __name__)
 
@@ -20,20 +34,77 @@ def _stream_host():
     return host or 'cinepi.local'
 
 
+def _stream_url_for(cam):
+    """Where the browser should fetch cam *cam*'s preview from.
+
+    Over plain HTTP the browser talks straight to cinepi-raw on 8000/8001,
+    which costs CineMate nothing.
+
+    Over HTTPS it cannot: cinepi-raw's MJPEG server speaks only plain HTTP,
+    and a secure page is not allowed to load an insecure subresource, so the
+    direct URL is blocked outright and the preview goes black. The same-origin
+    proxy below is the only way to keep a picture on an HTTPS page, so it is
+    used exactly when the page was served over TLS and never otherwise.
+    """
+    if request.is_secure:
+        return url_for('main.preview_stream', cam=cam)
+    port = CAM0_STREAM_PORT if cam == 0 else CAM1_STREAM_PORT
+    return f'http://{_stream_host()}:{port}/stream'
+
+
+@main_routes.route('/preview/<int:cam>/stream')
+def preview_stream(cam):
+    """Relay cinepi-raw's MJPEG stream from this origin.
+
+    Only reached on an HTTPS page (see _stream_url_for). Streamed straight
+    through in multipart-sized chunks rather than buffered: the response never
+    ends, so anything that accumulates it would grow without bound.
+    """
+    if cam not in (0, 1):
+        return Response('Unknown camera', status=404, mimetype='text/plain')
+    port = CAM0_STREAM_PORT if cam == 0 else CAM1_STREAM_PORT
+    upstream_url = f'http://127.0.0.1:{port}/stream'
+
+    try:
+        upstream = urllib.request.urlopen(upstream_url, timeout=5)
+    except (urllib.error.URLError, OSError) as exc:
+        # A 404 here is cinepi-raw not having published a frame yet, which is
+        # normal during boot; the page's <img> retries on error.
+        logger.info('Preview proxy could not reach %s: %s', upstream_url, exc)
+        return Response('Preview not available', status=503, mimetype='text/plain')
+
+    content_type = upstream.headers.get(
+        'Content-Type', 'multipart/x-mixed-replace; boundary=nadjiebmjpegstreamer')
+
+    def relay():
+        try:
+            while True:
+                chunk = upstream.read(16384)
+                if not chunk:
+                    break
+                yield chunk
+        except (OSError, GeneratorExit):
+            pass
+        finally:
+            upstream.close()
+
+    response = Response(stream_with_context(relay()), content_type=content_type)
+    response.headers['Cache-Control'] = 'no-store'
+    return response
+
+
 @main_routes.route('/')
 def index():
     simple_gui = current_app.config['SIMPLE_GUI']
     settings = current_app.config['SETTINGS']
-
-    host = _stream_host()
 
     # First paint only. Every displayed value arrives over Socket.IO as
     # `initial_values` (the full populate_values() dict) the moment the
     # socket connects, and as `gui_data_change` deltas after that.
     return render_template(
         'template.html',
-        stream_url=f'http://{host}:{CAM0_STREAM_PORT}/stream',
-        stream_url_cam1=f'http://{host}:{CAM1_STREAM_PORT}/stream',
+        stream_url=_stream_url_for(0),
+        stream_url_cam1=_stream_url_for(1),
         background_color=simple_gui.get_background_color(),
         api_token=web_api_settings(settings).get('token') or '',
     )

--- a/src/module/app/raw_files.py
+++ b/src/module/app/raw_files.py
@@ -16,6 +16,7 @@ reads free/total space and filesystem type directly via shutil/psutil instead.
 from __future__ import annotations
 
 import logging
+import errno
 import shutil
 import tempfile
 import zipfile
@@ -131,12 +132,12 @@ def storage_summary() -> list[dict]:
     return summaries
 
 
-def resolve_take(name: str) -> Path | None:
-    """Resolve *name* (a bare take dir name, no path separators) to its
-    real path under one of the known media roots. Refuses anything that
-    would escape that root (path traversal) or isn't actually a take dir."""
+def _candidate_paths(name: str):
+    """Every path *name* could denote under a mounted media root, whether or
+    not it currently looks like a take. Refuses anything that would escape
+    that root (path traversal)."""
     if not name or "/" in name or "\\" in name or name in (".", ".."):
-        return None
+        return
     for root in _media_roots():
         candidate = root / name
         try:
@@ -144,22 +145,63 @@ def resolve_take(name: str) -> Path | None:
                 continue
         except OSError:
             continue
+        yield candidate
+
+
+def resolve_take(name: str) -> Path | None:
+    """Resolve *name* (a bare take dir name, no path separators) to its
+    real path under one of the known media roots. Refuses anything that
+    would escape that root (path traversal) or isn't actually a take dir."""
+    for candidate in _candidate_paths(name):
         if _is_take_dir(candidate):
             return candidate
     return None
 
 
 def delete_take(name: str) -> tuple[bool, str]:
-    path = resolve_take(name)
+    """Delete a take. Idempotent: a take that is already gone is a success.
+
+    Deleting is slow (thousands of unlinks) and the pane refresh behind it is
+    slower still, so the row stays on screen well after the take is gone and a
+    second tap is easy. Reporting "not found" there told the operator a delete
+    had failed when it had in fact succeeded -- and turned one already-gone
+    name in a bulk selection into "Some deletes failed".
+
+    _candidate_paths rather than resolve_take, because a take whose *.dng
+    files were already removed by a partial delete is not an _is_take_dir any
+    more: it would neither list nor delete, and sat on the card forever.
+    """
+    path = next(iter(_candidate_paths(name)), None)
     if path is None:
+        # Not a legal take name at all (traversal, separators) -- a real
+        # client error, unlike a name that is simply gone.
         return False, f"Take '{name}' not found"
-    try:
-        shutil.rmtree(path)
-    except OSError as exc:
-        logger.exception("Failed to delete take %s", path)
-        return False, str(exc)
-    logger.info("Deleted take %s", path)
-    return True, "Deleted"
+
+    for candidate in _candidate_paths(name):
+        if not candidate.exists():
+            continue
+        try:
+            shutil.rmtree(candidate)
+        except OSError as exc:
+            logger.exception("Failed to delete take %s", candidate)
+            return False, _friendly_delete_error(exc, candidate)
+        logger.info("Deleted take %s", candidate)
+        return True, "Deleted"
+
+    logger.info("Take %s was already gone", name)
+    return True, "Already deleted"
+
+
+def _friendly_delete_error(exc: OSError, path: Path) -> str:
+    """A raw errno string is not something to put in front of an operator."""
+    if exc.errno == errno.EROFS:
+        return ("The card is mounted read-only, so nothing can be deleted "
+                "from it. Unmount and check the filesystem, then remount.")
+    if exc.errno in (errno.EACCES, errno.EPERM):
+        return "No permission to delete that take from the card."
+    if exc.errno == errno.EBUSY:
+        return "That take is in use right now. Stop recording and try again."
+    return f"Could not delete that take: {exc.strerror or exc}"
 
 
 def build_take_zip(path: Path) -> Path:

--- a/src/module/app/raw_files.py
+++ b/src/module/app/raw_files.py
@@ -15,9 +15,10 @@ reads free/total space and filesystem type directly via shutil/psutil instead.
 """
 from __future__ import annotations
 
+import io
 import logging
 import shutil
-import tempfile
+import threading
 import zipfile
 from pathlib import Path
 
@@ -27,6 +28,17 @@ logger = logging.getLogger(__name__)
 
 MEDIA_ROOT = Path("/media")
 ACTIVE_LABEL = "RAW"
+
+# W9: caps full-bandwidth reads off the media volume during a download. The
+# server is threaded werkzeug with no ceiling of its own -- storage
+# contention here is the same contention already known to cause frame drops
+# and ALSA xruns during a take. Acquired non-blocking in the route; released
+# inside the streaming generator's `finally`, not `@after_this_request` --
+# that hook runs at finalize_request, before the WSGI server ever consumes
+# the response iterable, so it would be a no-op for the case this exists to
+# protect. Matching client concurrency cap: settings_editor.html's
+# DOWNLOAD_CONCURRENCY.
+DOWNLOAD_SEMAPHORE = threading.BoundedSemaphore(2)
 
 
 def _media_roots() -> list[Path]:
@@ -131,26 +143,50 @@ def storage_summary() -> list[dict]:
     return summaries
 
 
-def resolve_take(name: str) -> Path | None:
+def resolve_take(name: str, *, storage: str | None = None) -> Path | None:
     """Resolve *name* (a bare take dir name, no path separators) to its
     real path under one of the known media roots. Refuses anything that
-    would escape that root (path traversal) or isn't actually a take dir."""
+    would escape that root (path traversal) or isn't actually a take dir.
+    *storage*, if given, restricts the match to that root's label (e.g.
+    "RAW1") -- needed when the same take name exists on more than one
+    mounted drive."""
     if not name or "/" in name or "\\" in name or name in (".", ".."):
         return None
     for root in _media_roots():
+        if storage and root.name != storage:
+            continue
         candidate = root / name
         try:
             if candidate.resolve().parent != root.resolve():
                 continue
-        except OSError:
+        except (OSError, ValueError):
+            # ValueError: Path.resolve() raises "embedded null character in
+            # path" on a %00-smuggled name -- previously escaped this
+            # function entirely and surfaced as a 500.
             continue
         if _is_take_dir(candidate):
             return candidate
     return None
 
 
-def delete_take(name: str) -> tuple[bool, str]:
-    path = resolve_take(name)
+def active_take_names(redis_controller) -> set[str]:
+    """Take names currently being written to, so a delete route can refuse
+    them. last_dng_cam0/cam1 hold a full DNG path and are only reset to
+    "None" on start_all/stop_all -- not on record stop -- so this must be
+    ANDed with is_recording by the caller."""
+    from module.redis_controller import ParameterKey
+
+    names = set()
+    for key in (ParameterKey.LAST_DNG_CAM0.value, ParameterKey.LAST_DNG_CAM1.value):
+        value = redis_controller.get_value(key, "None")
+        if not value or value == "None":
+            continue
+        names.add(Path(value).parent.name)
+    return names
+
+
+def delete_take(name: str, *, storage: str | None = None) -> tuple[bool, str]:
+    path = resolve_take(name, storage=storage)
     if path is None:
         return False, f"Take '{name}' not found"
     try:
@@ -162,22 +198,62 @@ def delete_take(name: str) -> tuple[bool, str]:
     return True, "Deleted"
 
 
-def build_take_zip(path: Path) -> Path:
-    """Build a temporary zip of *path* and return its location. DNGs are
-    already stored uncompressed (dng_encoder.cpp hardcodes
-    COMPRESSION_NONE), so this uses ZIP_STORED rather than spending CPU on
-    compression that won't shrink anything. The caller is responsible for
-    deleting the returned temp file once it's been sent -- this
-    necessarily doubles disk usage for the duration of one take's zip
-    (build a real, well-tested archive with Python's zipfile rather than a
-    hand-rolled streaming encoder, which risks silently corrupt downloads
-    on a format this unforgiving)."""
-    fd, tmp_path = tempfile.mkstemp(prefix="settings-editor-", suffix=".zip")
-    import os
-    os.close(fd)
-    tmp = Path(tmp_path)
-    with zipfile.ZipFile(tmp, mode="w", compression=zipfile.ZIP_STORED) as zf:
+class _StreamSink(io.RawIOBase):
+    """A non-seekable in-memory sink zipfile can write into directly --
+    stdlib zipfile handles a non-seekable destination itself (checked:
+    ZipFile._seekable == False, testzip() clean, byte-exact output), so no
+    hand-rolled zip encoder is needed to stream one."""
+
+    def __init__(self):
+        self._buf = bytearray()
+
+    def writable(self):
+        return True
+
+    def write(self, b):
+        self._buf += b
+        return len(b)
+
+    def drain(self):
+        chunk = bytes(self._buf)
+        self._buf.clear()
+        return chunk
+
+
+def stream_take_zip(path: Path):
+    """Yield a zip of *path* as it is built, instead of writing a whole take
+    to a temp file first (the previous build_take_zip -- a 60 s take was
+    ~4 GB written to /tmp before a single byte reached the browser). DNGs are
+    already stored uncompressed (dng_encoder.cpp hardcodes COMPRESSION_NONE),
+    so this uses ZIP_STORED rather than spending CPU on compression that
+    won't shrink anything."""
+    sink = _StreamSink()
+    with zipfile.ZipFile(sink, "w", compression=zipfile.ZIP_STORED, allowZip64=True) as zf:
         for f in sorted(path.rglob("*")):
-            if f.is_file():
-                zf.write(f, arcname=f"{path.name}/{f.relative_to(path)}")
-    return tmp
+            if not f.is_file():
+                continue
+            zi = zipfile.ZipInfo.from_file(f, arcname=f"{path.name}/{f.relative_to(path)}")
+            zi.compress_type = zipfile.ZIP_STORED
+            with zf.open(zi, "w") as dest, open(f, "rb") as src:
+                while chunk := src.read(1 << 20):
+                    dest.write(chunk)
+                    if out := sink.drain():
+                        yield out
+            if out := sink.drain():
+                yield out
+    if out := sink.drain():
+        yield out
+
+
+def guarded_stream(gen, sem=DOWNLOAD_SEMAPHORE):
+    """Release *sem* from inside the generator, not from a route-level
+    `finally` or `@after_this_request` -- both of those run before the WSGI
+    server consumes the response iterable (finalize_request precedes body
+    iteration), so releasing there is a no-op for the case the semaphore
+    exists to protect. Wrapping in try/finally here means a client abort
+    (GeneratorExit) still frees the permit; without it, two aborts leak both
+    permits and every later download 429s forever."""
+    try:
+        yield from gen
+    finally:
+        sem.release()

--- a/src/module/app/raw_files.py
+++ b/src/module/app/raw_files.py
@@ -37,9 +37,42 @@ ACTIVE_LABEL = "RAW"
 # inside the streaming generator's `finally`, not `@after_this_request` --
 # that hook runs at finalize_request, before the WSGI server ever consumes
 # the response iterable, so it would be a no-op for the case this exists to
-# protect. Matching client concurrency cap: settings_editor.html's
-# DOWNLOAD_CONCURRENCY.
+# protect. The client downloads sequentially (one take, one progress bar, at
+# a time), so it never approaches this cap on its own; it exists for the
+# case of several browser tabs, or a stray non-picker <a download> alongside
+# an in-progress picker download.
 DOWNLOAD_SEMAPHORE = threading.BoundedSemaphore(2)
+
+
+class _Permit:
+    """Releases *sem* at most once, however that happens.
+
+    guarded_stream()'s generator-finally frees the permit when a GET
+    response's body is iterated to completion, or aborted mid-stream
+    (GeneratorExit). Neither ever runs for a HEAD request: Werkzeug never
+    iterates a HEAD response's body, so the generator function's own code --
+    including its `finally` -- never executes, and the acquire() made before
+    the Response was constructed leaked forever. Two `curl -I` calls alone
+    exhausted the cap and every later download 429'd, permanently, with no
+    way to recover short of a restart.
+
+    Response.call_on_close() fires for both GET and HEAD, so the route
+    registers it as a second, always-armed release path. This class is what
+    makes 'released by whichever of the two fires first' safe, instead of a
+    double release raising on the underlying BoundedSemaphore.
+    """
+
+    def __init__(self, sem):
+        self._sem = sem
+        self._lock = threading.Lock()
+        self._released = False
+
+    def release(self):
+        with self._lock:
+            if self._released:
+                return
+            self._released = True
+        self._sem.release()
 
 
 def _media_roots() -> list[Path]:

--- a/src/module/app/settings_editor.py
+++ b/src/module/app/settings_editor.py
@@ -18,12 +18,13 @@ from pathlib import Path
 
 from flask import (
     Blueprint,
-    after_this_request,
+    Response,
     current_app,
     jsonify,
     render_template,
     request,
-    send_file,
+    send_from_directory,
+    stream_with_context,
 )
 
 from module.config_loader import (
@@ -477,29 +478,88 @@ def get_raw_takes():
     return jsonify({"ok": True, "takes": raw_files.list_takes()})
 
 
+def _recording_take_names() -> set[str]:
+    """Names currently being written to -- empty unless a recording is
+    actually in progress, since last_dng_cam0/cam1 are only reset to "None"
+    on start_all/stop_all, not on record stop."""
+    redis_controller = current_app.config.get("REDIS_CONTROLLER")
+    if redis_controller is None:
+        return set()
+    rec = str(redis_controller.get_value(ParameterKey.IS_RECORDING.value, "0") or "0").strip()
+    if rec != "1":
+        return set()
+    return raw_files.active_take_names(redis_controller)
+
+
 @settings_editor_bp.route("/api/raw/takes/<name>", methods=["DELETE"])
 def delete_raw_take(name):
-    ok, message = raw_files.delete_take(name)
+    storage = request.args.get("storage") or None
+    if name in _recording_take_names():
+        return jsonify({"ok": False, "message": "Refusing to delete while recording"}), 409
+    ok, message = raw_files.delete_take(name, storage=storage)
     return jsonify({"ok": ok, "message": message}), (200 if ok else 404)
 
 
 @settings_editor_bp.route("/api/raw/takes/<name>/download", methods=["GET"])
 def download_raw_take(name):
-    path = raw_files.resolve_take(name)
+    storage = request.args.get("storage") or None
+    path = raw_files.resolve_take(name, storage=storage)
     if path is None:
         return jsonify({"ok": False, "message": f"Take '{name}' not found"}), 404
 
-    zip_path = raw_files.build_take_zip(path)
+    if not raw_files.DOWNLOAD_SEMAPHORE.acquire(blocking=False):
+        return jsonify({"ok": False, "message": "A download is already in progress"}), 429, {"Retry-After": "5"}
 
-    @after_this_request
-    def _cleanup(response):
+    return Response(
+        stream_with_context(raw_files.guarded_stream(raw_files.stream_take_zip(path))),
+        mimetype="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{name}.zip"'},
+    )
+
+
+@settings_editor_bp.route("/api/raw/takes/<name>/files", methods=["GET"])
+def raw_take_manifest(name):
+    """Feeds the folder-picker client path (W10): the file list and sizes
+    it needs before it can start writing into a chosen directory."""
+    storage = request.args.get("storage") or None
+    path = raw_files.resolve_take(name, storage=storage)
+    if path is None:
+        return jsonify({"ok": False, "message": f"Take '{name}' not found"}), 404
+
+    files = []
+    total_bytes = 0
+    for f in sorted(path.rglob("*")):
+        if not f.is_file():
+            continue
         try:
-            zip_path.unlink(missing_ok=True)
+            stat = f.stat()
         except OSError:
-            logger.warning("Could not remove temp zip %s", zip_path)
-        return response
+            continue
+        files.append({"name": str(f.relative_to(path)), "size_bytes": stat.st_size, "mtime": stat.st_mtime})
+        total_bytes += stat.st_size
 
-    return send_file(zip_path, as_attachment=True, download_name=f"{name}.zip")
+    return jsonify({
+        "ok": True,
+        "take": name,
+        "storage": path.parent.name,
+        "file_count": len(files),
+        "total_bytes": total_bytes,
+        "recording": name in _recording_take_names(),
+        "files": files,
+    })
+
+
+@settings_editor_bp.route("/api/raw/takes/<name>/files/<path:filename>", methods=["GET"])
+def raw_take_file(name, filename):
+    """Per-file fetch for the folder-picker path. werkzeug's safe_join
+    (inside send_from_directory) is the traversal guard here, not
+    raw_files.resolve_take -- but resolve_take still confines *name* to a
+    real take dir before *path* is ever handed to it."""
+    storage = request.args.get("storage") or None
+    path = raw_files.resolve_take(name, storage=storage)
+    if path is None:
+        return jsonify({"ok": False, "message": f"Take '{name}' not found"}), 404
+    return send_from_directory(path, filename, conditional=True, max_age=0)
 
 
 @settings_editor_bp.route("/api/raw/bulk", methods=["POST"])
@@ -509,6 +569,18 @@ def bulk_raw_action():
     names = body.get("names") or []
     if action != "delete" or not isinstance(names, list):
         return jsonify({"ok": False, "message": "Expected {action: 'delete', names: [...]}"}), 400
+
+    # Whole-request refusal, not a per-name skip: a partial delete that
+    # silently dropped the recording take would be worse than a refusal the
+    # operator can see. Duplicate-name ambiguity across /media/RAW and
+    # /media/RAW1 is a separate, still-open issue -- bulk stays name-only.
+    blocked = _recording_take_names() & set(names)
+    if blocked:
+        return jsonify({
+            "ok": False,
+            "message": "Refusing to delete while recording",
+            "recording": sorted(blocked),
+        }), 409
 
     results = {}
     for name in names:

--- a/src/module/app/settings_editor.py
+++ b/src/module/app/settings_editor.py
@@ -26,6 +26,7 @@ from flask import (
     send_file,
 )
 
+from module.sensor_database import resolve_database_path
 from module.config_loader import (
     SettingsLoadError,
     _apply_settings_defaults,
@@ -159,7 +160,18 @@ def _public_method_names(obj) -> set[str]:
 @settings_editor_bp.route("/")
 def index():
     settings = current_app.config["SETTINGS"]
-    return render_template("settings_editor.html", api_token=web_api_settings(settings).get("token") or "")
+    # The resolved path, not the relative form settings.jsonc carries.
+    # sensors.database_file is operator-settable, and /home/pi/cinemate is a
+    # symlink on a source install (cinemate-install.sh), which Path.resolve()
+    # follows -- so the only truthful answer comes from the same helper the
+    # loader itself uses.
+    return render_template(
+        "settings_editor.html",
+        api_token=web_api_settings(settings).get("token") or "",
+        sensor_db_path=str(
+            resolve_database_path((settings.get("sensors") or {}).get("database_file"))
+        ),
+    )
 
 
 @settings_editor_bp.route("/api/settings", methods=["GET"])

--- a/src/module/app/settings_editor.py
+++ b/src/module/app/settings_editor.py
@@ -522,11 +522,21 @@ def download_raw_take(name):
     if not raw_files.DOWNLOAD_SEMAPHORE.acquire(blocking=False):
         return jsonify({"ok": False, "message": "A download is already in progress"}), 429, {"Retry-After": "5"}
 
-    return Response(
-        stream_with_context(raw_files.guarded_stream(raw_files.stream_take_zip(path))),
+    # Two release paths for one acquire: guarded_stream()'s generator-finally
+    # covers a GET whose body is iterated (to completion, or aborted mid-
+    # stream); call_on_close covers a HEAD, whose body Werkzeug never
+    # iterates -- the generator's own code, including that finally, never
+    # runs, so the acquire above would otherwise leak on every HEAD. _Permit
+    # makes it safe for whichever of the two actually fires to be the one
+    # that releases.
+    permit = raw_files._Permit(raw_files.DOWNLOAD_SEMAPHORE)
+    response = Response(
+        stream_with_context(raw_files.guarded_stream(raw_files.stream_take_zip(path), sem=permit)),
         mimetype="application/zip",
         headers={"Content-Disposition": f'attachment; filename="{name}.zip"'},
     )
+    response.call_on_close(permit.release)
+    return response
 
 
 @settings_editor_bp.route("/api/raw/takes/<name>/files", methods=["GET"])

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -105,6 +105,17 @@
   }
 
   *{ box-sizing: border-box; }
+  /* The page hides 15 things with `el.hidden`, and every one of them carries
+     an author `display` rule -- .card is grid, .pill and .btn are flex,
+     .action-args is inline-flex. An author display declaration beats the UA
+     stylesheet's `[hidden]{display:none}` whatever the specificity, so none of
+     them actually hid: measured on this page, a hidden #saveBtn stayed
+     109px wide, the unsaved-count pill 98px, a .card 834px, and the REC-tone
+     "at [1000] Hz" field rendered on every tally row, where a frequency is
+     meaningless (tally pins never get a PWM object -- gpio_output.py writes a
+     bare level). One author rule restores the attribute's meaning for all of
+     them; !important is what makes it beat the class rules. */
+  [hidden]{ display:none !important; }
   html,body{ height:auto; }
   body{
     margin:0;
@@ -1923,7 +1934,18 @@
       <div class="add-control-row">
         <button class="btn btn-ghost" type="button" id="addGpioOutBtn">+ Add pin</button>
       </div>
-      <div class="cards" style="margin-top:14px">
+      <!-- Both cards describe the slate tone, so they only mean anything once
+           a pin above is set to REC tone. Hidden together by syncToneCards(). -->
+      <div class="cards" style="margin-top:14px" id="toneCards">
+        <div class="card" data-search="rec tone frequency hz pitch slate">
+          <div class="card-main">
+            <label class="card-label" for="f-tonehz">Slate tone frequency</label>
+            <p class="card-help">Pitch of the tone, in hertz. One value for every pin set to REC tone.</p>
+          </div>
+          <div class="card-control">
+            <input class="field-input num-input" type="number" min="1" max="20000" id="f-tonehz" data-path="hardware_outputs.rec_tone.frequency_hz" data-type="number" data-original="1000" value="1000"> Hz
+          </div>
+        </div>
         <div class="card" data-search="rec tone duty cycle pulse width">
           <div class="card-main">
             <label class="card-label" for="f-toneduty">Slate tone duty cycle</label>
@@ -3549,11 +3571,37 @@
      defaults in config_loader.py) on every save regardless of what page the
      operator was actually editing. Adding a second tally/tone pin was
      impossible for the same reason: there was nowhere to put it. */
-  /* rec_tone.frequency_hz has no [data-path] widget (the per-row Hz fields
-     come and go with their rows), so it is carried here and written back in
-     applyGpioOutToState() on every save -- including when no tone pin
-     exists, so the key never vanishes from the file. */
+  /* One frequency for every tone pin. It now has a permanent [data-path]
+     card (#f-tonehz) so buildState round-trips it even with no tone pin
+     mapped, but the per-row "at [x] Hz" fields come and go with their rows,
+     so the live value is still mirrored here and pushed both ways by
+     syncToneHz(). */
   var currentToneHz = 1000;
+
+  /* Write the shared frequency to the card and to every visible row field,
+     without re-entering their own change handlers. */
+  function syncToneHz(hz, skipEl){
+    currentToneHz = hz;
+    var card = document.getElementById('f-tonehz');
+    if (card && card !== skipEl) card.value = String(hz);
+    document.querySelectorAll('.tone-freq-wrap input').forEach(function(inp){
+      if (inp !== skipEl) inp.value = String(hz);
+    });
+  }
+
+  /* The frequency and duty-cycle cards describe the tone, so they are only
+     meaningful once some pin is set to REC tone. Now that [hidden] actually
+     hides (see the rule at the top of this stylesheet), this works. */
+  function syncToneCards(){
+    var cards = document.getElementById('toneCards');
+    if (!cards) return;
+    var anyTone = false;
+    document.querySelectorAll('#gpioOutList [data-control-type="gpio-out"]').forEach(function(row){
+      var el = document.getElementById(row.getAttribute('data-prefix') + '-method');
+      if (el && el.value === 'tone') anyTone = true;
+    });
+    cards.hidden = !anyTone;
+  }
   function buildGpioOutRow(pin, method){
     var prefix = nextControlPrefix();
     var row = document.createElement('div');
@@ -3599,15 +3647,13 @@
     freqWrap.hidden = method !== 'tone';
     methodSel.addEventListener('change', function(){
       freqWrap.hidden = methodSel.value !== 'tone';
+      syncToneCards();
       markControlsDirtyIfNeeded();
     });
     freqInput.addEventListener('change', function(){
       var v = parseFloat(freqInput.value);
       if (!isNaN(v) && v > 0){
-        currentToneHz = v;
-        document.querySelectorAll('#gpioOutList .tone-freq').forEach(function(inp){
-          if (inp !== freqInput) inp.value = String(v);
-        });
+        syncToneHz(v, freqInput);
       } else {
         freqInput.value = String(currentToneHz);
       }
@@ -3629,7 +3675,7 @@
   function populateGpioOut(settings){
     var out = (settings && settings.hardware_outputs) || {};
     var loadedHz = out.rec_tone && parseFloat(out.rec_tone.frequency_hz);
-    if (loadedHz && !isNaN(loadedHz)) currentToneHz = loadedHz;
+    if (loadedHz && !isNaN(loadedHz)) syncToneHz(loadedHz);
     var list = document.getElementById('gpioOutList');
     list.innerHTML = '';
     (out.rec_out_pin || []).forEach(function(pin){
@@ -3642,14 +3688,34 @@
       list.appendChild(row);
       row.querySelectorAll('.gpio-select').forEach(initGpioSelect);
     });
+    syncToneCards();
   }
+
+  /* One frequency, two places to type it. */
+  (function(){
+    var card = document.getElementById('f-tonehz');
+    if (!card) return;
+    card.addEventListener('change', function(){
+      var v = parseFloat(card.value);
+      if (!isNaN(v) && v > 0) { syncToneHz(v, card); }
+      else { card.value = String(currentToneHz); }
+    });
+  })();
 
   document.getElementById('addGpioOutBtn').addEventListener('click', function(){
     var row = buildGpioOutRow(null, 'tally');
     document.getElementById('gpioOutList').appendChild(row);
     row.querySelectorAll('.gpio-select').forEach(initGpioSelect);
+    syncToneCards();
     markControlsDirtyIfNeeded();
   });
+
+  /* Removing the last tone row must retire the cards too, and rows are
+     removed by a generic button that knows nothing about tones. */
+  if (window.MutationObserver) {
+    new MutationObserver(syncToneCards)
+      .observe(document.getElementById('gpioOutList'), { childList: true });
+  }
 
   /* Called after buildState()'s generic [data-path] walk already populated
      state.hardware_outputs.rec_tone.{frequency_hz,duty_cycle,relay_drop_frames}
@@ -3673,7 +3739,10 @@
     state.hardware_outputs.rec_out_pin = recOutPins;
     state.hardware_outputs.rec_tone = state.hardware_outputs.rec_tone || {};
     state.hardware_outputs.rec_tone.pin = tonePins;
-    state.hardware_outputs.rec_tone.frequency_hz = currentToneHz;
+    var hzCard = document.getElementById('f-tonehz');
+    var cardHz = hzCard && parseFloat(hzCard.value);
+    state.hardware_outputs.rec_tone.frequency_hz =
+      (cardHz && !isNaN(cardHz)) ? cardHz : currentToneHz;
     var prevOutputs = lastLoadedSettings && lastLoadedSettings.hardware_outputs;
     if (prevOutputs && prevOutputs.pwm_pin !== undefined && state.hardware_outputs.pwm_pin === undefined){
       state.hardware_outputs.pwm_pin = prevOutputs.pwm_pin;

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -1956,10 +1956,10 @@
             <input class="field-input num-input" type="number" min="1" max="99" id="f-toneduty" data-path="hardware_outputs.rec_tone.duty_cycle" data-type="number" data-original="50" value="50"> %
           </div>
         </div>
-        <div class="card" data-search="rec tone relay drop frames">
+        <div class="card" data-search="rec tone relay drop frames mute dropped frame marker">
           <div class="card-main">
-            <label class="card-label" for="f-relaydrop">Drop a frame for the relay</label>
-            <p class="card-help">If your tally uses a mechanical relay, this holds the first frame briefly so the relay has time to physically click over.</p>
+            <label class="card-label" for="f-relaydrop">Mute the tone on a dropped frame</label>
+            <p class="card-help">When the camera drops a frame, cut the slate tone for about one frame, then resume. The gap is audible on the recorded scratch track, so a dropped frame is findable by ear in the edit.</p>
           </div>
           <div class="card-control">
             <button class="toggle" id="f-relaydrop" data-path="hardware_outputs.rec_tone.relay_drop_frames" data-type="bool" data-original="false" role="switch" aria-checked="false"></button>

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -1728,16 +1728,16 @@
         <div class="card" data-search="hdr threshold low high blend gain adder clearhdr knobs">
           <div class="card-main">
             <label class="card-label">ClearHDR startup knobs</label>
-            <p class="card-help">Applied when a ClearHDR mode is selected. Adjust live afterwards with <span class="mono">set hdr …</span> or a pot/quad‑rotary channel.</p>
+            <p class="card-help">Applied when a ClearHDR mode is selected. Adjust live afterwards with <span class="mono">set hdr …</span> or a pot/quad‑rotary channel. Leave a threshold blank to keep the sensor driver’s own pair (low 0, high 4095) — setting both to the same value flattens the image.</p>
           </div>
           <div class="card-control" style="display:flex; gap:8px; flex-wrap:wrap; justify-content:flex-end">
             <label style="display:flex; flex-direction:column; gap:3px; align-items:flex-end">
               <span class="live-cap" style="color:var(--muted)">Threshold low</span>
-              <input class="field-input num-input" type="number" id="f-hdr-thlow" data-path="image_capture.hdr.threshold_low" data-type="number" data-original="0" value="0" style="width:70px">
+              <input class="field-input num-input" type="number" id="f-hdr-thlow" data-path="image_capture.hdr.threshold_low" data-type="number" data-original="" value="" placeholder="driver" style="width:70px">
             </label>
             <label style="display:flex; flex-direction:column; gap:3px; align-items:flex-end">
               <span class="live-cap" style="color:var(--muted)">Threshold high</span>
-              <input class="field-input num-input" type="number" id="f-hdr-thhigh" data-path="image_capture.hdr.threshold_high" data-type="number" data-original="0" value="0" style="width:70px">
+              <input class="field-input num-input" type="number" id="f-hdr-thhigh" data-path="image_capture.hdr.threshold_high" data-type="number" data-original="" value="" placeholder="driver" style="width:70px">
             </label>
             <label style="display:flex; flex-direction:column; gap:3px; align-items:flex-end">
               <span class="live-cap" style="color:var(--muted)">Blend</span>
@@ -1770,7 +1770,7 @@
     <section class="group" id="fpsceilings" data-page="settings">
       <header class="group-head">
         <h2>Per-mode fps ceilings</h2>
-        <p class="group-sub">A mode's advertised fps_max is an electrical property of the sensor, not a guarantee this storage/CPU can sustain it. Leave a field blank to keep using the detected value; fill one in only for a mode you've found a lower real-world ceiling for by trial. Raising above the detected value is allowed but logged as a warning -- the sensor never reported it.</p>
+        <p class="group-sub">These are what <span class="mono">cinepi-raw --list-cameras</span> reported on this board, not a fixed property of the sensor: the figure is clamped by the RP1 pixel rate, so enabling the RP1 overclock can raise it (imx585 4K 12-bit reads 43 stock, 50 overclocked), and it is rounded <em>down</em> to a whole frame — 43 can mean 43.98. It is also not a guarantee this storage/CPU can sustain it. Leave a field blank to keep using the detected value; fill one in only for a mode you've found a lower real-world ceiling for by trial. Raising above the detected value is allowed but logged as a warning — the sensor never reported it.</p>
       </header>
       <div class="cards" id="fpsCeilingsList"><p class="card-help">Loading detected modes…</p></div>
     </section>

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -16,92 +16,36 @@
     font-display: swap;
   }
 
+  /* W6: this used to be a light "paper" palette, permanently overridden by
+     #app.skin-hud (below) -- #app carries that class unconditionally, so
+     nothing outside #app (the raw-file drawer, the toast, the confirm
+     modal) ever saw the HUD look; they flipped with the OS colour scheme
+     instead. Promoted to the live palette so the whole page is one skin.
+     --focus is the one declaration #app.skin-hud does not shadow -- every
+     keyboard focus ring on the page resolves against this block. */
   :root{
-    --bg: #f7f3ec;
-    --panel: #ffffff;
-    --panel-2: #f1ece1;
-    --line: #e3dbcb;
-    --ink: #211d17;
-    --muted: #6f6656;
-    --accent: #a6631c;
-    --accent-ink: #fffaf1;
-    --accent-soft: #f0e0c8;
-    --ok: #3f7c43;
-    --ok-soft: #e2ecdf;
-    --danger: #a23830;
-    --danger-soft: #f3e2df;
-    --restart: var(--accent);
-    --restart-soft: var(--accent-soft);
-    --dirty: var(--accent);
-    --dirty-soft: var(--accent-soft);
-    --shadow: 0 1px 0 rgba(33,29,23,0.05);
-    --radius: 3px;
-    --radius-lg: 5px;
+    --bg: #050403;
+    --panel: #0c0b09;
+    --panel-2: #131210;
+    --line: #262420;
+    --ink: #f9f9f9;
+    --muted: #8a8a8a;
+    --accent: #90ee90;
+    --accent-ink: #04210c;
+    --accent-soft: #12291a;
+    --ok: #90ee90;
+    --ok-soft: #12291a;
+    --danger: #ff4136;
+    --danger-soft: #2c0f0d;
+    --restart: #ffdd00;
+    --restart-soft: #2e2600;
+    --dirty: #ff33ff;
+    --dirty-soft: #2c0e2c;
+    --shadow: none;
+    --radius: 0px;
+    --radius-lg: 0px;
     --focus: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent);
-  }
-  @media (prefers-color-scheme: dark){
-    :root{
-      --bg: #100e0c;
-      --panel: #1a1713;
-      --panel-2: #221d17;
-      --line: #33301f2b;
-      --line: #363026;
-      --ink: #f2ede4;
-      --muted: #a49a89;
-      --accent: #dd9a45;
-      --accent-ink: #221704;
-      --accent-soft: #382a13;
-      --ok: #7fbb79;
-      --ok-soft: #1e2b1c;
-      --danger: #d9695f;
-      --danger-soft: #341c19;
-      --restart: var(--accent);
-      --restart-soft: var(--accent-soft);
-      --dirty: var(--accent);
-      --dirty-soft: var(--accent-soft);
-      --shadow: 0 1px 0 rgba(0,0,0,0.4);
-      --focus: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent);
-    }
-  }
-  :root[data-theme="dark"]{
-    --bg: #100e0c;
-    --panel: #1a1713;
-    --panel-2: #221d17;
-    --line: #363026;
-    --ink: #f2ede4;
-    --muted: #a49a89;
-    --accent: #dd9a45;
-    --accent-ink: #221704;
-    --accent-soft: #382a13;
-    --ok: #7fbb79;
-    --ok-soft: #1e2b1c;
-    --danger: #d9695f;
-    --danger-soft: #341c19;
-    --restart: var(--accent);
-    --restart-soft: var(--accent-soft);
-    --dirty: var(--accent);
-    --dirty-soft: var(--accent-soft);
-    --shadow: 0 1px 0 rgba(0,0,0,0.4);
-  }
-  :root[data-theme="light"]{
-    --bg: #f7f3ec;
-    --panel: #ffffff;
-    --panel-2: #f1ece1;
-    --line: #e3dbcb;
-    --ink: #211d17;
-    --muted: #6f6656;
-    --accent: #a6631c;
-    --accent-ink: #fffaf1;
-    --accent-soft: #f0e0c8;
-    --ok: #3f7c43;
-    --ok-soft: #e2ecdf;
-    --danger: #a23830;
-    --danger-soft: #f3e2df;
-    --restart: var(--accent);
-    --restart-soft: var(--accent-soft);
-    --dirty: var(--accent);
-    --dirty-soft: var(--accent-soft);
-    --shadow: 0 1px 0 rgba(33,29,23,0.05);
+    color-scheme: dark;
   }
 
   *{ box-sizing: border-box; }
@@ -178,12 +122,20 @@
     border-bottom: 1px solid var(--line);
     background: var(--panel);
     position: sticky; top:0; z-index: 20;
-    /* The toolbar is a nowrap flex row needing ~760px. Without these it sets
-       the whole grid's minimum width and the PAGE scrolls sideways instead;
-       scroll the toolbar inside itself, the way .page-tabs already does. */
-    min-width: 0; overflow-x: auto; scrollbar-width: none;
+    /* Only .topbar-scroll (below) scrolls now. #dirtyPill and #saveBtn are
+       pinned outside it so the one action that matters cannot scroll out of
+       reach; min-width:0 still stops the PAGE scrolling sideways -- that was
+       this rule's original job, before Save could end up 400px+ off screen
+       inside it on a phone. */
+    min-width: 0;
   }
-  .topbar::-webkit-scrollbar{ display:none; }
+  .topbar-scroll{
+    flex: 1 1 auto; min-width: 0;
+    display:flex; align-items:center; gap:14px;
+    overflow-x: auto; scrollbar-width: none;
+  }
+  .topbar-scroll::-webkit-scrollbar{ display:none; }
+  #dirtyPill, #saveBtn{ flex: 0 0 auto; }
   .hamburger{
     display:none;
     width:34px; height:34px; border-radius: var(--radius);
@@ -221,6 +173,11 @@
   }
   .pill.is-dirty{ color: var(--dirty); border-color: var(--dirty); background: var(--dirty-soft); }
   .pill .dot{ width:6px; height:6px; border-radius:50%; background: currentColor; }
+  /* .pill/.btn/.icon-action/.card all set their own `display`, which beats
+     the UA's [hidden]{display:none} rule -- so hidden="" alone does nothing
+     on any of them (#dirtyPill showed "0 UNSAVED" permanently; five RAW/Live
+     controls and two CSI-2 link cards stayed rendered while "hidden"). */
+  #dirtyPill[hidden], .btn[hidden], .icon-action[hidden], .card[hidden]{ display:none !important; }
 
   .btn{
     font-family:'DIN2014',sans-serif; font-weight:700; font-size:12.5px; letter-spacing:0.04em;
@@ -664,12 +621,11 @@
   .status-text b{ font-family:'DIN2014',sans-serif; }
 
   .console{
-    background: #0c0a08; color: #d8cdb8; border-radius: var(--radius);
+    color: #d8cdb8; border-radius: var(--radius);
     font-family: ui-monospace, monospace; font-size: 12px; line-height: 1.7;
     padding: 12px 14px; max-height: 220px; overflow-y: auto;
     display: none;
   }
-  :root[data-theme="light"] .console, .console{ }
   .console.open{ display:block; }
   .console .ln{ opacity:0; animation: rise .25s ease forwards; white-space: pre-wrap; word-break: break-word; }
   @media (prefers-reduced-motion: reduce){ .console .ln{ opacity:1; animation:none; } }
@@ -791,6 +747,14 @@
   .clip-badges{ display:flex; gap:6px; margin-top:7px; flex-wrap:wrap; }
   .clip-size{ font-variant-numeric: tabular-nums; font-size: 13px; text-align:right; white-space:nowrap; }
   .clip-actions{ display:flex; gap:6px; align-items:center; }
+  /* W10: only the folder-picker download path (fetch + a readable stream)
+     can report real byte progress -- a plain <a download> hands off to the
+     browser's own download manager, which owns its own UI. Hidden unless
+     .is-downloading is set on the row. */
+  .clip-progress{ grid-column: 1 / -1; display:none; align-items:center; gap:10px; margin-top:9px; }
+  .cliprow.is-downloading .clip-progress{ display:flex; }
+  .clip-progress .capacity-track{ flex:1; }
+  .clip-progress-text{ font-size:12px; color: var(--muted); font-variant-numeric: tabular-nums; white-space:nowrap; }
   .chip-log{ color: var(--accent); border-color: var(--accent); background: var(--accent-soft); }
   .chip-danger{ color: var(--danger); border-color: var(--danger); background: var(--danger-soft); }
 
@@ -887,28 +851,6 @@
      SYNC_WARNING flash color, red = LOCK). Always on — #app carries this
      class permanently, there's no Manual/HUD switch anymore.
      ========================================================================== */
-  #app.skin-hud{
-    --bg: #050403;
-    --panel: #0c0b09;
-    --panel-2: #131210;
-    --line: #262420;
-    --ink: #f9f9f9;
-    --muted: #8a8a8a;
-    --accent: #90ee90;
-    --accent-ink: #04210c;
-    --accent-soft: #12291a;
-    --ok: #90ee90;
-    --ok-soft: #12291a;
-    --danger: #ff4136;
-    --danger-soft: #2c0f0d;
-    --restart: #ffdd00;
-    --restart-soft: #2e2600;
-    --dirty: #ff33ff;
-    --dirty-soft: #2c0e2c;
-    --radius: 0px;
-    --radius-lg: 0px;
-    --shadow: none;
-  }
   #app.skin-hud,
   #app.skin-hud .card-label,
   #app.skin-hud .lede,
@@ -988,20 +930,22 @@
     <button class="hamburger" id="hamburger" aria-label="Toggle sections menu" aria-expanded="false">
       <span></span>
     </button>
-    <label class="search">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
-      <input id="searchInput" type="text" placeholder="Search settings — e.g. “gain”, “phase lock”, GPIO 13" autocomplete="off">
-    </label>
-    <div class="topbar-spacer"></div>
-    <span class="pill" id="dirtyPill" hidden><span class="dot"></span><span id="dirtyCount">0</span> unsaved</span>
-    <button class="btn btn-ghost" id="openJson" title="View the raw file this page edits">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3H5a2 2 0 0 0-2 2v3m0 8v3a2 2 0 0 0 2 2h3m8 0h3a2 2 0 0 0 2-2v-3m0-8V5a2 2 0 0 0-2-2h-3"/></svg>
-      <span id="openJsonLabel">settings.jsonc</span>
-    </button>
-    <button class="btn btn-ghost" id="revertBtn" title="Load the stock defaults into this form (not saved until you click Save)">Revert</button>
-    <button class="btn btn-ghost" id="downloadBtn" title="Download the current form state as a file">Download</button>
-    <button class="btn btn-ghost" id="uploadBtn" title="Load a file into this form (not saved until you click Save)">Upload</button>
+    <div class="topbar-scroll">
+      <label class="search">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
+        <input id="searchInput" type="text" placeholder="Search settings — e.g. “gain”, “phase lock”, GPIO 13" autocomplete="off">
+      </label>
+      <div class="topbar-spacer"></div>
+      <button class="btn btn-ghost" id="openJson" title="View the raw file this page edits">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3H5a2 2 0 0 0-2 2v3m0 8v3a2 2 0 0 0 2 2h3m8 0h3a2 2 0 0 0 2-2v-3m0-8V5a2 2 0 0 0-2-2h-3"/></svg>
+        <span id="openJsonLabel">settings.jsonc</span>
+      </button>
+      <button class="btn btn-ghost" id="revertBtn" title="Load the stock defaults into this form (not saved until you click Save)">Revert</button>
+      <button class="btn btn-ghost" id="downloadBtn" title="Download the current form state as a file">Download</button>
+      <button class="btn btn-ghost" id="uploadBtn" title="Load a file into this form (not saved until you click Save)">Upload</button>
+    </div>
     <input type="file" id="uploadInput" accept=".json,.jsonc,.txt" hidden>
+    <span class="pill" id="dirtyPill" hidden><span class="dot"></span><span id="dirtyCount">0</span> unsaved</span>
     <button class="btn btn-primary" id="saveBtn" disabled>Save changes</button>
   </header>
 
@@ -3871,6 +3815,44 @@
      populating fixed markup. See raw_files.py for the on-disk scan. ---------- */
   var DOWNLOAD_ICON = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12"/><path d="M7 10l5 5 5-5"/><path d="M4 21h16"/></svg>';
   var DELETE_ICON = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/></svg>';
+  var CANCEL_ICON = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18"/><path d="M6 6l12 12"/></svg>';
+
+  /* ---------- RAW take download (W9/W10) ----------
+     window.location was a top-level navigation: a 404/500 replaced the whole
+     settings editor, tore down the live-GUI iframe, and discarded unsaved
+     form edits with no beforeunload guard. An <a download> click hands the
+     request to the browser's download manager instead, so none of that can
+     happen -- the document never navigates. showDirectoryPicker() needs a
+     secure context (HTTPS); the camera is only ever reached over plain HTTP
+     (hotspot or mDNS), so CAN_PICK_FOLDER is expected false there and this
+     capability-gates rather than assumes. */
+  var CAN_PICK_FOLDER = !!(window.isSecureContext && window.showDirectoryPicker);
+  var DOWNLOAD_CONCURRENCY = 2; // matches raw_files.DOWNLOAD_SEMAPHORE
+  var refreshSuppressed = false;
+
+  function takeDownloadUrl(name, storage){
+    var url = '/settings-editor/api/raw/takes/' + encodeURIComponent(name) + '/download';
+    return storage ? url + '?storage=' + encodeURIComponent(storage) : url;
+  }
+  function takeFilesUrl(name, storage){
+    var url = '/settings-editor/api/raw/takes/' + encodeURIComponent(name) + '/files';
+    return storage ? url + '?storage=' + encodeURIComponent(storage) : url;
+  }
+  function takeFileUrl(name, storage, file){
+    return takeFilesUrl(name, storage) + '/' + encodeURIComponent(file);
+  }
+  function downloadViaAnchor(url, filename){
+    var a = document.createElement('a');
+    a.href = url; a.download = filename; a.rel = 'noopener';
+    document.body.appendChild(a); a.click(); a.remove();
+  }
+  // Cheap pre-flight: catches "take deleted / drive unmounted since the list
+  // was last drawn" without paying for a zip build first.
+  function takeStillListed(name){
+    return fetch('/settings-editor/api/raw/takes').then(function(r){ return r.json(); }).then(function(res){
+      return !!(res.ok && res.takes.some(function(t){ return t.name === name; }));
+    }).catch(function(){ return true; }); // best-effort; do not block a download on a flaky fetch
+  }
 
   function formatBytes(n){
     if (n == null) return '—';
@@ -3976,6 +3958,7 @@
       var row = document.createElement('div');
       row.className = 'cliprow';
       row.setAttribute('data-name', t.name);
+      row.setAttribute('data-storage', t.storage);
       row.setAttribute('data-search', t.name.toLowerCase() + ' ' + t.storage.toLowerCase());
       row.setAttribute('data-ts', String(t.mtime || 0));
       row.setAttribute('data-size', String(t.size_bytes || 0));
@@ -3993,6 +3976,11 @@
         '<div class="clip-actions">' +
           '<button class="icon-action" data-download title="Download" aria-label="Download this take">' + DOWNLOAD_ICON + '</button>' +
           '<button class="icon-action danger" data-delete title="Delete" aria-label="Delete this take">' + DELETE_ICON + '</button>' +
+        '</div>' +
+        '<div class="clip-progress">' +
+          '<div class="capacity-track"><div class="capacity-fill" data-progress-fill style="width:0%"></div></div>' +
+          '<span class="clip-progress-text" data-progress-text>Starting…</span>' +
+          '<button class="icon-action" data-cancel-download title="Cancel" aria-label="Cancel download">' + CANCEL_ICON + '</button>' +
         '</div>';
       list.appendChild(row);
     });
@@ -4000,6 +3988,15 @@
     footer.textContent = takes.length
       ? 'Showing all ' + takes.length + ' take' + (takes.length === 1 ? '' : 's') + ' across mounted storage.'
       : 'No takes found on mounted storage.';
+    // showDirectoryPicker() needs a secure context; this page is served
+    // over plain HTTP on the hotspot and over mDNS, so it is unreachable
+    // here on every browser. Say so rather than let a missing folder
+    // picker read as a bug.
+    if (!CAN_PICK_FOLDER) {
+      footer.textContent += ' This page is served over plain HTTP, so it cannot ask where to save a ' +
+        'download — enable "Ask where to save each file" in your browser’s download settings to ' +
+        'choose a folder yourself.';
+    }
 
     wireClipRowActions();
     updateBulkBar();
@@ -4019,8 +4016,115 @@
   }
 
   function refreshRawPane(){
+    // A mid-download refresh rebuilds every row via renderClipList()'s
+    // list.innerHTML = '', destroying the row holding the progress bar and
+    // wiring a fresh (uninstrumented) button under the operator's cursor.
+    if (refreshSuppressed) { return; }
     loadRawStorage();
     loadRawTakes();
+  }
+
+  // ---------- picker-path download (only reachable when CAN_PICK_FOLDER) ----------
+  var pickerAbort = null; // AbortController for the take currently in flight
+  function savePickedTake(dirRoot, take, storage, files, onProgress){
+    var total = files.reduce(function(a, f){ return a + f.size_bytes; }, 0), done = 0;
+    pickerAbort = new AbortController();
+    return dirRoot.getDirectoryHandle(take, { create: true }).then(function(dir){
+      return files.reduce(function(chain, f){
+        return chain.then(function(){
+          var writable;
+          return dir.getFileHandle(f.name, { create: true })
+            .then(function(fh){ return fh.createWritable(); })
+            .then(function(w){
+              writable = w;
+              return fetch(takeFileUrl(take, storage, f.name), { signal: pickerAbort.signal });
+            })
+            .then(function(res){
+              if (!res.ok) { throw new Error('HTTP ' + res.status + ' on ' + f.name); }
+              var reader = res.body.getReader();
+              function pump(){
+                return reader.read().then(function(r){
+                  if (r.done) { return writable.close(); }
+                  done += r.value.length;
+                  onProgress(total ? done / total : 1);
+                  return writable.write(r.value).then(pump);
+                });
+              }
+              return pump();
+            })
+            .catch(function(err){
+              // createWritable() truncates on open -- a half-written file
+              // must be removed, not just closed, or a cancel/error leaves a
+              // truncated file behind instead of no file at all.
+              var cleanup = writable ? writable.abort() : Promise.resolve();
+              return cleanup
+                .then(function(){ return dir.removeEntry(f.name); })
+                .catch(function(){ /* best effort */ })
+                .then(function(){ throw err; });
+            });
+        });
+      }, Promise.resolve());
+    });
+  }
+
+  function downloadErrorToast(err){
+    switch (err && err.name) {
+      case 'AbortError':      return null; // operator cancelled -- not an error
+      case 'NotAllowedError': return 'Permission denied for that folder';
+      case 'SecurityError':   return 'Folder picker unavailable here';
+      case 'QuotaExceededError': return 'Not enough space in that folder';
+      default: return 'download failed — ' + ((err && err.message) || err);
+    }
+  }
+
+  function startPickedDownload(name, storage, row){
+    var fill = row.querySelector('[data-progress-fill]');
+    var text = row.querySelector('[data-progress-text]');
+    var cancelBtn = row.querySelector('[data-cancel-download]');
+    var onCancel = function(){ if (pickerAbort) { pickerAbort.abort(); } };
+    window.showDirectoryPicker({ id: 'cinemate-raw-downloads' }).then(function(dirRoot){
+      return fetch(takeFilesUrl(name, storage)).then(function(r){ return r.json(); }).then(function(manifest){
+        if (!manifest.ok) { throw new Error(manifest.message || 'could not read that take'); }
+        row.classList.add('is-downloading');
+        fill.style.width = '0%';
+        text.textContent = 'Starting…';
+        cancelBtn.addEventListener('click', onCancel);
+        refreshSuppressed = true;
+        return savePickedTake(dirRoot, name, storage, manifest.files, function(frac){
+          var pct = Math.round(frac * 100);
+          fill.style.width = pct + '%';
+          text.textContent = pct + '%';
+        }).then(function(){
+          showToast('Saved ' + name);
+        }, function(err){
+          var msg = downloadErrorToast(err);
+          if (msg) { showToast(msg); }
+        }).then(function(){
+          cancelBtn.removeEventListener('click', onCancel);
+          row.classList.remove('is-downloading');
+          refreshSuppressed = false;
+        });
+      });
+    }).catch(function(err){
+      if (err && err.name === 'AbortError') { return; } // picker dialog dismissed
+      showToast('Folder picker unavailable here — using a normal download instead.');
+      downloadViaAnchor(takeDownloadUrl(name, storage), name + '.zip');
+    });
+  }
+
+  function startTakeDownload(name, storage, row){
+    takeStillListed(name).then(function(stillThere){
+      if (!stillThere) {
+        showToast('That take is no longer on the drive.');
+        refreshRawPane();
+        return;
+      }
+      if (CAN_PICK_FOLDER) {
+        startPickedDownload(name, storage, row);
+      } else {
+        downloadViaAnchor(takeDownloadUrl(name, storage), name + '.zip');
+      }
+    });
   }
 
   function selectedClipNames(){
@@ -4034,6 +4138,15 @@
     document.getElementById('bulkCount').textContent = names.length + ' selected';
     bar.classList.toggle('show', names.length > 0);
     document.getElementById('selectAllClips').checked = names.length > 0 && names.length === currentTakes.length;
+    // No server-side combined-zip endpoint exists, and N parallel per-take
+    // downloads race each other (see raw_files.DOWNLOAD_SEMAPHORE) -- so
+    // "download selected" is honest only for exactly one take at a time.
+    var bulkDownloadBtn = document.getElementById('bulkDownload');
+    var tooManyForDownload = names.length > 1;
+    bulkDownloadBtn.disabled = tooManyForDownload;
+    bulkDownloadBtn.title = tooManyForDownload
+      ? 'Download one take at a time — select a single take to download it'
+      : '';
   }
 
   function wireClipRowActions(){
@@ -4042,8 +4155,8 @@
     });
     document.querySelectorAll('.cliprow [data-download]').forEach(function(btn){
       btn.addEventListener('click', function(){
-        var name = btn.closest('.cliprow').getAttribute('data-name');
-        window.location = '/settings-editor/api/raw/takes/' + encodeURIComponent(name) + '/download';
+        var row = btn.closest('.cliprow');
+        startTakeDownload(row.getAttribute('data-name'), row.getAttribute('data-storage'), row);
       });
     });
     document.querySelectorAll('.cliprow [data-delete]').forEach(function(btn){
@@ -4082,17 +4195,13 @@
     }, null, { title: 'Delete ' + names.length + ' take(s)?', okLabel: 'Delete', danger: true });
   });
   document.getElementById('bulkDownload').addEventListener('click', function(){
-    // One take at a time client-side rather than a multi-take zip endpoint
-    // -- see raw_files.py's build_take_zip() docstring: even a single
-    // take's zip briefly doubles disk usage on a storage-constrained Pi,
-    // so a real multi-take zip endpoint isn't a safe default here yet.
+    // No server-side combined-zip endpoint exists (W9), and the old
+    // window.location-per-take stagger raced itself -- the button is
+    // disabled above >1 selection, so this only ever fires for exactly one.
     var names = selectedClipNames();
-    names.forEach(function(name, i){
-      setTimeout(function(){
-        window.location = '/settings-editor/api/raw/takes/' + encodeURIComponent(name) + '/download';
-      }, i * 800);
-    });
-    if (names.length > 1) showToast('Downloading ' + names.length + ' takes one at a time…');
+    if (names.length !== 1) { return; }
+    var row = document.querySelector('.cliprow[data-name="' + CSS.escape(names[0]) + '"]');
+    if (row) { startTakeDownload(names[0], row.getAttribute('data-storage'), row); }
   });
 
   /* ---------- initial load ---------- */

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -4592,7 +4592,25 @@
   }
   var pageTabButtons = document.querySelectorAll('[data-page-tab]');
   var pageLedes = document.querySelectorAll('[data-page-lede]');
-  function setActivePage(page){
+  /* Which page a reload lands on. The rail's links already put a section id
+     in the hash (#cam0, #steps, ...) and every section declares its page via
+     data-page, so the hash alone answers this -- a separate storage key would
+     be a second source of truth that can contradict a URL like
+     .../settings-editor/#cam0 with no principled winner. An unknown or stale
+     id falls back to the default rather than showing nothing. */
+  var PAGE_LANDING = { config: 'bootconfig', settings: 'welcome', raw: 'clips', live: 'live' };
+  var DEFAULT_PAGE = 'settings';
+  function pageFromHash(){
+    var id = (location.hash || '').slice(1);
+    if (!id) return DEFAULT_PAGE;
+    var el = document.getElementById(id);
+    var group = el && el.closest('.group[data-page]');
+    var page = group && group.getAttribute('data-page');
+    return Object.prototype.hasOwnProperty.call(PAGE_LANDING, page) ? page : DEFAULT_PAGE;
+  }
+
+  function setActivePage(page, opts){
+    opts = opts || {};
     /* loadConfigTxt() only ever ran once, at page load (see the bottom of
        this script). config.txt can change underneath an open tab without
        any of this page's own doing -- an SSH edit, a save from a different
@@ -4602,7 +4620,7 @@
        on every arrival at the config page instead, skipped only when there
        are unsaved edits already in progress (configDirty) so this can't
        silently discard those. */
-    if (page === 'config' && activePage !== 'config' && !configDirty) loadConfigTxt();
+    if (page === 'config' && activePage !== 'config' && !configDirty && !opts.skipConfigLoad) loadConfigTxt();
     activePage = page;
     pageTabButtons.forEach(function(b){
       var isActive = b.getAttribute('data-page-tab') === page;
@@ -4615,7 +4633,13 @@
     });
     updateGroupVisibility();
     syncTopbarForPage();
-    window.scrollTo({ top: 0, behavior: reduceMotion ? 'auto' : 'smooth' });
+    /* pushState, not replaceState: the rail's anchors push real history
+       entries, so replacing here would silently destroy the deep-link the
+       operator is standing on (at #steps, a tab click would rewrite that
+       entry and Back would skip past it). A tab click is a navigation the
+       operator made; giving it its own entry keeps Back meaning "undo that". */
+    if (!opts.keepHash) history.pushState(null, '', '#' + PAGE_LANDING[page]);
+    if (!opts.keepScroll) window.scrollTo({ top: 0, behavior: reduceMotion ? 'auto' : 'smooth' });
   }
   pageTabButtons.forEach(function(b){ b.addEventListener('click', function(){ setActivePage(b.getAttribute('data-page-tab')); }); });
   document.querySelectorAll('[data-goto-page]').forEach(function(a){
@@ -4741,7 +4765,25 @@
   styleTag.textContent = '@keyframes spin{from{transform:rotate(0)}to{transform:rotate(360deg)}}';
   document.head.appendChild(styleTag);
 
-  setActivePage('settings');
+  /* Restore the page the operator was on. Only the page: the section is
+     already handled -- on a fresh load the browser's fragment scroll lands on
+     the hash, and on a reload Chrome restores the exact prior offset, which is
+     finer than any scrollIntoView we could do. keepHash so this does not
+     rewrite the URL it just read; keepScroll so it does not fight either of
+     those; skipConfigLoad because config.txt is fetched unconditionally above. */
+  setActivePage(pageFromHash(), { keepHash: true, keepScroll: true, skipConfigLoad: true });
+  /* Back/forward across panes. The browser's fragment scroll fires BEFORE
+     hashchange, so at that moment the target section is still display:none and
+     the scroll is a no-op on a box-less element; scroll again once the page
+     that owns it is visible. */
+  window.addEventListener('hashchange', function(){
+    var page = pageFromHash();
+    if (page !== activePage){
+      setActivePage(page, { keepHash: true, keepScroll: true });
+      var target = document.getElementById((location.hash || '').slice(1));
+      if (target) target.scrollIntoView({ behavior: 'auto', block: 'start' });
+    }
+  });
   refreshDrawer();
 })();
 </script>

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -116,6 +116,7 @@
      bare level). One author rule restores the attribute's meaning for all of
      them; !important is what makes it beat the class rules. */
   [hidden]{ display:none !important; }
+  .cliprow.is-busy{ opacity:.5; pointer-events:none; }
   html,body{ height:auto; }
   body{
     margin:0;
@@ -4129,11 +4130,25 @@
       btn.addEventListener('click', function(){
         var name = btn.closest('.cliprow').getAttribute('data-name');
         showConfirm('Delete take "' + name + '"? This cannot be undone.', function(){
+          /* rmtree is thousands of unlinks and refreshRawPane() behind it
+             stats every file on the card, so the row stays on screen well
+             after the take is gone. Without this the operator taps twice and
+             the second one used to report a failure for a delete that
+             worked. */
+          if (btn.disabled) { return; }
+          btn.disabled = true;
+          var row = btn.closest('.cliprow');
+          if (row) { row.classList.add('is-busy'); }
           fetch('/settings-editor/api/raw/takes/' + encodeURIComponent(name), { method: 'DELETE' })
             .then(function(r){ return r.json(); }).then(function(res){
               showToast(res.ok ? 'Deleted ' + name : 'Delete failed: ' + res.message);
-              if (res.ok) refreshRawPane();
-            }).catch(function(err){ showToast('Delete failed: ' + err); });
+              if (res.ok) { refreshRawPane(); }
+              else { btn.disabled = false; if (row) { row.classList.remove('is-busy'); } }
+            }).catch(function(err){
+              showToast('Delete failed: ' + err);
+              btn.disabled = false;
+              if (row) { row.classList.remove('is-busy'); }
+            });
         }, null, { title: 'Delete this take?', okLabel: 'Delete', danger: true });
       });
     });

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -438,6 +438,9 @@
 
   .filepath{
     font-size: 12px; color: var(--muted); display:flex; align-items:center; gap:6px;
+    /* A resolved absolute path is far longer than the relative form this
+       showed before, and .card-control is not a min-width:0 flex item. */
+    min-width:0; overflow-wrap:anywhere;
   }
   .filepath svg{ opacity:.6; flex:none; }
 
@@ -1741,7 +1744,14 @@
             <p class="card-help">Source file describing every supported sensor's modes. Edit only if you're adding hardware support.</p>
           </div>
           <div class="card-control">
-            <span class="filepath mono"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>resources/sensors.json</span>
+            <span class="filepath mono"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>{{ sensor_db_path }}</span>
+            <!-- The card is read-only, but the key still has to round-trip:
+                 buildState() only collects [data-path] elements, so without
+                 this field a Save posts no sensors.database_file at all and
+                 _apply_settings_defaults setdefaults it back to the stock
+                 "resources/sensors.json" -- silently discarding an
+                 operator's override. -->
+            <input type="hidden" data-path="sensors.database_file">
           </div>
         </div>
       </div>
@@ -2220,12 +2230,12 @@
     <section class="group" id="live" data-page="live">
       <header class="group-head">
         <h2>Live view</h2>
-        <p class="group-sub">The real Cinemate live-camera page, embedded and scaled to fit this column. Every control here is the genuine on-camera preview + <span class="mono">/api/v1/cmd</span> control surface — nothing here is a mockup.</p>
+        <p class="group-sub">The real Cinemate live-camera page, embedded at this column’s width. Every control here is the genuine on-camera preview + <span class="mono">/api/v1/cmd</span> control surface — nothing here is a mockup.</p>
       </header>
       <div class="live-embed-wrap">
         <iframe id="liveEmbedFrame" class="live-embed-frame" src="/" title="Cinemate live camera preview" loading="lazy"></iframe>
       </div>
-      <p class="card-help" style="margin-top:14px">Opens <a class="mono" href="/" target="_blank" rel="noopener">/</a> in a scaled frame. If controls feel cramped, open it in its own tab full-size.</p>
+      <p class="card-help" style="margin-top:14px;max-width:60ch">This is the page on port <span class="mono">5000</span> with <span class="mono">/settings-editor</span> dropped off the address — <a href="/" target="_blank" rel="noopener">open it in its own tab</a> if the controls feel cramped in here. The clean feed, no controls over it, is on port <span class="mono">8000</span> at <span class="mono">/stream</span> — same address, <span class="mono">8001</span> for cam1 on a dual‑sensor rig.</p>
     </section>
 
   </main>

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -185,12 +185,6 @@
   }
   .pill.is-dirty{ color: var(--dirty); border-color: var(--dirty); background: var(--dirty-soft); }
   .pill .dot{ width:6px; height:6px; border-radius:50%; background: currentColor; }
-  /* .pill/.btn/.icon-action/.card all set their own `display`, which beats
-     the UA's [hidden]{display:none} rule -- so hidden="" alone does nothing
-     on any of them (#dirtyPill showed "0 UNSAVED" permanently; five RAW/Live
-     controls and two CSI-2 link cards stayed rendered while "hidden"). */
-  #dirtyPill[hidden], .btn[hidden], .icon-action[hidden], .card[hidden]{ display:none !important; }
-
   .btn{
     font-family:'DIN2014',sans-serif; font-weight:700; font-size:12.5px; letter-spacing:0.04em;
     border-radius: var(--radius);
@@ -2038,7 +2032,6 @@
       <div class="bulk-bar" id="bulkBar">
         <span id="bulkCount">0 selected</span>
         <span class="actions">
-          <button class="btn btn-primary" id="bulkDownloadFolder" hidden>Download into a folder…</button>
           <button class="btn btn-primary" id="bulkDownload">Download selected</button>
           <button class="btn btn-danger-outline" id="bulkDelete">Delete selected</button>
         </span>
@@ -3904,11 +3897,12 @@
      form edits with no beforeunload guard. An <a download> click hands the
      request to the browser's download manager instead, so none of that can
      happen -- the document never navigates. showDirectoryPicker() needs a
-     secure context (HTTPS); the camera is only ever reached over plain HTTP
-     (hotspot or mDNS), so CAN_PICK_FOLDER is expected false there and this
-     capability-gates rather than assumes. */
+     secure context: HTTPS (module.https_settings, off by default -- see
+     settings.jsonc's system.https), or a plain browser secure-context
+     exemption such as http://localhost. A camera reached over the hotspot's
+     plain-HTTP address or over mDNS has neither, so CAN_PICK_FOLDER is
+     false there and this capability-gates rather than assumes. */
   var CAN_PICK_FOLDER = !!(window.isSecureContext && window.showDirectoryPicker);
-  var DOWNLOAD_CONCURRENCY = 2; // matches raw_files.DOWNLOAD_SEMAPHORE
   var refreshSuppressed = false;
 
   function takeDownloadUrl(name, storage){
@@ -4069,14 +4063,17 @@
     footer.textContent = takes.length
       ? 'Showing all ' + takes.length + ' take' + (takes.length === 1 ? '' : 's') + ' across mounted storage.'
       : 'No takes found on mounted storage.';
-    // showDirectoryPicker() needs a secure context; this page is served
-    // over plain HTTP on the hotspot and over mDNS, so it is unreachable
-    // here on every browser. Say so rather than let a missing folder
-    // picker read as a bug.
+    // showDirectoryPicker() needs a secure context, and even there only
+    // Chromium implements it -- Safari and Firefox expose it on neither http
+    // nor https. Two different reasons read as the same missing button, so
+    // say which one applies rather than let it look like a bug either way.
     if (!CAN_PICK_FOLDER) {
-      footer.textContent += ' This page is served over plain HTTP, so it cannot ask where to save a ' +
-        'download — enable "Ask where to save each file" in your browser’s download settings to ' +
-        'choose a folder yourself.';
+      footer.textContent += window.isSecureContext
+        ? ' This browser has no folder picker (Chromium only, today) — enable ' +
+          '"Ask where to save each file" in your download settings to choose a folder yourself.'
+        : ' This page is served over plain HTTP, so it cannot ask where to save a download — turn on ' +
+          'system.https in settings.jsonc, or enable "Ask where to save each file" in your browser’s ' +
+          'download settings to choose a folder yourself.';
     }
 
     wireClipRowActions();
@@ -4158,33 +4155,59 @@
     }
   }
 
-  function startPickedDownload(name, storage, row){
+  // The folder is picked once, whether one take or several are queued --
+  // asking again per take would re-prompt for permission on every file.
+  function pickFolder(){
+    // mode:'readwrite' up front, rather than letting the first
+    // createWritable() request it implicitly: that first request lands after
+    // an async manifest fetch, by which point user activation can have
+    // expired, turning one prompt into a second one (or a NotAllowedError).
+    return window.showDirectoryPicker({
+      id: 'cinemate-raw-downloads', mode: 'readwrite', startIn: 'downloads',
+    });
+  }
+
+  // One take, into an already-picked folder. Returns a promise so the bulk
+  // path below can chain N of these; refreshSuppressed is the caller's job
+  // (set once for a whole batch, not toggled per take -- see refreshRawPane's
+  // comment on why a mid-batch refresh would destroy the row it is showing
+  // progress on).
+  function savePickedTakeIntoRow(dirRoot, name, storage, row){
     var fill = row.querySelector('[data-progress-fill]');
     var text = row.querySelector('[data-progress-text]');
     var cancelBtn = row.querySelector('[data-cancel-download]');
     var onCancel = function(){ if (pickerAbort) { pickerAbort.abort(); } };
-    window.showDirectoryPicker({ id: 'cinemate-raw-downloads' }).then(function(dirRoot){
-      return fetch(takeFilesUrl(name, storage)).then(function(r){ return r.json(); }).then(function(manifest){
-        if (!manifest.ok) { throw new Error(manifest.message || 'could not read that take'); }
-        row.classList.add('is-downloading');
-        fill.style.width = '0%';
-        text.textContent = 'Starting…';
-        cancelBtn.addEventListener('click', onCancel);
-        refreshSuppressed = true;
-        return savePickedTake(dirRoot, name, storage, manifest.files, function(frac){
-          var pct = Math.round(frac * 100);
-          fill.style.width = pct + '%';
-          text.textContent = pct + '%';
-        }).then(function(){
-          showToast('Saved ' + name);
-        }, function(err){
-          var msg = downloadErrorToast(err);
-          if (msg) { showToast(msg); }
-        }).then(function(){
-          cancelBtn.removeEventListener('click', onCancel);
-          row.classList.remove('is-downloading');
-          refreshSuppressed = false;
-        });
+    return fetch(takeFilesUrl(name, storage)).then(function(r){ return r.json(); }).then(function(manifest){
+      if (!manifest.ok) { throw new Error(manifest.message || 'could not read that take'); }
+      row.classList.add('is-downloading');
+      fill.style.width = '0%';
+      text.textContent = 'Starting…';
+      cancelBtn.addEventListener('click', onCancel);
+      return savePickedTake(dirRoot, name, storage, manifest.files, function(frac){
+        var pct = Math.round(frac * 100);
+        fill.style.width = pct + '%';
+        text.textContent = pct + '%';
+      });
+    }).then(function(){
+      cancelBtn.removeEventListener('click', onCancel);
+      row.classList.remove('is-downloading');
+    }, function(err){
+      cancelBtn.removeEventListener('click', onCancel);
+      row.classList.remove('is-downloading');
+      throw err;
+    });
+  }
+
+  function startPickedDownload(name, storage, row){
+    pickFolder().then(function(dirRoot){
+      refreshSuppressed = true;
+      return savePickedTakeIntoRow(dirRoot, name, storage, row).then(function(){
+        showToast('Saved ' + name);
+      }, function(err){
+        var msg = downloadErrorToast(err);
+        if (msg) { showToast(msg); }
+      }).then(function(){
+        refreshSuppressed = false;
       });
     }).catch(function(err){
       if (err && err.name === 'AbortError') { return; } // picker dialog dismissed
@@ -4219,11 +4242,14 @@
     document.getElementById('bulkCount').textContent = names.length + ' selected';
     bar.classList.toggle('show', names.length > 0);
     document.getElementById('selectAllClips').checked = names.length > 0 && names.length === currentTakes.length;
-    // No server-side combined-zip endpoint exists, and N parallel per-take
-    // downloads race each other (see raw_files.DOWNLOAD_SEMAPHORE) -- so
-    // "download selected" is honest only for exactly one take at a time.
+    // With a folder picker, several takes download sequentially into it, one
+    // write stream at a time -- see the bulk handler below. Without one there
+    // is no server-side combined-zip endpoint, and N parallel per-take
+    // <a download> clicks would race each other (raw_files.DOWNLOAD_SEMAPHORE
+    // caps concurrent server-side reads at 2), so "download selected" stays
+    // honest only for exactly one take at a time on that fallback path.
     var bulkDownloadBtn = document.getElementById('bulkDownload');
-    var tooManyForDownload = names.length > 1;
+    var tooManyForDownload = !CAN_PICK_FOLDER && names.length > 1;
     bulkDownloadBtn.disabled = tooManyForDownload;
     bulkDownloadBtn.title = tooManyForDownload
       ? 'Download one take at a time — select a single take to download it'
@@ -4253,7 +4279,14 @@
           btn.disabled = true;
           var row = btn.closest('.cliprow');
           if (row) { row.classList.add('is-busy'); }
-          fetch('/settings-editor/api/raw/takes/' + encodeURIComponent(name), { method: 'DELETE' })
+          // Same idiom as the download path: without ?storage=, a take name
+          // duplicated across /media/RAW and /media/RAW1 resolves to
+          // whichever mounted root delete_take() checks first, which can be
+          // the wrong copy.
+          var deleteUrl = '/settings-editor/api/raw/takes/' + encodeURIComponent(name);
+          var storage = row ? row.getAttribute('data-storage') : null;
+          if (storage) { deleteUrl += '?storage=' + encodeURIComponent(storage); }
+          fetch(deleteUrl, { method: 'DELETE' })
             .then(function(r){ return r.json(); }).then(function(res){
               showToast(res.ok ? 'Deleted ' + name : 'Delete failed: ' + res.message);
               if (res.ok) { refreshRawPane(); }
@@ -4282,74 +4315,65 @@
       fetch('/settings-editor/api/raw/bulk', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'delete', names: names })
-      }).then(function(r){ return r.json(); }).then(function(res){
-        showToast(res.ok ? 'Deleted ' + names.length + ' take(s)' : 'Some deletes failed — see console');
-        if (!res.ok) console.warn('Bulk delete results', res.results);
+      }).then(function(r){
+        return r.json().then(function(res){ return { status: r.status, res: res }; });
+      }).then(function(result){
+        var status = result.status, res = result.res;
+        if (status === 409) {
+          // Whole-request refusal (a recording take was in the selection):
+          // res.recording names which ones, rather than the generic
+          // "Some deletes failed" this used to collapse into.
+          var blocked = (res.recording || []).join(', ');
+          showToast(blocked ? res.message + ': ' + blocked : res.message);
+          return;
+        }
+        if (res.ok) {
+          showToast('Deleted ' + names.length + ' take(s)');
+        } else {
+          var failedNames = Object.keys(res.results || {})
+            .filter(function(n){ return !res.results[n].ok; });
+          var firstReason = failedNames.length
+            ? res.results[failedNames[0]].message : '';
+          showToast('Some deletes failed (' + failedNames.length + '/' + names.length + '): ' +
+            failedNames[0] + ' — ' + firstReason +
+            (failedNames.length > 1 ? ' (see console for the rest)' : ''));
+          console.warn('Bulk delete results', res.results);
+        }
         refreshRawPane();
       }).catch(function(err){ showToast('Bulk delete failed: ' + err); });
     }, null, { title: 'Delete ' + names.length + ' take(s)?', okLabel: 'Delete', danger: true });
   });
   document.getElementById('bulkDownload').addEventListener('click', function(){
-    // No server-side combined-zip endpoint exists (W9), and the old
-    // window.location-per-take stagger raced itself -- the button is
-    // disabled above >1 selection, so this only ever fires for exactly one.
     var names = selectedClipNames();
-    if (names.length !== 1) { return; }
-    var row = document.querySelector('.cliprow[data-name="' + CSS.escape(names[0]) + '"]');
-    if (row) { startTakeDownload(names[0], row.getAttribute('data-storage'), row); }
-  });
-
-  /* ---------- download straight into a chosen folder ----------
-     showDirectoryPicker() is the only browser API that can write into a
-     directory the operator names, and it exists only on a SECURE context --
-     so on plain HTTP it is undefined and this button stays hidden, with the
-     plain per-take download still there. Turn on system.https in
-     settings.jsonc to get it. It is also Chromium-only today: Safari and
-     Firefox expose neither, on http or https.
-
-     It also sidesteps the bulk-download race below: each take is fetched and
-     written to completion before the next one starts, instead of n top-level
-     navigations 800 ms apart cancelling each other. */
-  var folderDownloadSupported = (typeof window.showDirectoryPicker === 'function');
-  (function(){
-    var btn = document.getElementById('bulkDownloadFolder');
-    if (!btn) { return; }
-    btn.hidden = !folderDownloadSupported;
-    if (!folderDownloadSupported) { return; }
-    btn.addEventListener('click', function(){
-      var names = selectedClipNames();
-      if (!names.length) { return; }
-      var dir;
-      window.showDirectoryPicker({ mode: 'readwrite', startIn: 'downloads' })
-        .then(function(handle){
-          dir = handle;
-          btn.disabled = true;
-          return names.reduce(function(chain, name, i){
-            return chain.then(function(){
-              showToast('Saving ' + (i + 1) + ' of ' + names.length + ': ' + name);
-              return fetch('/settings-editor/api/raw/takes/' +
-                           encodeURIComponent(name) + '/download')
-                .then(function(res){
-                  if (!res.ok) { throw new Error(name + ' — ' + res.status); }
-                  return dir.getFileHandle(name + '.zip', { create: true })
-                    .then(function(fh){ return fh.createWritable(); })
-                    .then(function(w){ return res.body.pipeTo(w); });
-                });
-            });
-          }, Promise.resolve());
-        })
-        .then(function(){
-          if (dir) { showToast('Saved ' + names.length +
-                               (names.length === 1 ? ' take' : ' takes')); }
-        })
-        .catch(function(err){
-          // AbortError is the operator dismissing the picker, not a failure.
-          if (err && err.name === 'AbortError') { return; }
-          showToast('Download failed: ' + (err && err.message ? err.message : err));
-        })
-        .then(function(){ btn.disabled = false; });
+    if (!names.length) { return; }
+    if (names.length === 1) {
+      var row = document.querySelector('.cliprow[data-name="' + CSS.escape(names[0]) + '"]');
+      if (row) { startTakeDownload(names[0], row.getAttribute('data-storage'), row); }
+      return;
+    }
+    // More than one take is only reachable here with a folder picker --
+    // updateBulkBar() disables this button above one selection otherwise.
+    if (!CAN_PICK_FOLDER) { return; }
+    pickFolder().then(function(dirRoot){
+      refreshSuppressed = true;
+      return names.reduce(function(chain, name, i){
+        return chain.then(function(){
+          var row = document.querySelector('.cliprow[data-name="' + CSS.escape(name) + '"]');
+          if (!row) { return; } // no longer listed -- skip rather than fail the batch
+          showToast('Saving ' + (i + 1) + ' of ' + names.length + ': ' + name);
+          return savePickedTakeIntoRow(dirRoot, name, row.getAttribute('data-storage'), row);
+        });
+      }, Promise.resolve());
+    }).then(function(){
+      refreshSuppressed = false;
+      showToast('Saved ' + names.length + ' takes');
+    }, function(err){
+      refreshSuppressed = false;
+      if (err && err.name === 'AbortError') { return; } // picker dismissed, or a take cancelled
+      var msg = downloadErrorToast(err);
+      showToast(msg || ('Download failed: ' + ((err && err.message) || err)));
     });
-  })();
+  });
 
   /* ---------- initial load ---------- */
   loadSettings();

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -2094,6 +2094,7 @@
       <div class="bulk-bar" id="bulkBar">
         <span id="bulkCount">0 selected</span>
         <span class="actions">
+          <button class="btn btn-primary" id="bulkDownloadFolder" hidden>Download into a folder…</button>
           <button class="btn btn-primary" id="bulkDownload">Download selected</button>
           <button class="btn btn-danger-outline" id="bulkDelete">Delete selected</button>
         </span>
@@ -4188,6 +4189,58 @@
     });
     if (names.length > 1) showToast('Downloading ' + names.length + ' takes one at a time…');
   });
+
+  /* ---------- download straight into a chosen folder ----------
+     showDirectoryPicker() is the only browser API that can write into a
+     directory the operator names, and it exists only on a SECURE context --
+     so on plain HTTP it is undefined and this button stays hidden, with the
+     plain per-take download still there. Turn on system.https in
+     settings.jsonc to get it. It is also Chromium-only today: Safari and
+     Firefox expose neither, on http or https.
+
+     It also sidesteps the bulk-download race below: each take is fetched and
+     written to completion before the next one starts, instead of n top-level
+     navigations 800 ms apart cancelling each other. */
+  var folderDownloadSupported = (typeof window.showDirectoryPicker === 'function');
+  (function(){
+    var btn = document.getElementById('bulkDownloadFolder');
+    if (!btn) { return; }
+    btn.hidden = !folderDownloadSupported;
+    if (!folderDownloadSupported) { return; }
+    btn.addEventListener('click', function(){
+      var names = selectedClipNames();
+      if (!names.length) { return; }
+      var dir;
+      window.showDirectoryPicker({ mode: 'readwrite', startIn: 'downloads' })
+        .then(function(handle){
+          dir = handle;
+          btn.disabled = true;
+          return names.reduce(function(chain, name, i){
+            return chain.then(function(){
+              showToast('Saving ' + (i + 1) + ' of ' + names.length + ': ' + name);
+              return fetch('/settings-editor/api/raw/takes/' +
+                           encodeURIComponent(name) + '/download')
+                .then(function(res){
+                  if (!res.ok) { throw new Error(name + ' — ' + res.status); }
+                  return dir.getFileHandle(name + '.zip', { create: true })
+                    .then(function(fh){ return fh.createWritable(); })
+                    .then(function(w){ return res.body.pipeTo(w); });
+                });
+            });
+          }, Promise.resolve());
+        })
+        .then(function(){
+          if (dir) { showToast('Saved ' + names.length +
+                               (names.length === 1 ? ' take' : ' takes')); }
+        })
+        .catch(function(err){
+          // AbortError is the operator dismissing the picker, not a failure.
+          if (err && err.name === 'AbortError') { return; }
+          showToast('Download failed: ' + (err && err.message ? err.message : err));
+        })
+        .then(function(){ btn.disabled = false; });
+    });
+  })();
 
   /* ---------- initial load ---------- */
   loadSettings();

--- a/src/module/app/templates/template.html
+++ b/src/module/app/templates/template.html
@@ -34,6 +34,7 @@
             --box-text: #000;
             --zoom-hi: rgb(255, 221, 0);
             --drop: rgb(120, 40, 180);
+            --drop-text: rgb(255, 255, 255);
             --sync: rgb(255, 0, 255);
             --log-badge: rgb(205, 205, 205);
             --hdr-badge: rgb(205, 205, 205);
@@ -49,6 +50,14 @@
             --label-size: clamp(0.72rem, 1.45vw, 1.35rem);
             --box-size: clamp(38px, 3.6vw, 60px);
             --box-height: clamp(28px, 2.5vw, 40px);
+
+            /* W1+W2: the rail re-derives these four from *-base * --fit
+               (see .rail below and fitRails()). The names above stay the
+               laptop-authored minimums tools/design_token_diff.py reads. */
+            --gap-base:        clamp(8px, 1.4vw, 22px);
+            --label-size-base: clamp(0.72rem, 1.45vw, 1.35rem);
+            --box-size-base:   clamp(38px, 3.6vw, 60px);
+            --box-height-base: clamp(28px, 2.5vw, 40px);
         }
 
         /* draw_gui() switches every label and value to black once the
@@ -92,7 +101,12 @@
             flex-wrap: wrap;
             justify-content: space-between;
             align-items: baseline;
-            gap: calc(var(--gap) * 0.5) var(--gap);
+            /* Row gap must be at least twice .group select's 8px vertical
+               bleed, or the two wrapped rows' invisible hit areas meet in
+               the middle and the lower row's picker wins the upper row's
+               bottom 4px. Inert whenever the row does not wrap, so it costs
+               nothing at any width the HDMI GUI has a counterpart for. */
+            gap: max(16px, calc(var(--gap) * 0.5)) var(--gap);
         }
 
         .group {
@@ -130,11 +144,14 @@
            the text is only ~18px tall on a phone, far under the ~44px
            touch-target guideline. px, not em: em here would resolve
            against the UA's hidden control font (13-16px depending on
-           engine), not the visible text. Invisible, so the only cost is
-           ambiguity where the top row wraps on a portrait phone: rows sit
-           4px apart there, so a lower row's select reaches ~4px into the
-           row above — a tap on those descender pixels opens the lower
-           group's picker. Recoverable, and only in the wrapped layout. */
+           engine), not the visible text. Invisible, so the cost is that
+           where the top row wraps on a portrait phone, the lower row's
+           select wins a 4px strip of the row above — DOM order breaks the
+           tie between two position:absolute, z-index:auto siblings — which
+           cancels this rule's own tap-target gain for the two affected
+           groups. #top-row's row gap (below) is what prevents it; the two
+           rules are coupled. That 4px band is line-box leading, not
+           descender ink — it contains no glyph. */
         .group select {
             position: absolute;
             inset: -8px -6px;
@@ -192,13 +209,54 @@
             overflow-y: auto;
             overflow-x: hidden;
             scrollbar-width: thin;
+            /* W1+W2: --fit is written by fitRails() and is the smaller of the
+               height ratio (rail content vs stage row) and the width ratio
+               (rail budget vs viewport). The max() floors are the legibility
+               floor; when one binds, fitRails sets .clipped and the fade
+               fallback (below) shows. Operator ruling: rails stay left and
+               right at every viewport and shrink, never restack -- this is
+               the shrink. */
+            --gap:         max(6px,  calc(var(--gap-base)        * var(--fit, 1)));
+            --label-size:  max(11px, calc(var(--label-size-base) * var(--fit, 1)));
+            --box-size:    max(31px, calc(var(--box-size-base)   * var(--fit, 1)));
+            --box-height:  max(23px, calc(var(--box-height-base) * var(--fit, 1)));
             /* draw_left_sections() starts its CAM column at y=97 on the
                1080p canvas — roughly a box-height of air below the top row.
                Reproduce that offset so the rails sit like the HDMI GUI's
-               instead of hugging the top bar. */
-            padding-top: calc(var(--box-height) * 1.3);
+               instead of hugging the top bar. --rail-pad shrinks this dead
+               band once the rail is actually being fitted. */
+            padding-top: calc(var(--box-height) * var(--rail-pad, 1.3));
+            overscroll-behavior: contain;   /* matches #experiment; the rails were missed */
+        }
+        .rail.fitted { --rail-pad: 0.4; }   /* reclaim the dead band once we are shrinking */
+        /* Fallback only, once the legibility floor above stops the shrink
+           short of the rail's available height (fitRails sets .clipped).
+           A mask paints in the element's own border box and does not scroll
+           away with the content, unlike a ::after pseudo-element would. */
+        .rail.clipped.more-below {
+            -webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 26px), transparent);
+                    mask-image: linear-gradient(to bottom, #000 calc(100% - 26px), transparent);
+        }
+        .rail.clipped.more-above {
+            -webkit-mask-image: linear-gradient(to bottom, transparent, #000 14px);
+                    mask-image: linear-gradient(to bottom, transparent, #000 14px);
+        }
+        .rail.clipped.more-above.more-below {
+            -webkit-mask-image: linear-gradient(to bottom, transparent, #000 14px, #000 calc(100% - 26px), transparent);
+                    mask-image: linear-gradient(to bottom, transparent, #000 14px, #000 calc(100% - 26px), transparent);
         }
         .rail:empty { display: none; }
+
+        /* W1: narrow width only, claws back the fixed chrome around the
+           rails. The rails themselves shrink through --fit (fitRails, in the
+           script below), never through this block. Width-keyed, so 812x375
+           landscape does NOT match -- unlike the @media below (:orientation),
+           which fires on landscape phones. No .rail declaration belongs here:
+           that would be a second, equal-specificity geometry mechanism. */
+        @media (max-width: 540px) {
+            #stage { gap: 6px; }
+            #app   { padding-left: 4px; padding-right: 4px; }
+        }
 
         .section { display: flex; flex-direction: column; align-items: center; }
         .section + .section { margin-top: calc(var(--gap) * 0.7); }
@@ -229,9 +287,19 @@
         /* aspect and anamorphic get the inset outline simple_gui draws */
         .box.outlined { box-shadow: inset 0 0 0 2px #000; }
         .box.small { font-size: calc(var(--box-height) * 0.48); }
+        /* A warning box may carry a count ("DROP 17"). simple_gui's box is a fixed
+           60x40 and shrinks the font instead (simple_gui.py:1290-1293); the browser
+           has room. Grow on the inline axis only, from the same --box-size floor,
+           so every box that already fits keeps the rail's pitch. */
+        .box.wide {
+            width: auto;
+            min-width: var(--box-size);
+            padding-inline: calc(var(--box-height) * 0.18);
+            white-space: nowrap;
+        }
         .box.zoom-active { background: var(--zoom-hi); }
         .box.log { background: var(--log-badge); }
-        .box.drop { background: var(--drop); }
+        .box.drop { background: var(--drop); color: var(--drop-text); }
         .box.sync { background: var(--sync); position: relative; }
         /* _draw_status_box(crossed=True) strikes the SYNC box through */
         .box.sync::after {
@@ -564,9 +632,12 @@
            This used to restack #stage into rows and turn each .rail into a
            horizontal strip above/below the preview at <=900px or portrait
            -- the one thing that made the web GUI stop resembling the HDMI
-           GUI at narrow widths (simple_gui.py scales its whole 1920x1080
-           layout by a single disp_width/1920, disp_height/1080 ratio; it
-           never restacks). #stage's 3-column grid (left rail | preview |
+           GUI at narrow widths. simple_gui.py never restacks either, but it
+           does not scale its whole layout by one ratio: only the top row,
+           layout-dict positions, the HDR badge and the clip name scale by
+           disp_width/1920 / disp_height/1080 -- draw_left_sections() and
+           draw_right_sections() draw the rail boxes at a fixed BOX_H/BOX_W
+           with no shrink factor at all. #stage's 3-column grid (left rail | preview |
            right rail) and .rail's own column direction are the same at
            every width now -- --gap/--box-size/--box-height/--value-size/
            --label-size are already clamp()-based (top of this file), so
@@ -796,7 +867,7 @@
         if (V.drop_frame_latched) {
             const count = Number(V.drop_frame_count) || 0;
             const label = count > 0 ? `DROP ${count}` : 'DROP';
-            out.push(box(label, 'drop' + (label.length > 4 ? ' small' : '')));
+            out.push(box(label, 'drop' + ' small' + (count > 0 ? ' wide' : '')));
         }
         if (V.frames_off_sync) { out.push(box('SYNC', 'sync')); }
         return out;
@@ -1039,8 +1110,14 @@
 
     function renderSelectors() {
         fillSelect($('s-iso'), steps.iso.map((v) => ({ value: v, text: v })), V.iso);
+        // find() returns undefined when the live angle isn't in the current
+        // step table (e.g. a rejected pick on a locked shutter, or a
+        // free-stepping table rebuild); fillSelect() then leaves the select
+        // showing whatever was last chosen. Fall back to '' so a stale pick
+        // clears instead of silently lingering.
+        const shutterLive = steps.shutter_a.find((v) => String(v) === String(parseFloat(V.shutter_speed)));
         fillSelect($('s-shutter'), steps.shutter_a.map((v) => ({ value: v, text: v })),
-            steps.shutter_a.find((v) => String(v) === String(parseFloat(V.shutter_speed))));
+            shutterLive !== undefined ? shutterLive : '');
         fillSelect($('s-fps'), steps.fps.map((v) => ({ value: v, text: v })), V.fps);
         fillSelect($('s-wb'), steps.wb.map((v) => ({ value: v, text: v + 'K' })), V.wb);
         fillSelect($('s-res'),
@@ -1079,6 +1156,14 @@
     // is present only on a sensor that actually has ClearHDR modes — on an
     // imx477 or imx283 those four commands write redis keys nothing will ever
     // read, so offering them would be four controls that appear to do nothing.
+    // Shared with the top row's lock guard (bindTopSelect, below) so the
+    // wording exists in exactly one place.
+    const LOCK_LABELS = {
+        iso_lock: 'ISO is locked',
+        shutter_a_nom_lock: 'Shutter angle is locked',
+        fps_lock: 'Frame rate is locked',
+    };
+
     const XP_SLIDER_GROUPS = [
         {
             title: 'EXPOSURE',
@@ -1093,19 +1178,19 @@
                 // the ends off the live table means widening arrays.iso.steps
                 // widens the slider instead of silently disagreeing with it.
                 { label: 'ISO',         cmd: 'set iso',           key: 'iso',           min: 100, max: 3200, step: 1,
-                  boundsFrom: 'iso', lockKey: 'iso_lock', lockLabel: 'ISO is locked' },
+                  boundsFrom: 'iso', lockKey: 'iso_lock', lockLabel: LOCK_LABELS.iso_lock },
                 // set_shutter_a_nom() snaps to the flicker-free angle table in
                 // normal mode and accepts verbatim in free/sync mode. Indexing
                 // the table is correct in BOTH: free stepping rebuilds it as a
                 // fine continuous grid, which the setter then takes verbatim.
                 { label: 'SHUTTER NOM', cmd: 'set shutter a nom', key: 'shutter_a_nom', steps: 'shutter_a', dp: 1,
-                  lockKey: 'shutter_a_nom_lock', lockLabel: 'Shutter angle is locked' },
+                  lockKey: 'shutter_a_nom_lock', lockLabel: LOCK_LABELS.shutter_a_nom_lock },
                 // set_fps() snaps into fps_steps_dynamic. Its setter can also
                 // trigger a sensor-mode change and block for up to two seconds
                 // inside the request, so this one gets a slower throttle and
                 // stops sending while a resolution switch is in flight.
                 { label: 'FPS',         cmd: 'set fps',           key: 'fps',           steps: 'fps',
-                  lockKey: 'fps_lock', lockLabel: 'Frame rate is locked',
+                  lockKey: 'fps_lock', lockLabel: LOCK_LABELS.fps_lock,
                   busyKey: 'resolution_switching', throttle: 600 },
                 // set_wb() snaps to wb_steps unconditionally, in every mode.
                 { label: 'WB',          cmd: 'set wb',            key: 'wb',            steps: 'wb' },
@@ -1578,7 +1663,59 @@
         renderPreview();
         renderSelectors();
         renderExperiment();
+        scheduleFit();
     }
+
+    // ── W1+W2: shrink-to-fit rails ───────────────────────────────────────
+    // Operator ruling (2026-09-01, binding): the rails stay left and right at
+    // every viewport, including portrait phone. The layout never reflows or
+    // restacks -- it shrinks. See the .rail rule above for the CSS half.
+    //
+    // Each rail may take at most 8.5% of the viewport width (W1). At 375 that
+    // is 31.9px against a 38px natural box -> 0.839, landing --box-size just
+    // above its 31px floor. Inert above 447px of viewport width
+    // (447 * 0.085 == 38), so no laptop/desktop viewport is affected.
+    const RAIL_WIDTH_SHARE = 0.085;
+
+    let fitPending = false;
+    function fitRails() {
+        fitPending = false;
+        ['rail-left', 'rail-right'].forEach((id) => {
+            const el = $(id);
+            if (!el || !el.isConnected || !el.clientHeight) { return; }
+            el.classList.remove('fitted');
+            el.style.setProperty('--fit', '1');          // measure at natural size
+            const natural  = el.scrollHeight, avail = el.clientHeight;
+            const naturalW = el.getBoundingClientRect().width;
+            const fitH = Math.min(1, avail / natural);                                   // W2, height
+            const fitW = Math.min(1, (window.innerWidth * RAIL_WIDTH_SHARE) / naturalW); // W1, width
+            const fit  = Math.min(fitH, fitW);
+            if (fit < 1) { el.classList.add('fitted'); }
+            el.style.setProperty('--fit', fit.toFixed(4));
+            // The max() floors in the .rail rule can stop the shrink short of
+            // avail -- say so out loud via the fade fallback (CSS above).
+            el.classList.toggle('clipped', el.scrollHeight - el.clientHeight > 1);
+            updateRailFade(el);
+        });
+    }
+    const scheduleFit = () => { if (!fitPending) { fitPending = true; requestAnimationFrame(fitRails); } };
+
+    function updateRailFade(el) {
+        el.classList.toggle('more-above', el.scrollTop > 0);
+        el.classList.toggle('more-below', el.scrollTop + el.clientHeight < el.scrollHeight - 1);
+    }
+    ['rail-left', 'rail-right'].forEach((id) => {
+        const el = $(id);
+        if (el) { el.addEventListener('scroll', () => updateRailFade(el), { passive: true }); }
+    });
+
+    // Observe #stage, not the rails: writing --fit changes a rail's own
+    // width, which would re-trigger a ResizeObserver on the rail itself.
+    // #stage's border box is fixed by the grid and only its columns
+    // redistribute, so this cannot loop. #stage's height also changes when
+    // the EXPERIMENT drawer opens, with no window resize -- exactly the case
+    // a media query cannot see.
+    if (window.ResizeObserver) { new ResizeObserver(scheduleFit).observe($('stage')); }
 
     // ── push: server → browser only (module/app/main/events.py) ────────
     const socket = io();
@@ -1731,11 +1868,32 @@
     }, 4000);
 
     // ── bindings ──────────────────────────────────────────────────────
-    $('s-iso').addEventListener('change', (e) => cmd('set iso ' + e.target.value));
-    $('s-shutter').addEventListener('change', (e) => cmd('set shutter a ' + e.target.value));
-    $('s-fps').addEventListener('change', (e) => cmd('set fps ' + e.target.value));
-    $('s-wb').addEventListener('change', (e) => cmd('set wb ' + e.target.value));
-    $('s-res').addEventListener('change', (e) => cmd('set resolution ' + e.target.value));
+    // A locked parameter's setter drops the write and still answers 200
+    // (cinepi_controller.set_fps / set_iso), so the only feedback today is
+    // _confirm_or_ok's generic "requested X, live value is Y" -- which never
+    // says "locked". SHUTTER is worse: the top row sends `set shutter a`,
+    // which never reads shutter_a_nom_lock, so the pill lies.
+    const TOP_LOCKS = {
+        's-iso':     { key: 'iso_lock',           label: LOCK_LABELS.iso_lock },
+        's-shutter': { key: 'shutter_a_nom_lock', label: LOCK_LABELS.shutter_a_nom_lock },
+        's-fps':     { key: 'fps_lock',           label: LOCK_LABELS.fps_lock },
+    };
+    function bindTopSelect(id, prefix) {
+        $(id).addEventListener('change', (e) => {
+            const guard = TOP_LOCKS[id];
+            if (guard && truthy(V[guard.key])) {
+                toast(guard.label);
+                renderSelectors();
+                return;
+            }
+            cmd(prefix + e.target.value);
+        });
+    }
+    bindTopSelect('s-iso',     'set iso ');
+    bindTopSelect('s-shutter', 'set shutter a ');
+    bindTopSelect('s-fps',     'set fps ');
+    bindTopSelect('s-wb',      'set wb ');
+    bindTopSelect('s-res',     'set resolution ');
 
     $('preview-frame').addEventListener('click', () => cmd('rec'));
     $('btn-log').addEventListener('click', () => cmd('set log'));
@@ -1761,20 +1919,38 @@
         new ResizeObserver(sizePreview).observe($('preview-wrap'));
     }
 
+    // iPhone Safari exposes no element-fullscreen API at all; iPad does
+    // (webkit-prefixed since iOS 12, unprefixed since 16.4). Probe the methods,
+    // never the UA, so iPad keeps the button and a future iPhone gains it. The
+    // preview is an MJPEG <img>, not a <video>, so there is no
+    // HTMLVideoElement.webkitEnterFullscreen() fallback here. Calling a missing
+    // method threw a TypeError inside the click listener that nothing caught --
+    // and button:active still flashed, so the control looked like it worked.
     const fsBtn = $('btn-fullscreen');
-    function toggleFullScreen() {
-        const el = document.documentElement;
-        const active = document.fullscreenElement || document.webkitFullscreenElement;
-        if (!active) {
-            (el.requestFullscreen || el.webkitRequestFullscreen).call(el);
-        } else {
-            (document.exitFullscreen || document.webkitExitFullscreen).call(document);
-        }
+    const fsRoot = document.documentElement;
+    const fsRequest = fsRoot.requestFullscreen || fsRoot.webkitRequestFullscreen;
+    const fsExit = document.exitFullscreen || document.webkitExitFullscreen;
+    const fsActive = () => document.fullscreenElement || document.webkitFullscreenElement;
+
+    show(fsBtn, Boolean(fsRequest && fsExit));
+
+    if (fsRequest && fsExit) {
+        fsBtn.addEventListener('click', () => {
+            // Both return a promise that rejects on an untrusted gesture or a
+            // blocking permissions policy. webkitRequestFullscreen returns
+            // undefined, hence the guard.
+            const p = fsActive() ? fsExit.call(document) : fsRequest.call(fsRoot);
+            if (p && p.catch) { p.catch((err) => toast('fullscreen → ' + err.message)); }
+        });
+        // Safari and iPadOS below 16.4 fire only the prefixed event and set only
+        // document.webkitFullscreenElement, so one name and one property left
+        // the label permanently stuck on 'FULLSCREEN' there.
+        ['fullscreenchange', 'webkitfullscreenchange'].forEach((ev) => {
+            document.addEventListener(ev, () => {
+                fsBtn.textContent = fsActive() ? 'EXIT FULLSCREEN' : 'FULLSCREEN';
+            });
+        });
     }
-    fsBtn.addEventListener('click', toggleFullScreen);
-    document.addEventListener('fullscreenchange', () => {
-        fsBtn.textContent = document.fullscreenElement ? 'EXIT FULLSCREEN' : 'FULLSCREEN';
-    });
 
     render();
 }());

--- a/src/module/app/templates/template.html
+++ b/src/module/app/templates/template.html
@@ -422,8 +422,18 @@
             overflow-y: auto;
             overscroll-behavior: contain;
             scrollbar-width: thin;
-            display: flex;
-            flex-direction: column;
+            /* Columns, not one stack. The drawer's groups were laid out full
+               width at every size, so on a 1440px screen seven groups of
+               ~60px stacked into 570px of content inside a 367px box and a
+               third of the panel was unreachable. auto-fit uses the width
+               that was already there instead of taking height from the
+               preview: measured at 1440x800, content 570 -> 514, and the
+               groups that carry sliders keep the full width below. Below
+               ~340px + gap it resolves to one column, i.e. exactly today's
+               layout on a phone. */
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+            align-content: start;
             gap: calc(var(--gap) * 0.55);
             /* The fixed right padding is for the panel's own scrollbar. An
                overlay scrollbar (macOS, iOS, Android) reserves no width and
@@ -436,6 +446,11 @@
         }
 
         .xp-group { display: flex; flex-direction: column; gap: calc(var(--gap) * 0.3); }
+        /* A slider group always spans the whole row. The rule below ("track
+           length IS the resolution of the control") is the reason: letting a
+           0-4095 threshold fall into a 340px column would put ~19 counts on
+           every pixel. Measured at 1440x800: 1148px of track either way. */
+        .xp-group.xp-wide { grid-column: 1 / -1; }
         .xp-title {
             font-weight: 700;
             font-size: var(--label-size);
@@ -453,6 +468,15 @@
             display: grid;
             grid-template-columns: minmax(0, 1fr);
             gap: calc(var(--gap) * 0.2);
+        }
+        /* Overlay scrollbars (macOS, iOS, Android) reserve no width and paint
+           nothing until a scroll is already under way, so a clipped drawer
+           reads as a finished one. Columns close the gap on a desktop but not
+           at 800x480 or a landscape phone; fade the last rows there so the
+           remainder is visible as missing. */
+        #experiment.more-below {
+            -webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 2.2em), transparent);
+            mask-image: linear-gradient(to bottom, #000 calc(100% - 2.2em), transparent);
         }
         .xp-slider { display: flex; align-items: center; gap: 0.55em; }
         .xp-slider .label {
@@ -1372,6 +1396,10 @@
             const rows = xpRow('xp-sliders');
             group.sliders.forEach((s) => rows.appendChild(buildSlider(s)));
             const wrap = xpGroup(group.title, rows);
+            // Full-width row: see .xp-group.xp-wide -- slider track length is
+            // the control's resolution. Set here rather than with :has(),
+            // which needs Safari 15.4 and this page targets older iOS.
+            wrap.classList.add('xp-wide');
             if (group.visibleKey) { xpConditionalGroups.push({ el: wrap, key: group.visibleKey }); }
             return wrap;
         });
@@ -1441,6 +1469,15 @@
             xpGroup('ACTIONS', actions)
         );
         xpBuilt = true;
+    }
+
+    // Mark the drawer while content sits below the fold, so CSS can fade the
+    // last rows. Columns fit everything on a desktop, but not at 800x480 or a
+    // landscape phone, and an overlay scrollbar says nothing.
+    function noteExperimentOverflow() {
+        const panel = $('experiment');
+        panel.classList.toggle('more-below',
+            panel.scrollHeight - panel.clientHeight - panel.scrollTop > 4);
     }
 
     function renderExperiment() {
@@ -1750,6 +1787,7 @@
         const open = panel.classList.toggle('hidden');
         $('btn-experiment').classList.toggle('on', !open);
         render();
+        noteExperimentOverflow();
     });
 
     // The drawer changes the preview's available box without a window
@@ -1759,7 +1797,12 @@
     // child, so this cannot feed itself.
     if (window.ResizeObserver) {
         new ResizeObserver(sizePreview).observe($('preview-wrap'));
+        // Same reasoning for the drawer's own overflow flag: a rotate or a
+        // group appearing/disappearing changes it with no window resize.
+        // mask-image changes no layout, so this cannot feed itself.
+        new ResizeObserver(noteExperimentOverflow).observe($('experiment'));
     }
+    $('experiment').addEventListener('scroll', noteExperimentOverflow, { passive: true });
 
     const fsBtn = $('btn-fullscreen');
     function toggleFullScreen() {

--- a/src/module/app/templates/template.html
+++ b/src/module/app/templates/template.html
@@ -758,18 +758,58 @@
         (typeof v === 'string' && ['true', 'yes', 'on'].includes(v.trim().toLowerCase()));
 
     function fillSelect(sel, options, current) {
-        const wanted = options.map((o) => String(o.value)).join(' ');
+        // The disabled flags are part of the cache key: a free-stepping toggle
+        // can leave the value list identical while changing which entries are
+        // selectable, and without this the list would not repaint.
+        const wanted = options.map((o) => String(o.value) + (o.disabled ? '!' : '')).join(' ');
         if (sel.dataset.filled !== wanted) {
             sel.innerHTML = '';
             options.forEach((o) => {
                 const opt = document.createElement('option');
                 opt.value = o.value;
                 opt.textContent = o.text;
+                if (o.disabled) { opt.disabled = true; }
                 sel.appendChild(opt);
             });
             sel.dataset.filled = wanted;
         }
         if (current !== undefined && current !== null) { sel.value = String(current); }
+    }
+
+    // Free stepping replaces a preset table with a fine grid — 1-360 in whole
+    // degrees for SHUTTER — and the setter then accepts any value verbatim
+    // instead of snapping to the table (cinepi_controller: "In sync mode, or
+    // free-stepping, just accept it verbatim"; the fps setter clamps to
+    // 1..fps_max the same way). So the interior entries stop being the legal
+    // set and become an arbitrary sample of a continuum. Grey them, leaving
+    // the two ends, so the picker reads as the range it actually is; the value
+    // itself is dialled with the EXPERIMENT slider, a pot, an encoder or the
+    // CLI, and the live value still shows even while greyed because a
+    // disabled <option> can be selected programmatically.
+    //
+    // Only SHUTTER and FPS. NOT WB: set_wb picks the closest entry of wb_steps
+    // unconditionally and every entry has a real cg_rb pair, so under WB free
+    // stepping the interior IS the exact legal set. NOT ISO: set_iso clamps
+    // and never snaps in any mode, so iso_free changes what is offered, not
+    // what is accepted. Greying either would state something untrue.
+    // `current` is threaded in because a free grid need not contain the live
+    // value: toggle free stepping on while SHUTTER sits at a preset 172.8 and
+    // the 1-degree grid has no such entry, so the <select> would fall back to
+    // its first option and read 1 while the camera runs at 172.8. Any value is
+    // legal in this mode, so the honest thing is to carry it.
+    function freeStepBounds(list, isFree, current) {
+        const opts = list.map((v, i) => ({
+            value: v,
+            text: v,
+            disabled: Boolean(isFree) && list.length > 2 && i > 0 && i < list.length - 1,
+        }));
+        const live = parseFloat(current);
+        if (isFree && isFinite(live) && !list.some((v) => Number(v) === live)) {
+            const at = opts.findIndex((o) => Number(o.value) > live);
+            opts.splice(at < 0 ? opts.length : at, 0,
+                { value: live, text: live, disabled: false });
+        }
+        return opts;
     }
 
     // ── left / right rails: same sections, order and box contents as
@@ -1063,9 +1103,12 @@
 
     function renderSelectors() {
         fillSelect($('s-iso'), steps.iso.map((v) => ({ value: v, text: v })), V.iso);
-        fillSelect($('s-shutter'), steps.shutter_a.map((v) => ({ value: v, text: v })),
-            steps.shutter_a.find((v) => String(v) === String(parseFloat(V.shutter_speed))));
-        fillSelect($('s-fps'), steps.fps.map((v) => ({ value: v, text: v })), V.fps);
+        const liveShutter = parseFloat(V.shutter_speed);
+        fillSelect($('s-shutter'),
+            freeStepBounds(steps.shutter_a, truthy(V.shutter_a_free), liveShutter),
+            steps.shutter_a.find((v) => String(v) === String(liveShutter))
+                ?? (truthy(V.shutter_a_free) && isFinite(liveShutter) ? liveShutter : undefined));
+        fillSelect($('s-fps'), freeStepBounds(steps.fps, truthy(V.fps_free), V.fps), V.fps);
         fillSelect($('s-wb'), steps.wb.map((v) => ({ value: v, text: v + 'K' })), V.wb);
         fillSelect($('s-res'),
             steps.resolutions.map((r) => ({ value: r.mode, text: r.resolution })),

--- a/src/module/app/templates/template.html
+++ b/src/module/app/templates/template.html
@@ -1733,7 +1733,22 @@
         img._reloadTimer = setTimeout(() => {
             img._reloadTimer = null;
             if (img.classList.contains('hidden')) { return; }
-            img.src = img.dataset.streamBase + '?reload=' + Date.now();
+            // NO query string. cinepi-raw's MJPEG server matches the raw
+            // request-target against the one topic it publishes ("/stream"):
+            // nadjieb mjpeg_streamer.hpp reads the target with
+            // `getline(iss, target_, ' ')`, so the query is part of it, and
+            // pathExists() is an exact map lookup -- "/stream?reload=1756..."
+            // misses and the server answers 404 and closes. Every recovery
+            // path here funnels through this function, so a cache-buster did
+            // not just fail to help, it replaced a working MJPEG connection
+            // with a permanent 404 (cinepi-raw deliberately keeps the listener
+            // alive across a camera reconfigure, so the old connection would
+            // have survived on its own).
+            //
+            // Dropping src first is what makes the browser re-request an
+            // identical URL -- which is the reason the cache-buster was there.
+            img.removeAttribute('src');
+            img.src = img.dataset.streamBase;
         }, delay);
     }
     function reloadStreams() {

--- a/src/module/config_loader.py
+++ b/src/module/config_loader.py
@@ -291,6 +291,35 @@ def clearhdr_startup_values(settings: dict) -> dict:
     }
 
 
+REC_TONE_DEFAULTS = {
+    "pin": [],
+    "frequency_hz": 1000,
+    "duty_cycle": 50,
+    "relay_drop_frames": False,
+}
+
+
+def rec_tone_config(gpio_cfg: dict) -> dict:
+    """Read hardware_outputs.rec_tone, tolerating the pre-c171975e flat keys.
+
+    c171975e regrouped `rec_tone_pin` / `rec_tone_frequency_hz` /
+    `rec_tone_duty_cycle` / `rec_tone_relay_drop_frames` under a nested
+    `rec_tone` object. main.py's section name was updated; its leaf reads were
+    not, so every one of them silently fell back to a hardcoded default -- the
+    configured tone pin was ignored in favour of pwm_pin, frequency and duty
+    cycle could not be changed at all, and relay_drop_frames could never be
+    true, which meant relay_drop_frame_on_rec_tone() returned at its guard on
+    every call. settings.schema.json declares rec_tone with
+    additionalProperties:false, so the flat keys cannot appear in a current
+    file; the fallback is only for a hand-written one predating the rename.
+    """
+    nested = gpio_cfg.get("rec_tone") or {}
+    return {
+        key: nested[key] if key in nested else gpio_cfg.get(f"rec_tone_{key}", default)
+        for key, default in REC_TONE_DEFAULTS.items()
+    }
+
+
 def _apply_settings_defaults(settings: dict) -> dict:
     # ── system: splash, network, storage behavior ──────────────────────────
     system_cfg = settings.setdefault("system", {})
@@ -538,10 +567,8 @@ def _apply_settings_defaults(settings: dict) -> dict:
     outputs_cfg.setdefault("pwm_pin", 19)
     outputs_cfg.setdefault("rec_out_pin", [6, 21])
     rec_tone_cfg = outputs_cfg.setdefault("rec_tone", {})
-    rec_tone_cfg.setdefault("pin", [])
-    rec_tone_cfg.setdefault("frequency_hz", 1000)
-    rec_tone_cfg.setdefault("duty_cycle", 50)
-    rec_tone_cfg.setdefault("relay_drop_frames", False)
+    for _key, _default in REC_TONE_DEFAULTS.items():
+        rec_tone_cfg.setdefault(_key, _default)
     outputs_cfg["rec_tone"] = rec_tone_cfg
     settings["hardware_outputs"] = outputs_cfg
 

--- a/src/module/design_tokens.py
+++ b/src/module/design_tokens.py
@@ -23,6 +23,7 @@ DESIGN_TOKENS = {
     "guide": (249, 249, 249),  # preview-guide outline, un-zoomed state
     "zoom_hi": (255, 221, 0),  # preview-guide outline once zoomed in
     "drop": (120, 40, 180),
+    "drop_text": (255, 255, 255),  # W3: black-on-purple was 2.76:1, fails AA
     "sync": (255, 0, 255),
     "log_badge": (205, 205, 205),
     "hdr_badge": (205, 205, 205),

--- a/src/module/https_settings.py
+++ b/src/module/https_settings.py
@@ -1,0 +1,147 @@
+"""Shared settings["system"]["https"] defaults, plus self-signed cert issuing.
+
+Split out the same way module.web_api_settings is, so main.py can read the
+block and mint a certificate without importing flask.
+
+Why this is off by default, and why it is not simply "better":
+
+  * A camera is reached at cinepi.local or, on the hotspot, at 10.42.0.1.
+    Neither can ever hold a publicly-trusted certificate -- no CA will issue
+    for an mDNS name or a private address -- so HTTPS here always means a
+    self-signed certificate and a full-page browser interstitial on first
+    visit (and on every visit in a private window, and repeatedly on iOS).
+  * cinepi-raw's MJPEG preview is plain HTTP on port 8000 and cannot speak
+    TLS. A secure page may not load an insecure subresource, so turning this
+    on without more would black out the live preview. main.routes handles
+    that by proxying the stream same-origin when, and only when, the page was
+    served over TLS -- see _stream_url_for_request().
+
+Turn it on when you need a secure context: the RAW pane's "download to a
+folder" uses the File System Access API, which browsers refuse to expose on
+a plain-HTTP origin.
+"""
+from __future__ import annotations
+
+import datetime
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HTTPS_SETTINGS = {
+    "enabled": False,
+    # Relative paths resolve against the repo root, like sensors.database_file.
+    "cert_file": "resources/certs/cinemate.crt",
+    "key_file": "resources/certs/cinemate.key",
+    # Days a freshly minted self-signed certificate is good for. It is
+    # re-issued automatically once it expires.
+    "valid_days": 3650,
+}
+
+
+def https_settings(settings):
+    """Merge settings["system"]["https"] over the documented defaults."""
+    cfg = ((settings or {}).get("system", {}) or {}).get("https", {}) or {}
+    merged = dict(DEFAULT_HTTPS_SETTINGS)
+    merged.update({k: v for k, v in cfg.items() if k in DEFAULT_HTTPS_SETTINGS})
+    return merged
+
+
+def _repo_root() -> Path:
+    # src/module/https_settings.py -> repo root
+    return Path(__file__).resolve().parents[2]
+
+
+def resolve_path(path_value: str) -> Path:
+    path = Path(path_value)
+    return path if path.is_absolute() else _repo_root() / path
+
+
+def _certificate_is_usable(cert: Path) -> bool:
+    """True if *cert* exists and has not expired.
+
+    Checked with openssl rather than parsed here: a certificate that expired
+    while the camera sat on a shelf would otherwise fail at bind time, which
+    is the worst possible moment to find out.
+    """
+    if not cert.is_file():
+        return False
+    openssl = shutil.which("openssl")
+    if not openssl:
+        return True  # cannot check; assume the operator knows
+    result = subprocess.run(
+        [openssl, "x509", "-checkend", "0", "-noout", "-in", str(cert)],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        logger.warning("TLS certificate %s has expired; re-issuing", cert)
+        return False
+    return True
+
+
+def ensure_certificate(cfg: dict) -> tuple[Path, Path] | None:
+    """Return (cert, key), minting a self-signed pair if needed.
+
+    Returns None if a certificate cannot be produced, so the caller can fall
+    back to plain HTTP rather than failing to serve at all -- a camera that
+    does not answer on :5000 is worse than one that answers insecurely.
+    """
+    cert = resolve_path(cfg["cert_file"])
+    key = resolve_path(cfg["key_file"])
+
+    if _certificate_is_usable(cert) and key.is_file():
+        return cert, key
+
+    openssl = shutil.which("openssl")
+    if not openssl:
+        logger.error(
+            "https.enabled is true but openssl is not installed, so no "
+            "certificate can be issued. Serving plain HTTP instead."
+        )
+        return None
+
+    try:
+        cert.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            [
+                openssl, "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+                "-keyout", str(key), "-out", str(cert),
+                "-days", str(int(cfg.get("valid_days") or 3650)),
+                "-subj", "/CN=cinepi.local/O=CineMate",
+                # The names a camera is actually reached by. Without these a
+                # modern browser rejects the certificate outright rather than
+                # merely warning, because CN alone has not been honoured for
+                # years.
+                "-addext",
+                "subjectAltName=DNS:cinepi.local,DNS:localhost,"
+                "IP:127.0.0.1,IP:10.42.0.1",
+            ],
+            capture_output=True,
+            check=True,
+        )
+        key.chmod(0o600)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        detail = getattr(exc, "stderr", b"") or b""
+        logger.error(
+            "Could not issue a TLS certificate (%s); serving plain HTTP. %s",
+            exc, detail.decode("utf-8", "replace").strip(),
+        )
+        return None
+
+    logger.info(
+        "Issued a self-signed TLS certificate valid until %s: %s",
+        (datetime.date.today()
+         + datetime.timedelta(days=int(cfg.get("valid_days") or 3650))).isoformat(),
+        cert,
+    )
+    return cert, key
+
+
+def ssl_context_for(settings) -> tuple[Path, Path] | None:
+    """The ssl_context to hand socketio.run(), or None for plain HTTP."""
+    cfg = https_settings(settings)
+    if not cfg.get("enabled"):
+        return None
+    return ensure_certificate(cfg)

--- a/src/module/simple_gui.py
+++ b/src/module/simple_gui.py
@@ -19,6 +19,7 @@ import re
 RECORDER_VU_REDIS_KEY    = "audio_vu"
 WAV_RECORDING_COLOR      = DESIGN_TOKENS["wav_rec"]   # bright grey while WAV is actively recording
 DROP_WARNING_COLOR = DESIGN_TOKENS["drop"]
+DROP_TEXT_COLOR = DESIGN_TOKENS["drop_text"]
 SYNC_WARNING_COLOR = DESIGN_TOKENS["sync"]
 SYNC_FLASH_COLOR = "magenta"  # PIL named colour -- no CSS/design-token counterpart
 RESOLUTION_SWITCHING_COLOR = DESIGN_TOKENS["res_switching"]
@@ -1378,7 +1379,7 @@ class SimpleGUI(threading.Thread):
                     "DROP",
                     DROP_WARNING_COLOR,
                     box_font,
-                    TEXT_COLOR,
+                    DROP_TEXT_COLOR,
                 )
                 y += BOX_H + BOX_GAP
 
@@ -1523,7 +1524,7 @@ class SimpleGUI(threading.Thread):
                     "DROP",
                     DROP_WARNING_COLOR,
                     box_font,
-                    TEXT_COLOR,
+                    DROP_TEXT_COLOR,
                 )
                 y += BOX_H + BOX_GAP
 


### PR DESCRIPTION
## Summary

Combines two independently-developed web-UI branches into one:

- **`fix/web-ui-round2`** — opt-in HTTPS with a self-signed cert, a same-origin MJPEG preview proxy, idempotent take delete, the preview-stream reload fix, EXPERIMENT drawer columns, free-stepping greying, settings-editor page restore, the sensor-database card, slate-tone GPIO fixes, blank ClearHDR thresholds.
- **`fix/web-ui-portrait`** — the C8 web-UI review spec and its W1–W10 implementation: shrink-to-fit rails (W1/W2), the DROP contrast token (W3), locked-select handling (W4), fullscreen feature detection (W5), dead theme CSS removal (W6), pinned Save (W7), select inset (W8), and streaming clip download — server (W9) and a folder-picker client (W10).

**Both parents are Pi-unverified.** Neither branch has been loaded on a camera; every commit on this branch says so explicitly, and this PR is not evidence otherwise.

## What's here

**Commit 1** merges the two branches. Three conflicts, each resolved by combining both sides' intent rather than picking one:
- `.gitignore` — union of both branches' ignore rules.
- `raw_files.py` — round2's idempotent-delete generator shape, with portrait's `storage=` keyword and its `(OSError, ValueError)` catch (a `%00`-smuggled name used to 500, now 404s) threaded through.
- `template.html`'s `renderSelectors()` — round2's free-stepping option greying, with portrait's `''` fallback so a rejected pick on a locked shutter clears instead of lingering.

**Commit 2** reconciles a real collision the merge didn't catch: both branches independently built a "download into a folder" client for the RAW pane, and they auto-merged with zero conflict markers because they landed in disjoint regions of `settings_editor.html`. Portrait's per-row client survives (progress bar, cancel button, cleanup-on-failure, `?storage=` on every request); round2's separate bulk client is removed, and its multi-take sequencing (pick the folder once, write takes one after another) is grafted onto portrait's functions instead. Also fixed in this commit: a download-semaphore permit that leaked on every `HEAD` request (Werkzeug never iterates a HEAD response's body, so the generator-based release never ran), `DELETE` not sending `?storage=`, and bulk-delete collapsing every failure into a generic toast instead of surfacing the real reason.

## Verification

Desk-only — see "Not verified" below. Both commits pass: `ruff check src/`, the full pytest suite (772 passed, 368 subtests, up from round2's 747 / portrait's 699), `docs_drift_check --strict`, `findings_disposition_check`, `design_token_diff --strict`, `gui_field_extract --max-unresolved 0`, `link_frequency_drift_check --strict`, `check_generated_scripts`, `mkdocs build --strict`, and `redis_key_diff --max-unreferenced 12`.

## Not verified

- **No Pi has served this branch.** Every claim here is a desk-level code/test claim, not a hardware-confirmed one.
- **The companion cinepi-raw change (`fix/mjpeg-clean-preview`, commit `ca68ab9`) is optional and intentionally not part of this PR.** It fixes two defects in the clean-preview port-8000 endpoint (a bare `/` 404s; `/stream` 404s during cold start before the first frame) but has never been compiled by meson or run against libcamera. Nothing in this branch depends on it — `docs/web-gui.md` names the commit conditionally rather than assuming it has merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)