### PR TITLE
docs: release-prep fixes for 3.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It pairs a lightweight Python interface with a custom fork of [cinepi-raw](https
 - 10/12-bit CinemaDNG recording, plus 16-bit [ClearHDR](https://tiramisioux.github.io/cinemate/clear-hdr/) on the IMX585
 - [CineMate Log](https://tiramisioux.github.io/cinemate/cinemate-log/) — log-companded DNGs on the IMX585 and IMX283, 17–37 % smaller, decoded back to linear automatically by any DNG-aware app
 - [Dual sensors](https://tiramisioux.github.io/cinemate/dual-sensors/) — two libcamera-synchronised sensors, side-by-side / picture-in-picture HDMI preview, per-sensor recording
-- [Web GUI](https://tiramisioux.github.io/cinemate/web-gui/) on the Pi's own hotspot, plus a browser settings editor for `settings.jsonc`, `config.txt` and the RAW drive
+- [Web GUI](https://tiramisioux.github.io/cinemate/web-gui/) on the Pi's own hotspot, plus a browser [settings editor](https://tiramisioux.github.io/cinemate/settings-editor/) for `settings.jsonc`, `config.txt` and the RAW drive
 - [Web API](https://tiramisioux.github.io/cinemate/web-api/) — build wireless controllers and tally lights from an ESP32, Pico W or M5Stack ([Building control units](https://tiramisioux.github.io/cinemate/building-control-units/))
 - GPIO buttons, switches, rotary encoders, pots and an OLED, mapped in one settings file ([Additional hardware](https://tiramisioux.github.io/cinemate/hardware-controls/))
 - Multi-drive RAW hot-swap with a standby drive; SSD, NVMe or CFE Hat storage

--- a/cinemate-install.sh
+++ b/cinemate-install.sh
@@ -101,16 +101,25 @@ LGPIO_REPO_REF="${LGPIO_REPO_REF:-}"
 # and 2.7K 16:9 (mode 2A) readout modes on top of the upstream 6.12.y base.
 IMX283_DRIVER_REPO_URL="${IMX283_DRIVER_REPO_URL:-https://github.com/Tiramisioux/imx283-v4l2-driver.git}"
 IMX283_DRIVER_REPO_REF="${IMX283_DRIVER_REPO_REF:-6.12.y}"
-# Tiramisioux fork of Will Whang's driver. innomaker-v1.0 = upstream main
-# (verified byte-identical to the INNO-MAKER v1.0 vendor driver package,
-# 2026-08-27): WINMODE active-area modes (1920x1080 binned, 3840x2160 12-bit,
-# 3840x2200 16-bit ClearHDR), gates the invalid binned-ClearHDR combo, and its
-# overlay carries the `ccmp` parameter that enables 12-bit CCMP ClearHDR.
-# Pairs with the rp1-cfe Y16 patch (scripts/patch-rp1-cfe.sh) for mono 16-bit.
+# Tiramisioux fork of Will Whang's driver. cinemate-7modes (switched
+# 2026-09-03, replaces innomaker-v1.0 as the default) ships seven modes —
+# three SDR (1920x1080 12-bit binned, 3840x2160 12-bit all-pixel, and a
+# 3840x2160 10-bit RAW10 all-pixel mode up to 90 fps) and four ClearHDR
+# (1920x1080 12-bit binned ClearHDR+CCMP, 3840x2160 12-bit all-pixel
+# ClearHDR+CCMP, 1920x1100 16-bit binned ClearHDR linear, and 3840x2200
+# 16-bit all-pixel ClearHDR linear). The two binned-HDR modes are restored
+# from `6.12.y` (innomaker-v1.0 had dropped them) and are colour-sensor only
+# — mono returns pure BLC pedestal at binned resolutions and stays on the
+# 4K-only 16-bit HDR entry. Also makes 12-bit CCMP ClearHDR default-on for
+# colour (mono still needs the `ccmp` overlay flag below). Gates the invalid
+# binned-ClearHDR combo on mono, and pairs with the rp1-cfe Y16 patch
+# (scripts/patch-rp1-cfe.sh) for mono 16-bit.
+# Verified on hardware.
 # The old `6.12.y` branch (readout dims 3856x2180/1928x1090, no ccmp param)
-# stays selectable via this env var but is no longer the supported default.
+# and `innomaker-v1.0` (dropped the two binned-HDR modes and the RAW10 mode)
+# stay selectable via this env var but are no longer the supported default.
 IMX585_DRIVER_REPO_URL="${IMX585_DRIVER_REPO_URL:-https://github.com/Tiramisioux/imx585-v4l2-driver.git}"
-IMX585_DRIVER_REPO_REF="${IMX585_DRIVER_REPO_REF:-innomaker-v1.0}"
+IMX585_DRIVER_REPO_REF="${IMX585_DRIVER_REPO_REF:-cinemate-7modes}"
 IR_FILTER_URL="${IR_FILTER_URL:-https://raw.githubusercontent.com/will127534/StarlightEye/master/software/IRFilter}"
 PISHRINK_URL="${PISHRINK_URL:-https://raw.githubusercontent.com/Drewsif/PiShrink/master/pishrink.sh}"
 # Pi 5 kernel baseline. 6.12.93+rpt is the oldest baseline validated for

--- a/cinemate-update.sh
+++ b/cinemate-update.sh
@@ -8,10 +8,20 @@ set -euo pipefail
 CINEPI_RAW_DIR=${CINEPI_RAW_DIR:-$HOME/cinepi-raw}
 CINEMATE_DIR=${CINEMATE_DIR:-$(cd "$(dirname "$0")" && pwd)}
 
+# Optional pairing manifest (same file cinemate-install.sh reads): pins each
+# repo to a specific ref. Empty/absent reproduces exactly today's behaviour of
+# following whatever branch is currently checked out.
+_versions_env="$(dirname "$0")/versions.env"
+# shellcheck source=/dev/null
+[[ -f "$_versions_env" ]] && source "$_versions_env"
+CINEMATE_REPO_REF="${CINEMATE_REPO_REF:-}"
+CINEPI_RAW_REPO_REF="${CINEPI_RAW_REPO_REF:-}"
+
 # Helper function for updating a git repo
 update_repo() {
     local dir="$1"
     local name="$2"
+    local ref="${3:-}"
     printf '\n----- Checking %s -----\n' "$name"
     if [ ! -d "$dir/.git" ]; then
         echo "[Error] $name repo not found at $dir"
@@ -23,23 +33,40 @@ update_repo() {
     echo "Current branch: $branch"
     echo "Fetching latest changes..."
     git fetch
+    if [[ -n "$ref" && "$branch" != "$ref" ]]; then
+        echo "versions.env pins $name to $ref; checking out..."
+        git checkout "$ref"
+    fi
     local local_rev remote_rev
     local_rev=$(git rev-parse @)
-    # shellcheck disable=SC1083  # @{u} is git syntax for the upstream ref,
-    # not brace expansion.
-    remote_rev=$(git rev-parse "@{u}")
+    if [[ -n "$ref" ]]; then
+        if git show-ref --verify --quiet "refs/remotes/origin/$ref"; then
+            remote_rev=$(git rev-parse "origin/$ref")
+        else
+            # Tag or fixed commit: nothing to fast-forward to.
+            remote_rev=$(git rev-parse "$ref")
+        fi
+    else
+        # shellcheck disable=SC1083  # @{u} is git syntax for the upstream ref,
+        # not brace expansion.
+        remote_rev=$(git rev-parse "@{u}")
+    fi
     if [[ "$local_rev" == "$remote_rev" ]]; then
         echo "$name is up to date."
         REPO_UPDATED=0
     else
         echo "Updates available for $name. Pulling..."
-        git pull --ff-only
+        if [[ -n "$ref" ]]; then
+            git pull --ff-only origin "$ref"
+        else
+            git pull --ff-only
+        fi
         REPO_UPDATED=1
     fi
 }
 
 # Update cinepi-raw
-update_repo "$CINEPI_RAW_DIR" "cinepi-raw"
+update_repo "$CINEPI_RAW_DIR" "cinepi-raw" "$CINEPI_RAW_REPO_REF"
 if [ "$REPO_UPDATED" -eq 1 ]; then
     echo "Rebuilding cinepi-raw..."
     cd "$CINEPI_RAW_DIR"
@@ -60,7 +87,7 @@ else
 fi
 
 # Update cinemate
-update_repo "$CINEMATE_DIR" "cinemate"
+update_repo "$CINEMATE_DIR" "cinemate" "$CINEMATE_REPO_REF"
 if [ "$REPO_UPDATED" -eq 1 ]; then
     echo "Reinstalling Cinemate..."
     cd "$CINEMATE_DIR"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,12 @@ Release notes for Cinemate. For downloads, see the [releases page](https://githu
 
 - **Default branch moves to `cinemate-7modes`**, replacing `innomaker-v1.0`. Seven modes total — three SDR (1920×1080 12-bit binned, 3840×2160 12-bit all-pixel, and a 3840×2160 10-bit RAW10 all-pixel mode, up to 90 fps) and four ClearHDR (1920×1080 12-bit binned ClearHDR+CCMP, 3840×2160 12-bit all-pixel ClearHDR+CCMP, 1920×1100 16-bit binned ClearHDR linear, and 3840×2200 16-bit all-pixel ClearHDR linear) — restoring the two binned-HDR modes `6.12.y` had and `innomaker-v1.0` dropped (both colour-sensor only), on top of `innomaker-v1.0`'s RAW10 mode and its dedicated 16-bit entry. Also makes 12-bit CCMP ClearHDR default-on for colour sensors. Verified on hardware. The old `6.12.y` and `innomaker-v1.0` branches stay selectable via `IMX585_DRIVER_REPO_REF` but are no longer the supported default.
 
+### libcamera
+
+- **PiSP pixel-rate bound taken as an explicit input, derived from the RP1 clock** — previously a compile-time constant baked at the overclocked value. Cinemate now computes the ceiling from the RP1 overclock toggle's actual state and passes it to cinepi-raw as `--max-pixel-rate`. See [Overclocking the Pi](overclocking.md).
+- **Fixed 16-bit ClearHDR corruption on compressed (COMP1) capture** — the 16-bit endian swap was keyed only on sensor bus bit depth, so a 16-bit ClearHDR mode with COMP1-compressed CFE output got byte-swapped too. The swap assumes 2 bytes/pixel and scrambled the 8-byte compression blocks, corrupting both the raw stream and the back-end input. The swap is now gated off compressed formats — consumers decode COMP1 directly.
+- **RP1 overclock tuning** — `minPixelProcessingTime` adjusted so the overclock toggle actually raises the achievable frame rate.
+
 ### ClearHDR (imx585)
 
 - **16-bit ClearHDR recording** — the imx585's on-sensor single-frame HDR is now a first-class mode: Cinemate probes the sensor with and without `--hdr sensor` and lists the plain and ClearHDR modes (12-bit and 16-bit) in one mode table. Selecting an HDR mode relaunches cinepi-raw with the flag; `HDR` labels mark the modes in both GUIs. See [ClearHDR](clear-hdr.md).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,40 +2,35 @@
 
 Release notes for Cinemate. For downloads, see the [releases page](https://github.com/Tiramisioux/cinemate/releases).
 
-## Version 3.3.2
+## Version 3.4.0
 
-### Dual sensors improved
+### Dual sensors
 
 - **Automatic dual-camera** — two connected sensors are each detected and driven by their own `cinepi-raw` process, with frame capture synchronised by libcamera (cam0 server, cam1 client).
 - **HDMI preview switching** — new command `set preview` cycles side-by-side → cam0 → cam1 → pip_cam0 → pip_cam1 (picture-in-picture).
 - **Per-sensor recording** — record both sensors or just the previewed one (`sensors.record_policy` can be set in settings.jsonc), or target sensors with `rec cam0` / `rec cam1` / `rec both`. Each sensor writes its own `..._cam0` / `..._cam1` clip folder.
 
-### libcamera
-
-- Cinemate now uses its own fork of libcamera.
-
-### imx283 driver
-
-- Cinemate now uses its own fork of the imx283 driver.
-- 2 additional modes: 3840 x 2160 (4K UHD, native crop) and 2736 x 1538 (2.7K 16:9, binned).
-
 ### imx585 driver
 
-- Cinemate now uses its own fork of the imx585 driver.
+- **Default branch moves to `cinemate-7modes`**, replacing `innomaker-v1.0`. Seven modes total — three SDR (1920×1080 12-bit binned, 3840×2160 12-bit all-pixel, and a 3840×2160 10-bit RAW10 all-pixel mode, up to 90 fps) and four ClearHDR (1920×1080 12-bit binned ClearHDR+CCMP, 3840×2160 12-bit all-pixel ClearHDR+CCMP, 1920×1100 16-bit binned ClearHDR linear, and 3840×2200 16-bit all-pixel ClearHDR linear) — restoring the two binned-HDR modes `6.12.y` had and `innomaker-v1.0` dropped (both colour-sensor only), on top of `innomaker-v1.0`'s RAW10 mode and its dedicated 16-bit entry. Also makes 12-bit CCMP ClearHDR default-on for colour sensors. Verified on hardware. The old `6.12.y` and `innomaker-v1.0` branches stay selectable via `IMX585_DRIVER_REPO_REF` but are no longer the supported default.
 
 ### ClearHDR (imx585)
 
 - **16-bit ClearHDR recording** — the imx585's on-sensor single-frame HDR is now a first-class mode: Cinemate probes the sensor with and without `--hdr sensor` and lists the plain and ClearHDR modes (12-bit and 16-bit) in one mode table. Selecting an HDR mode relaunches cinepi-raw with the flag; `HDR` labels mark the modes in both GUIs. See [ClearHDR](clear-hdr.md).
+- **12-bit CCMP ClearHDR, and mono-sensor support** — the imx585's on-sensor HDR is also exposed at 12-bit (CCMP) alongside the 16-bit mode, in the same mode table. Verified working on the mono sensor (`imx585_mono`) as of 2026-08-27: a stock 6.12.y kernel gives every Bayer 16-bit format an RP1 workaround that misses mono's `Y16` entry, recording PiSP-COMP1-structured garbage unless patched (`scripts/patch-rp1-cfe.sh`, applied automatically by the installer for `imx585_mono`); binned (2K) ClearHDR is an invalid sensor combination on mono and is removed from its mode table.
+- **Mode-detection guard against a stale `cinepi-raw`** — sensor probing now kills any leftover `cinepi-raw` process (orphaned by a crashed or manually-run previous session) before probing for HDR modes; if it was still holding the sensor's `wide_dynamic_range` control, the ClearHDR modes silently dropped out of the mode table with no error. Cinemate now warns if HDR modes still don't appear after the kill.
+- **ClearHDR stabilization** — several rounds of fixes across the mono-sensor stack, gain shocks on a mode switch, self-healing after a bad sensor handshake, shutter follow-ups, and corrected default merge thresholds.
 - **Live merge knobs** — `set hdr threshold low/high`, `set hdr blend`, `set hdr gain adder` tune the sensor's HG/LG merge while streaming; startup defaults live in `image_capture.hdr` and the knobs can be mapped to pots and encoders.
 - **RP1 overclock, automated** — the installer compiles the `rp1-overclock` overlay, ships it disabled (`#dtoverlay=rp1-overclock` in config.txt), and the settings editor's Boot config pane toggles it for higher ClearHDR frame rates on Pi 5 / CM5. See [Overclocking the Pi](overclocking.md).
+- **RP1 pixel-rate ceiling passed to cinepi-raw** — libcamera's PiSP pixel-rate bound used to be a compile-time constant baked at the overclocked value, so a non-overclocked board running a fast imx585 mode could silently corrupt frames (a CSI2-to-ISP-FE FIFO overrun that returns static with nothing logged, not a dropped frame). Cinemate now decides the ceiling from the RP1 overclock toggle's actual state and passes it to cinepi-raw as `--max-pixel-rate`. See [Overclocking the Pi](overclocking.md).
+- **Launch refusal on a failed HDR handshake** — cinepi-raw retries the sensor's `wide_dynamic_range=1` write up to 4 times, 50 ms apart, and now throws and refuses to launch — instead of silently proceeding — when the sensor never confirms it. Previously an unconfirmed write still launched and recorded a flat BLC pedestal fill instead of real image data. See [ClearHDR](clear-hdr.md#new-launch-refusal-if-the-sensor-doesnt-confirm-hdr).
 
 ### CinePi-RAW recorder
 
-- **Frame-rate phase lock** — DNG timecode and frame capture is locked to the Pi's wall clock, making audio sync more accurate.
-- **More reliable audio sync on 4K / exFAT** — the capture path was reworked (protected helper, dedicated writer thread, wall-clock reconciliation, real-time scheduling) for more reliable WAV sync on demanding modes.
-- **Correct Pi 4 RAW** — CSI2-packed frames decode correctly on Pi 4-family boards; raw packing (P/U) is chosen per Pi model automatically.
-- **Camera model** — set the camera model manually for each attached sensor.
 - **`--keep16` removed** — SDR sensor modes always write 12-bit DNGs. The flag only preserved 4 padding bits, so files are ~33% smaller with no loss of information. True 16-bit modes (IMX585 ClearHDR) are unaffected.
+- **Reworked capture path under load** — the redis-based per-frame capture pipeline was reworked, with a bgsave debounce, for steadier behaviour when the storage device is under load.
+- **Correct DNG timecode frame base** — the SMPTE timecode frame base is now derived from the configured fps instead of `FrameDuration`, fixing incorrect embedded timecode on modes where the two disagreed.
+- **MJPEG clean preview fix** — the clean (no-overlay) preview feed now serves correctly on `/` and registers its stream targets before the first frame arrives.
 
 ### CineMate Log
 
@@ -45,9 +40,17 @@ Release notes for Cinemate. For downloads, see the [releases page](https://githu
 
 ### Cinemate
 
-- **Storage / media** — multi-drive RAW hot-swap with a standby drive and automatic promotion. Default format is exFAT.
-- **Settings editor** — a browser settings page at `cinepi.local:5000/settings-editor`: edit `settings.jsonc` panel by panel, stage `/boot/firmware/config.txt` changes (RP1 overclock toggle, link frequency), and browse, download or format the RAW drive from the RAW files pane.
+- **Settings editor** — a new browser page at `cinepi.local:5000/settings-editor` for configuring and operating the camera without SSH: edit `settings.jsonc` section by section, stage `/boot/firmware/config.txt` changes (sensor overlays, RP1 overclock, link frequency), watch the live camera feed, review a take frame-by-frame, and browse, download, delete or format the RAW drive — all from one page. Saving `config.txt` here writes and reboots within under a second, with **no confirm/revert window and no backup of the previous file** — unlike the recovery console's config.txt editor, which backs up and arms a 5-minute confirm/revert timer. Use the recovery console instead when you want that safety net. See [Settings editor](settings-editor.md).
+- **Settings editor config.txt write fix, and `cinepi.local` mDNS install** — the settings editor runs as `pi`, and saving `config.txt` from it previously raised `EACCES` before writing a byte, so the save silently could never succeed; it now falls back to a narrowly-scoped privileged helper (`cinemate-apply-config-txt`) that preserves the file's existing owner/mode. The installer also installs and enables `avahi-daemon`/`libnss-mdns` so `cinepi.local` resolves out of the box, and fixes a stale `/etc/hosts` `127.0.1.1` entry that could break local name resolution independently of mDNS.
+- **Playback** — a new tab in the settings editor plays a recorded take back in the browser at its conform frame rate, decoding frames live from the CinemaDNG files on the card — nothing is transcoded, nothing is written back. See [Playback](playback.md).
 - **Recovery console** — a new, independent `cinemate-recovery.service` on `:8080` lets you diagnose a Cinemate that will not start, edit `settings.jsonc` and `/boot/firmware/config.txt`, and restart Cinemate — from a phone on the hotspot, with no laptop or SSH. Standard library only, runs as root, and has no dependency on `cinemate-autostart.service` so it survives a crash that takes Cinemate down. The hotspot's Wi-Fi profile now also autoconnects at boot and self-heals a broken `settings.jsonc` by falling back to the last-known-good SSID rather than the compiled-in `CinePi` default. See [Recovery console](recovery-console.md).
+- **Storage** — a new `hw_write_failures` counter surfaces as a live "use exFAT or ext4" warning when the storage device can't keep up with the write rate during a take; NTFS is now explicitly flagged supported but not recommended for recording, since its Linux driver can drop frames under sustained 4K writes.
+- **No camera at boot** — Cinemate now starts and stays usable with no camera attached instead of failing: the HDMI and web GUIs show a full-width `CAMERA NOT FOUND` message while the hotspot, web UI and settings editor stay reachable. Cinemate re-probes for the sensor on every start, so recovery is just power off, connect the camera, power back on — no command needed.
+- **Web GUI rebuilt onto `simple_gui`'s layout** (`feature/web-preview-layout`), driven over the same `/api/v1/cmd` dispatcher as the CLI/serial paths, and gained a live mic-input VU meter (matching `simple_gui`'s green/yellow/red thresholds and L/R channel labels). The page also now reloads automatically once a resolution/mode change completes, gained an EXPERIMENT drawer for live exposure sliders, rebuilt GPIO IN/OUT panes that represent every binding, and phone-usability fixes (viewport meta on the settings editor, larger tap targets and type floors on the live GUI).
+- **Per-mode fps ceiling override** — the fps ceiling for each sensor mode can now be corrected and edited directly in `settings.jsonc` (`custom_modes`) instead of being fixed by the driver's mode table.
+- **Dynamic resolution** — the tie-break between candidate modes now ranks bit depth over `fps_max`, and an explicit 12-bit request combined with a missing toggle no longer silently downgrades resolution.
+- **Controls** — fixed a race between the front-panel potentiometer and an explicit app-side `set` landing on the same control; fixed `get_setting('shutter_a_nom')` resolving to the wrong redis key, which had broken shutter-angle increment/decrement via the Komodo GPIO rotary encoder and the CLI; decoupled shutter-angle sync-mode granularity from the free-increment step setting; fixed mode-switch controls not re-applying correctly after a resolution/mode change.
+- **Fixes** — RAW-drive unmount/remount no longer fails to find the volume again on a stale `blkid` probe; `cinemate-autostart` restart no longer hangs behind a polkit auth prompt; the link-frequency dropdown no longer shows disabled/greyed out incorrectly in the web GUI; the config.txt toggle no longer shows a stale state when navigating back to the settings editor; the exposure-time/shutter display no longer goes stale in the GUI.
 
 ### Web API
 
@@ -55,7 +58,37 @@ Release notes for Cinemate. For downloads, see the [releases page](https://githu
 
 ### Raspberry Pi / Bookworm
 
-- **Boot / install** — faster boot-to-preview on Pi 4/5 (about 10-15 seconds).
+- **Installer** — no longer creates a Python virtualenv; packages install straight into system Python (`cinemate-autostart.service` now launches `python3` directly), fixing several install blockers that only appeared in the venv path.
+
+## Version 3.3.2
+
+### libcamera
+
+- Cinemate now uses its own fork of libcamera.
+
+### imx283 driver
+
+- Cinemate now uses its own fork of imx283 driver.
+- 2 additional modes: 3840 x 2160 (4K UHD, native crop) and 2736 x 1538 (2.7K 16:9, binned) 
+
+### imx585 driver
+
+- Cinemate now uses its own fork of imx283 driver.
+
+### CinePi-RAW recorder
+
+- **Frame-rate phase lock** — closed-loop control (sigma-delta VBLANK dither) keeps long takes locked to the Pi's wall clock and pre-converges during preview. On by default.
+- **More reliable audio sync on 4K / exFAT** — the capture path was reworked (protected helper, dedicated writer thread, wall-clock reconciliation, real-time scheduling) for more reliable WAV sync on demanding modes.
+- **Wall clock embedded timecode** — timecode is anchored to the first frame's wall-clock time and follows the Pi's real-time clock.
+- **Correct Pi 4 RAW** — CSI2-packed frames decode correctly on Pi 4-family boards; raw packing (P/U) is chosen per Pi model automatically.
+- **Camera model** — set the camera model manually for each attached sensor.
+
+### Cinemate
+
+- **Storage / media** — multi-drive RAW hot-swap with a standby drive and automatic promotion. Default format is exFAT.
+
+### Raspberry Pi / Bookworm**
+- **Boot / install** — faster boot-to-preview on Pi 4/5 (about 10-15 seconds)
 
 ## Version 3.3.1
 
@@ -71,4 +104,4 @@ Release notes for Cinemate. For downloads, see the [releases page](https://githu
 - Dynamic resolution switching to match the observed sustainable frame rate for the attached sensor and storage media — for example, IMX585 automatically switches to HD above 25 fps when an SSD is used.
 - Hot-swapping between 16-bit and 24-bit USB microphones.
 - 4K-class recording modes are visible by default.
-- Automatic storage pre-roll can be disabled in `settings.jsonc`.
+- Automatic storage pre-roll can be disabled in `settings.json`.

--- a/docs/clear-hdr.md
+++ b/docs/clear-hdr.md
@@ -7,11 +7,37 @@ ClearHDR is the imx585's on-sensor single-frame HDR. The sensor merges a high-ga
 | Piece | Needed | Why |
 |-------|--------|-----|
 | Kernel | ≥ 6.12.93+rpt (the Cinemate baseline) | older `rp1-cfe` corrupts 16-bit CSI-2 capture; 10/12-bit is unaffected |
-| Sensor driver | Tiramisioux `imx585-v4l2-driver`, branch `innomaker-v1.0` | exposes `wide_dynamic_range`, the 3840×2200 16-bit mode, and the `ccmp` overlay parameter; gates the invalid binned-ClearHDR combo |
+| Sensor driver | Tiramisioux `imx585-v4l2-driver`, branch `cinemate-7modes` | exposes `wide_dynamic_range`, the 3840×2200 16-bit mode, and the `ccmp` overlay parameter; gates the invalid binned-ClearHDR combo |
 | Overlay | `dtoverlay=imx585,...,ccmp` in config.txt | without `ccmp` the 12-bit CCMP ClearHDR mode does not exist on this driver (the installer writes it) |
 | libcamera | Tiramisioux `libcamera`, branch `cinemate` | 16-bit endian swap handling |
 | Kernel patch (mono only) | `scripts/patch-rp1-cfe.sh` | the stock kernel's Y16 format entry misses the 16-bit workaround — see [Mono sensor](#mono-sensor-imx585_mono) |
 | Exposure | manual | ISP statistics are invalid at 16-bit, so auto exposure and auto white balance cannot run |
+
+## New: launch refusal if the sensor doesn't confirm HDR
+
+cinepi-raw now hard-fails at launch instead of silently continuing when the
+sensor doesn't confirm the ClearHDR write. If you hit this, you'll see:
+
+> `imx585/imx708 ClearHDR: sensor did not accept wide_dynamic_range=1 after retrying -- refusing to launch with --hdr sensor while the sensor's combiner is still off (this is the invalid-combo BLC-fill defect, not a software problem; retry the launch)`
+
+(`sensor` in the message is whichever `--hdr` value you launched with — `sensor`
+or `auto`.)
+
+**What it means:** at startup cinepi-raw writes `wide_dynamic_range=1` to the
+sensor subdevice, then reads it back to confirm the sensor actually applied
+it. This message means that readback never came back true — not on the first
+write, and not after 4 retries 50 ms apart.
+
+**What changed:** previously, a failed readback was not checked at all —
+cinepi-raw would launch anyway with the HDR write requested but not actually
+applied, and the sensor's WDR combiner still off. In that state a ClearHDR
+mode records a flat BLC pedestal fill instead of real image data, with every
+ClearHDR knob (thresholds, blend, gain adder) inert against it — silently.
+cinepi-raw now refuses to launch in that case instead. This is a fail-fast
+change, not a new defect: if you see this error, it means the same
+invalid-combo condition that used to record garbage now stops you before it
+does. Retry the launch — the confirmation usually succeeds on a subsequent
+attempt.
 
 ## What changes when ClearHDR is on
 
@@ -31,7 +57,7 @@ without it. No separate toggle is needed.
 
 The imx585 exposes ClearHDR at **both** 12-bit and 16-bit, so the table is
 ordered plain modes first, then 12-bit HDR, then 16-bit HDR. On the
-`innomaker-v1.0` driver (active-area dims) the mono table is:
+`cinemate-7modes` driver (active-area dims) the mono table is:
 
 | Mode | Resolution | Bit depth | HDR |
 |------|-----------|-----------|-----|
@@ -188,7 +214,7 @@ variant. Three mono-specific facts:
 |------|--------|
 | Kernel patch required for 16-bit | The stock rpi-6.12.y kernel gives every Bayer 16-bit format the "RP1 HW mismatch" workaround (`csi_dt = 0`) but missed the mono `Y16` entry. Unpatched, mono 16-bit records PiSP-COMP1-structured garbage (stripes on flat scenes, noise on detailed ones). The installer applies `scripts/patch-rp1-cfe.sh` automatically for `SENSOR_MODEL=imx585_mono`; rerun it after any kernel package upgrade (the upgrade silently restores the stock module). |
 | 16-bit frames are 3840×2200 | The sensor prepends ~20 optical-black rows to its RAW16 output; the top rows of every 16-bit DNG sit at the 3200 pedestal. Expected geometry, not a defect. |
-| No binned ClearHDR | Binned (2K) ClearHDR is an invalid sensor configuration on mono — the sensor emits pure black-level regardless of exposure (AppNote §2 p.6). The `innomaker-v1.0` driver removes the combination from the mode table; only full-res 12-bit CCMP and 16-bit ClearHDR are offered. |
+| No binned ClearHDR | Binned (2K) ClearHDR is an invalid sensor configuration on mono — the sensor emits pure black-level regardless of exposure (AppNote §2 p.6). The `cinemate-7modes` driver removes the combination from the mode table; only full-res 12-bit CCMP and 16-bit ClearHDR are offered. |
 
 Mono launches also drop `--awb`/`--awbgains` (no CFA to balance) and use the
 `imx585_mono.json` tuning automatically.

--- a/docs/installation-steps.md
+++ b/docs/installation-steps.md
@@ -394,7 +394,7 @@ cd
 ```
 
 ```shell
-git clone https://github.com/Tiramisioux/imx585-v4l2-driver.git --branch innomaker-v1.0
+git clone https://github.com/Tiramisioux/imx585-v4l2-driver.git --branch cinemate-7modes
 cd imx585-v4l2-driver/
 ./setup.sh
 sudo dkms autoinstall -k "$(uname -r)"
@@ -402,7 +402,7 @@ cd
 ```
 
 !!! note ""
-    The IMX283 and IMX585 DKMS drivers used here are based on Will Whang's work and installed from Tiramisioux forks (`6.12.y` branch of each). The [IMX283 fork](https://github.com/Tiramisioux/imx283-v4l2-driver) adds UHD 4K (3840×2160, 10-bit) and 2.7K 16:9 (2736×1538, 12-bit) readout modes on top of the upstream `6.12.y` base; the [IMX585 fork](https://github.com/Tiramisioux/imx585-v4l2-driver) installs its `innomaker-v1.0` branch — upstream `main`, byte-identical to the INNO-MAKER v1.0 vendor driver: active-area modes (1920×1080 / 3840×2160 / 3840×2200 16-bit ClearHDR), the `ccmp` overlay parameter, and the invalid binned-ClearHDR combination gated out. For a mono imx585 the installer additionally applies the `scripts/patch-rp1-cfe.sh` kernel patch — without it, mono 16-bit capture records garbage (see [ClearHDR](clear-hdr.md#mono-sensor-imx585_mono)). For the original drivers and startup guides, visit https://github.com/will127534/imx283-v4l2-driver and https://github.com/will127534/imx585-v4l2-driver
+    The IMX283 and IMX585 DKMS drivers used here are based on Will Whang's work and installed from Tiramisioux forks (`6.12.y` branch for IMX283). The [IMX283 fork](https://github.com/Tiramisioux/imx283-v4l2-driver) adds UHD 4K (3840×2160, 10-bit) and 2.7K 16:9 (2736×1538, 12-bit) readout modes on top of the upstream `6.12.y` base; the [IMX585 fork](https://github.com/Tiramisioux/imx585-v4l2-driver) installs its `cinemate-7modes` branch — built on `innomaker-v1.0` (upstream `main`, byte-identical to the INNO-MAKER v1.0 vendor driver) — with seven active-area modes: three SDR (1920×1080 12-bit 2x2 binned, 3840×2160 12-bit all-pixel, and a 3840×2160 10-bit RAW10 all-pixel mode up to 90 fps) and four ClearHDR (1920×1080 12-bit binned ClearHDR+CCMP, 3840×2160 12-bit all-pixel ClearHDR+CCMP, 1920×1100 16-bit binned ClearHDR linear, and 3840×2200 16-bit all-pixel ClearHDR linear). The two binned ClearHDR modes are restored from `6.12.y` (`innomaker-v1.0` had dropped them) on top of `innomaker-v1.0`'s RAW10 mode and its dedicated 16-bit entry, and are colour-sensor only — mono returns pure black level at binned ClearHDR, so mono stays on the existing 4K-only entries. The branch also carries the `ccmp` overlay parameter (default-on for the colour sensor's 12-bit CCMP ClearHDR on this branch; mono still needs the overlay flag) and gates the invalid binned-ClearHDR combination out of mono's mode table. This driver pin is verified on Cinemate hardware. For a mono imx585 the installer additionally applies the `scripts/patch-rp1-cfe.sh` kernel patch — without it, mono 16-bit capture records garbage (see [ClearHDR](clear-hdr.md#mono-sensor-imx585_mono)). For the original drivers and startup guides, visit https://github.com/will127534/imx283-v4l2-driver and https://github.com/will127534/imx585-v4l2-driver
 
 #### Cinemate IMX283 and IMX585 tuning overrides
 
@@ -636,7 +636,7 @@ For more details on running CinePi-raw from the command line, see [this section]
 ```shell
 sudo apt update
 sudo apt install -y \
-    git build-essential python3-dev python3-pip python3-venv \
+    git build-essential python3-dev python3-pip \
     i2c-tools python3-smbus python3-pyudev \
     libgpiod-dev libgpiod2 python3-libgpiod gpiod \
     portaudio19-dev python3-systemd \
@@ -1031,6 +1031,8 @@ sudo make enable
     ```
 
     Cinemate checks this for you at startup and logs a warning naming this exact command if any installed copy is out of date with the repo. Re-running the full installer does the same thing, since it calls `sudo make install` itself.
+
+For routine updates, run `cinemate-update.sh` from the repo root (`/home/pi/cinemate/cinemate-update.sh`) instead of a bare `git pull`. It fetches and fast-forwards both `cinepi-raw` and `cinemate`, then rebuilds/reinstalls whichever repo actually changed — including the `make install` step above — so the installed copies stay current automatically. If `versions.env` has a `CINEMATE_REPO_REF` and/or `CINEPI_RAW_REPO_REF` recorded (see [Dependency files](#dependency-files) above), it checks out and follows that pinned ref for the corresponding repo instead of whatever branch happens to be checked out; left empty (the default), it behaves exactly as before.
 
 You now have a 12 bit RAW image capturing system on your Raspberry Pi!
 

--- a/docs/settings-editor.md
+++ b/docs/settings-editor.md
@@ -1,0 +1,95 @@
+# Settings editor
+
+A browser page for configuring and operating the camera without SSH: edit `settings.jsonc` and `/boot/firmware/config.txt`, browse and pull takes off the RAW drive, review a take's frames, and see the live camera feed — all from one page over Wi‑Fi.
+
+It is a Flask blueprint (`src/module/app/settings_editor.py`) served by the same process as the [Web GUI](web-gui.md), so it needs Cinemate itself running. For the console that stays up when Cinemate won't start, see the [Recovery console](recovery-console.md) instead.
+
+## Reaching it
+
+```
+http://cinepi.local:5000/settings-editor
+```
+
+Over the camera's own hotspot (see [Configuring the Wi-Fi hotspot](hotspot-logic.md)):
+
+```
+http://10.42.0.1:5000/settings-editor
+```
+
+## Layout
+
+The top bar carries a search box (filters every field/take on the current tab by name) and, on the two file-editing tabs, four more controls:
+
+| Control | Does |
+|---|---|
+| **View raw file** | Opens a drawer showing the exact text the next Save would write — `settings.jsonc` or `config.txt` — with a Copy button |
+| **Revert** | Loads the stock shipped defaults into the on-screen form only — nothing is written until you click Save |
+| **Download** | Downloads the current form state as a file, for a local backup or diffing |
+| **Upload** | Parses a `.jsonc`/`.txt` file you pick and loads it into the form — again, not written until Save |
+| **Save changes** | Writes the file for the active tab and applies it (see below) — disabled until something is actually dirty |
+
+Five tabs run across the top of the page:
+
+| Tab | Edits |
+|---|---|
+| **config.txt** | The managed block Cinemate owns inside `/boot/firmware/config.txt` — sensor overlays, hardware buses, RP1 overclock |
+| **settings.jsonc** | Everything in `settings.jsonc`, grouped into sections (below) |
+| **Live view** | The main Web GUI, embedded |
+| **Playback** | Reviews a recorded take frame-by-frame off the card |
+| **RAW files** | Browse, download, delete and format the mounted RAW storage |
+
+## settings.jsonc tab
+
+The left rail groups the same fields `settings.jsonc` holds, unchanged in meaning from the [Settings file](settings-json.md) reference — this page is a form over that file, not a different configuration surface:
+
+| Group | Sections |
+|---|---|
+| Look & feel | Welcome screen (HDMI boot splash) · Wi‑Fi hotspot |
+| Cameras | Camera 0 · Camera 1 — geometry, HDMI routing, USB device name, independent per sensor |
+| Timing | Timing & sync — how strictly frame timing is watched before warning or flagging a take |
+| Exposure & steps | Value steps (click-stops per control) · Pots & free stepping (Grove Base HAT channel assignments) · Resolution & sensor (crop factors, bit depths, ClearHDR startup values) · Per-mode fps ceilings (per-sensor-mode overrides — see `custom_modes` in the settings reference) |
+| Recording | Audio (input gain, timecode alignment per bit depth) · HDMI & preview (monitor overlay, dual-feed framing) |
+| Physical controls | Buttons & switches (GPIO in) · Rec tally & GPIO out · OLED status display |
+| System | Restart Cinemate |
+
+Editing anything marks the page dirty (the header shows an "N unsaved" pill) but touches nothing on disk until you click **Save changes**.
+
+### Save & restart
+
+Clicking **Save changes** on this tab:
+
+1. Backs up the current `settings.jsonc` to `.settings-backups/` next to it (timestamped, last 10 kept).
+2. Writes your changes. If only values changed, the surgical writer keeps every comment and the file's formatting; if a key was added or removed (a structural change), it falls back to a full rewrite and tells you comments were lost, with the backup path to recover them from.
+3. Restarts Cinemate automatically to apply the new file — the same effect as the CLI's `restart cinemate`, not a reboot. Recording stops if one is in progress.
+
+You can also apply a save-in-place, or just restart with nothing pending, from **System → Restart Cinemate**.
+
+## Boot config (config.txt) tab
+
+!!! danger "No confirm, no revert — unlike the recovery console"
+    Clicking **Save changes** on this tab writes `/boot/firmware/config.txt` and reboots the Pi within under a second, with **no confirm-or-revert window and no backup of the previous file**.
+
+    This is different from the [Recovery console](recovery-console.md)'s config.txt editor, which backs up the previous file on every save and arms a 5‑minute confirm‑or‑revert countdown — reverting and rebooting automatically if you never confirm. The settings editor has none of that: if the change you save stops the Pi from booting cleanly, the only way back is the manual SD-card recovery procedure in [The honest limit](recovery-console.md#the-honest-limit).
+
+    Double-check the change before saving, especially sensor overlay and link-frequency picks. Consider making config.txt edits through the recovery console instead when you want the safety net.
+
+Everything here needs a full reboot to take effect — restarting Cinemate alone never picks up a `config.txt` change. The page shows the detected sensor modes for whatever is actually attached right now, separately from the overlay picks above them (those apply only after the reboot). Cinemate only manages its own fenced block; anything you add to the file outside it survives updates and is untouched by this page.
+
+## RAW files tab
+
+**Storage** shows a card per mounted drive: label, device and filesystem, free/total space, take count, and — for the active drive only — a **Format…** control. Formatting asks for confirmation, is refused while a recording is in progress, and is verified against the drive's actual filesystem after the dispatch completes rather than trusting the command succeeded.
+
+**Takes** lists every take across all mounted storage, newest first by default (also sortable by oldest or largest), each with a thumbnail you can scrub for a quick frame check. Per take:
+
+- **Download** — streams a zip of the take. Only one download runs at a time server-wide; a second attempt is told to wait. On a Chromium browser over a secure context (HTTPS, or localhost) it can write straight into a folder you pick; elsewhere it's a normal browser download.
+- **Delete** — asks for confirmation, and is refused while that take is actively being written to.
+
+Checking takes and using **Download selected** / **Delete selected** applies the same actions to the whole selection. Bulk delete refuses the entire request (not a partial delete) if any selected take is currently recording. Downloading more than one take at once needs the folder-picker path above.
+
+## Playback tab
+
+Reviews a take's frames, decoded live from the CinemaDNG files, at the settings' conform frame rate. Fully covered in [Playback](playback.md) — including the storage-contention lockout that holds playback while a take is recording or its buffer is still flushing.
+
+## Live view tab
+
+Embeds the main [Web GUI](web-gui.md) (the page at the site root, port 5000) in an iframe — the same live image, ISO/shutter/fps/WB controls and record button, without leaving the settings editor. Open it in its own tab if the controls feel cramped here; the clean feed with no overlay is on port 8000 at `/stream` (`8001` for cam1 on a dual-sensor rig).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
       - Storage pre-roll warm-up: storage-preroll.md
   - Configuring:
       - Settings file: settings-json.md
+      - Settings editor: settings-editor.md
       - Camera sensors and frame rates: sensors.md
       - ClearHDR (imx585): clear-hdr.md
       - CineMate Log (imx585 / imx283): cinemate-log.md


### PR DESCRIPTION
## Summary
- Switch the imx585-v4l2-driver installer pin from `innomaker-v1.0` to `cinemate-7modes` (seven modes: three SDR incl. RAW10, four ClearHDR incl. two restored binned-HDR modes; CCMP default-on for colour). Verified on hardware by the operator.
- Document cinepi-raw's new ClearHDR launch-refusal behavior (hard fail instead of a silent BLC-pedestal recording when the sensor won't confirm the HDR handshake).
- Add a dedicated Settings editor doc page, including its config.txt safety gap (immediate reboot, no confirm/revert, no backup — unlike the recovery console).
- Make `cinemate-update.sh` respect a recorded `versions.env` pairing (no-op when unset).
- Restore the Version 3.3.2 changelog section to its original tag content and draft the new Version 3.4.0 section, including a `### libcamera` section covering the fork's PiSP pixel-rate/ClearHDR-corruption fixes.
- Drop the stale `python3-venv` install step; the installer no longer uses a virtualenv.

## Test plan
- [x] `mkdocs serve` against this branch's `mkdocs.yml`: new Settings editor page renders correctly at `/cinemate/settings-editor/`
- [x] Every technical claim (mode counts, error strings, line references) re-verified against source, not just the prior audit
- [ ] Hardware test pass on a fresh install with the `cinemate-7modes` driver pin (operator has verified the driver switch works; a full clean-install pass is still recommended before tagging the release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)